### PR TITLE
Add initial UI for runlock password utility

### DIFF
--- a/Win/runlock/MainWindow.xaml
+++ b/Win/runlock/MainWindow.xaml
@@ -4,12 +4,51 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:runlock"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Title="runlock">
 
-    <Grid>
+    <Grid AllowDrop="True" Drop="Archive_Drop" DragOver="Archive_DragOver">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
 
+        <MenuBar Grid.Row="0">
+            <MenuBarItem Title="Project">
+                <MenuFlyoutItem Text="Save Project" Click="SaveProject_Click"/>
+                <MenuFlyoutItem Text="Load Project" Click="LoadProject_Click"/>
+            </MenuBarItem>
+        </MenuBar>
+
+        <StackPanel Grid.Row="1" Spacing="8" Padding="8">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBox x:Name="ArchivePathBox" Width="300" IsReadOnly="True" PlaceholderText="Select RAR file"/>
+                <Button Content="Browse" Click="BrowseArchive_Click"/>
+                <TextBlock Text="CPU Cores:" VerticalAlignment="Center"/>
+                <ComboBox x:Name="CpuCoresComboBox" Width="60"/>
+            </StackPanel>
+
+            <TextBox x:Name="PasswordRulesBox" Height="200" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" AllowDrop="True" Drop="PasswordRules_Drop" DragOver="PasswordRules_DragOver" PlaceholderText="Enter password rules or drop a text file"/>
+
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="Min Length" VerticalAlignment="Center"/>
+                <controls:NumberBox x:Name="MinLengthBox" Width="60" Minimum="0"/>
+                <TextBlock Text="Max Length" VerticalAlignment="Center"/>
+                <controls:NumberBox x:Name="MaxLengthBox" Width="60" Minimum="0"/>
+            </StackPanel>
+
+            <controls:ProgressBar x:Name="UnlockProgressBar" Height="20" Minimum="0" Maximum="100"/>
+            <TextBlock x:Name="StatusText" Text="Idle"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center" Margin="0,8,0,8">
+            <Button x:Name="GenerateButton" Content="Generate Passwords" Click="GeneratePasswords_Click"/>
+            <Button x:Name="CancelGenerateButton" Content="Cancel" IsEnabled="False" Click="CancelGenerate_Click"/>
+            <Button x:Name="UnlockButton" Content="Start" Click="UnlockButton_Click"/>
+        </StackPanel>
     </Grid>
 </Window>

--- a/Win/runlock/MainWindow.xaml.cpp
+++ b/Win/runlock/MainWindow.xaml.cpp
@@ -4,14 +4,102 @@
 #include "MainWindow.g.cpp"
 #endif
 
+#include <thread>
+#include <winrt/Windows.ApplicationModel.DataTransfer.h>
+
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace winrt::runlock::implementation
 {
+    MainWindow::MainWindow()
+    {
+        InitializeComponent();
+        Loaded({ this, &MainWindow::Window_Loaded });
+    }
+
+    void MainWindow::Window_Loaded(IInspectable const&, RoutedEventArgs const&)
+    {
+        uint32_t cores = std::thread::hardware_concurrency();
+        if (cores == 0) { cores = 1; }
+        for (uint32_t i = 1; i <= cores; ++i)
+        {
+            CpuCoresComboBox().Items().Append(box_value(i));
+        }
+        CpuCoresComboBox().SelectedIndex(0);
+    }
+
+    void MainWindow::BrowseArchive_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        // TODO: Implement file picker for RAR files
+    }
+
+    void MainWindow::Archive_DragOver(IInspectable const&, DragEventArgs const& e)
+    {
+        e.AcceptedOperation(Windows::ApplicationModel::DataTransfer::DataPackageOperation::Copy);
+    }
+
+    void MainWindow::Archive_Drop(IInspectable const&, DragEventArgs const&)
+    {
+        // TODO: Handle dropped RAR file
+    }
+
+    void MainWindow::PasswordRules_DragOver(IInspectable const&, DragEventArgs const& e)
+    {
+        e.AcceptedOperation(Windows::ApplicationModel::DataTransfer::DataPackageOperation::Copy);
+    }
+
+    void MainWindow::PasswordRules_Drop(IInspectable const&, DragEventArgs const&)
+    {
+        // TODO: Populate password rules from dropped text file
+    }
+
+    void MainWindow::GeneratePasswords_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        // TODO: Generate list of passwords
+        CancelGenerateButton().IsEnabled(true);
+        GenerateButton().IsEnabled(false);
+    }
+
+    void MainWindow::CancelGenerate_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        // TODO: Cancel password generation
+        CancelGenerateButton().IsEnabled(false);
+        GenerateButton().IsEnabled(true);
+    }
+
+    void MainWindow::UnlockButton_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        switch (m_unlockState)
+        {
+        case UnlockState::Stopped:
+            m_unlockState = UnlockState::Running;
+            UnlockButton().Content(box_value(L"Pause"));
+            StatusText().Text(L"Running...");
+            break;
+        case UnlockState::Running:
+            m_unlockState = UnlockState::Paused;
+            UnlockButton().Content(box_value(L"Resume"));
+            StatusText().Text(L"Paused");
+            break;
+        case UnlockState::Paused:
+            m_unlockState = UnlockState::Stopped;
+            UnlockButton().Content(box_value(L"Start"));
+            StatusText().Text(L"Stopped");
+            break;
+        }
+    }
+
+    void MainWindow::SaveProject_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        // TODO: Save project settings
+    }
+
+    void MainWindow::LoadProject_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        // TODO: Load project settings
+    }
+
     int32_t MainWindow::MyProperty()
     {
         throw hresult_not_implemented();

--- a/Win/runlock/MainWindow.xaml.h
+++ b/Win/runlock/MainWindow.xaml.h
@@ -6,14 +6,26 @@ namespace winrt::runlock::implementation
 {
     struct MainWindow : MainWindowT<MainWindow>
     {
-        MainWindow()
-        {
-            // Xaml objects should not call InitializeComponent during construction.
-            // See https://github.com/microsoft/cppwinrt/tree/master/nuget#initializecomponent
-        }
+        MainWindow();
 
         int32_t MyProperty();
         void MyProperty(int32_t value);
+
+        void BrowseArchive_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        void Archive_DragOver(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
+        void Archive_Drop(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
+        void PasswordRules_DragOver(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
+        void PasswordRules_Drop(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
+        void GeneratePasswords_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        void CancelGenerate_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        void UnlockButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        void SaveProject_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        void LoadProject_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        void Window_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+
+    private:
+        enum class UnlockState { Stopped, Running, Paused };
+        UnlockState m_unlockState{ UnlockState::Stopped };
     };
 }
 


### PR DESCRIPTION
## Summary
- add menu, file selector with drag-and-drop, CPU core selection and password rules text area
- include password length fields, progress indicator, and control buttons
- stub handlers for generating passwords and unlocking, plus save/load project actions

## Testing
- `dotnet build Win/trifles-win.sln` *(fails: command not found)*
- `msbuild Win/trifles-win.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0713bde8883338fdb53237651ffb6