### PR TITLE
Add initial WinUI interface for runlock utility

### DIFF
--- a/Win/runlock/MainWindow.xaml
+++ b/Win/runlock/MainWindow.xaml
@@ -1,0 +1,57 @@
+<Window
+    x:Class="runlock::MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:runlock"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid AllowDrop="True" Drop="Archive_Drop">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <MenuBar Grid.Row="0">
+            <MenuBarItem Title="Project">
+                <MenuFlyoutItem Text="Save" Click="SaveProject_Click"/>
+                <MenuFlyoutItem Text="Load" Click="LoadProject_Click"/>
+            </MenuBarItem>
+        </MenuBar>
+
+        <ScrollViewer Grid.Row="1">
+            <StackPanel Spacing="12" Padding="12">
+                <StackPanel Orientation="Horizontal" AllowDrop="True" Drop="Archive_Drop" DragOver="Archive_DragOver">
+                    <TextBox x:Name="ArchivePath" Width="300" IsReadOnly="True" PlaceholderText="Select .rar archive or drag file here"/>
+                    <Button Content="Browse..." Click="BrowseArchive_Click" Margin="8,0,0,0"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="CPU Cores:" VerticalAlignment="Center"/>
+                    <NumberBox x:Name="CpuCores" Minimum="1" Maximum="64" Width="80" Margin="8,0,0,0"/>
+                </StackPanel>
+
+                <TextBox x:Name="PasswordRules" AcceptsReturn="True" Height="200" TextWrapping="Wrap" PlaceholderText="Enter password rules or drop a text file" AllowDrop="True" Drop="Rules_Drop" DragOver="Rules_DragOver"/>
+
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Min Length:" VerticalAlignment="Center"/>
+                    <NumberBox x:Name="MinLength" Minimum="1" Maximum="128" Width="80" Margin="8,0,0,0"/>
+                    <TextBlock Text="Max Length:" VerticalAlignment="Center" Margin="12,0,0,0"/>
+                    <NumberBox x:Name="MaxLength" Minimum="1" Maximum="128" Width="80" Margin="8,0,0,0"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal">
+                    <Button x:Name="GenerateButton" Content="Generate Passwords" Click="GeneratePasswords_Click"/>
+                    <Button x:Name="StartPauseButton" Content="Start" Click="StartPause_Click" Margin="8,0,0,0"/>
+                </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" Padding="12">
+            <ProgressBar x:Name="Progress" Width="200" Height="20"/>
+            <TextBlock x:Name="StatusText" Text="Idle" VerticalAlignment="Center"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Win/runlock/MainWindow.xaml.cpp
+++ b/Win/runlock/MainWindow.xaml.cpp
@@ -1,0 +1,119 @@
+#include "pch.h"
+#include "MainWindow.xaml.h"
+#if __has_include("MainWindow.g.cpp")
+#include "MainWindow.g.cpp"
+#endif
+
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Windows.Storage.h>
+#include <winrt/Windows.Storage.Pickers.h>
+#include <winrt/Windows.ApplicationModel.DataTransfer.h>
+
+using namespace winrt;
+using namespace Microsoft::UI::Xaml;
+using namespace Windows::Storage;
+using namespace Windows::Storage::Pickers;
+using namespace Windows::ApplicationModel::DataTransfer;
+
+namespace winrt::runlock::implementation
+{
+    MainWindow::MainWindow()
+    {
+        InitializeComponent();
+    }
+
+    void MainWindow::BrowseArchive_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        StatusText().Text(L"Browse archive clicked");
+    }
+
+    void MainWindow::Archive_DragOver(IInspectable const&, DragEventArgs const& e)
+    {
+        e.AcceptedOperation(DataPackageOperation::Copy);
+    }
+
+    IAsyncAction MainWindow::Archive_Drop(IInspectable const&, DragEventArgs const& e)
+    {
+        if (e.DataView().Contains(StandardDataFormats::StorageItems()))
+        {
+            auto items = co_await e.DataView().GetStorageItemsAsync();
+            if (items.Size() > 0)
+            {
+                if (auto file = items.GetAt(0).try_as<StorageFile>())
+                {
+                    ArchivePath().Text(file.Path());
+                }
+            }
+        }
+    }
+
+    void MainWindow::Rules_DragOver(IInspectable const&, DragEventArgs const& e)
+    {
+        e.AcceptedOperation(DataPackageOperation::Copy);
+    }
+
+    IAsyncAction MainWindow::Rules_Drop(IInspectable const&, DragEventArgs const& e)
+    {
+        if (e.DataView().Contains(StandardDataFormats::StorageItems()))
+        {
+            auto items = co_await e.DataView().GetStorageItemsAsync();
+            if (items.Size() > 0)
+            {
+                if (auto file = items.GetAt(0).try_as<StorageFile>())
+                {
+                    PasswordRules().Text(co_await FileIO::ReadTextAsync(file));
+                }
+            }
+        }
+    }
+
+    void MainWindow::GeneratePasswords_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        auto label = unbox_value<hstring>(GenerateButton().Content());
+        if (label == L"Generate Passwords")
+        {
+            GenerateButton().Content(box_value(L"Cancel"));
+            StatusText().Text(L"Generating passwords...");
+        }
+        else
+        {
+            GenerateButton().Content(box_value(L"Generate Passwords"));
+            StatusText().Text(L"Generation cancelled");
+        }
+    }
+
+    void MainWindow::StartPause_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        auto label = unbox_value<hstring>(StartPauseButton().Content());
+        if (label == L"Start")
+        {
+            StartPauseButton().Content(box_value(L"Pause"));
+            StatusText().Text(L"Unlocking...");
+        }
+        else if (label == L"Pause")
+        {
+            StartPauseButton().Content(box_value(L"Resume"));
+            StatusText().Text(L"Paused");
+        }
+        else if (label == L"Resume")
+        {
+            StartPauseButton().Content(box_value(L"Stop"));
+            StatusText().Text(L"Running");
+        }
+        else
+        {
+            StartPauseButton().Content(box_value(L"Start"));
+            StatusText().Text(L"Stopped");
+        }
+    }
+
+    void MainWindow::SaveProject_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        StatusText().Text(L"Save project clicked");
+    }
+
+    void MainWindow::LoadProject_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        StatusText().Text(L"Load project clicked");
+    }
+}

--- a/Win/runlock/MainWindow.xaml.h
+++ b/Win/runlock/MainWindow.xaml.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "MainWindow.g.h"
+
+namespace winrt::runlock::implementation
+{
+    struct MainWindow : MainWindowT<MainWindow>
+    {
+        MainWindow();
+
+        void BrowseArchive_Click(winrt::Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        void Archive_DragOver(winrt::Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::DragEventArgs const& args);
+        winrt::Windows::Foundation::IAsyncAction Archive_Drop(winrt::Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::DragEventArgs const& args);
+
+        void Rules_DragOver(winrt::Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::DragEventArgs const& args);
+        winrt::Windows::Foundation::IAsyncAction Rules_Drop(winrt::Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::DragEventArgs const& args);
+
+        void GeneratePasswords_Click(winrt::Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        void StartPause_Click(winrt::Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
+
+        void SaveProject_Click(winrt::Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        void LoadProject_Click(winrt::Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    };
+}
+
+namespace winrt::runlock::factory_implementation
+{
+    struct MainWindow : MainWindowT<MainWindow, implementation::MainWindow>
+    {
+    };
+}

--- a/Win/runlock/pch.cpp
+++ b/Win/runlock/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/Win/runlock/pch.h
+++ b/Win/runlock/pch.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <unknwn.h>
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Microsoft.UI.Xaml.Data.h>
+#include <winrt/Microsoft.UI.Xaml.Input.h>
+#include <winrt/Microsoft.UI.Xaml.Media.h>
+#include <winrt/Microsoft.UI.Xaml.Navigation.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>


### PR DESCRIPTION
## Summary
- scaffold main window with file selector, CPU core selection, password rule editor, length fields, progress indicator and control buttons
- add handlers for drag-and-drop and basic button state changes

## Testing
- `dotnet --version` (fails: command not found)
- `msbuild Win/runlock/runlock.vcxproj` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68c0680bd1948333bf317d87fd8ba197