### PR TITLE
Add coroutine-based password list generator

### DIFF
--- a/Win/runlock/MainWindow.xaml.cpp
+++ b/Win/runlock/MainWindow.xaml.cpp
@@ -5,7 +5,15 @@
 #endif
 
 #include <thread>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <algorithm>
+
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
+#include <winrt/Windows.Storage.h>
+#include <winrt/Windows.Storage.Pickers.h>
+#include <winrt/Windows.Storage.Streams.h>
 
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
@@ -54,18 +62,33 @@ namespace winrt::runlock::implementation
         // TODO: Populate password rules from dropped text file
     }
 
-    void MainWindow::GeneratePasswords_Click(IInspectable const&, RoutedEventArgs const&)
+    Windows::Foundation::IAsyncAction MainWindow::GeneratePasswords_Click(IInspectable const&, RoutedEventArgs const&)
     {
-        // TODO: Generate list of passwords
+        Windows::Storage::Pickers::FileSavePicker picker;
+        picker.SuggestedStartLocation(Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
+        picker.FileTypeChoices().Insert(L"Text", single_threaded_vector<hstring>({ L".txt" }));
+
+        auto file = co_await picker.PickSaveFileAsync();
+        if (!file)
+        {
+            co_return;
+        }
+
+        m_cancelGenerate = false;
         CancelGenerateButton().IsEnabled(true);
         GenerateButton().IsEnabled(false);
+        StatusText().Text(L"Generating...");
+
+        co_await GeneratePasswordFileAsync(file);
+
+        CancelGenerateButton().IsEnabled(false);
+        GenerateButton().IsEnabled(true);
+        StatusText().Text(m_cancelGenerate ? L"Cancelled" : L"Done");
     }
 
     void MainWindow::CancelGenerate_Click(IInspectable const&, RoutedEventArgs const&)
     {
-        // TODO: Cancel password generation
-        CancelGenerateButton().IsEnabled(false);
-        GenerateButton().IsEnabled(true);
+        m_cancelGenerate = true;
     }
 
     void MainWindow::UnlockButton_Click(IInspectable const&, RoutedEventArgs const&)
@@ -108,5 +131,90 @@ namespace winrt::runlock::implementation
     void MainWindow::MyProperty(int32_t /* value */)
     {
         throw hresult_not_implemented();
+    }
+
+    Windows::Foundation::IAsyncAction MainWindow::GeneratePasswordFileAsync(Windows::Storage::StorageFile const& file)
+    {
+        using namespace Windows::Storage;
+        using namespace Windows::Storage::Streams;
+
+        auto stream = co_await file.OpenAsync(FileAccessMode::ReadWrite);
+        DataWriter writer(stream);
+
+        std::vector<std::vector<std::wstring>> groups;
+        std::wstring rules = PasswordRulesBox().Text().c_str();
+        std::wstringstream ss(rules);
+        std::wstring line;
+        while (std::getline(ss, line))
+        {
+            if (!line.empty() && line.back() == L'\r')
+            {
+                line.pop_back();
+            }
+            if (line.empty())
+            {
+                continue;
+            }
+            std::wstringstream ls(line);
+            std::wstring token;
+            std::vector<std::wstring> options;
+            while (std::getline(ls, token, L'|'))
+            {
+                if (!token.empty())
+                {
+                    options.push_back(token);
+                }
+            }
+            options.push_back(L"");
+            groups.push_back(std::move(options));
+        }
+
+        int minLen = static_cast<int>(MinLengthBox().Value());
+        int maxLen = static_cast<int>(MaxLengthBox().Value());
+        std::wstring current;
+        GenerateRecursive(groups, 0, current, minLen, maxLen, writer);
+
+        co_await writer.StoreAsync();
+        writer.DetachStream();
+        stream.Close();
+    }
+
+    void MainWindow::GenerateRecursive(
+        std::vector<std::vector<std::wstring>> const& groups,
+        size_t index,
+        std::wstring& current,
+        int minLen,
+        int maxLen,
+        Windows::Storage::Streams::DataWriter& writer)
+    {
+        if (m_cancelGenerate)
+        {
+            return;
+        }
+
+        if (index == groups.size())
+        {
+            if (static_cast<int>(current.size()) >= minLen && static_cast<int>(current.size()) <= maxLen)
+            {
+                auto toWrite = current + L"\n";
+                writer.WriteString(hstring(toWrite));
+            }
+            return;
+        }
+
+        for (auto const& part : groups[index])
+        {
+            auto prevLen = current.size();
+            current += part;
+            if (static_cast<int>(current.size()) <= maxLen)
+            {
+                GenerateRecursive(groups, index + 1, current, minLen, maxLen, writer);
+            }
+            current.resize(prevLen);
+            if (m_cancelGenerate)
+            {
+                return;
+            }
+        }
     }
 }

--- a/Win/runlock/MainWindow.xaml.h
+++ b/Win/runlock/MainWindow.xaml.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include "MainWindow.g.h"
+#include <vector>
+#include <string>
+#include <winrt/Windows.Storage.h>
+#include <winrt/Windows.Storage.Streams.h>
 
 namespace winrt::runlock::implementation
 {
@@ -16,7 +20,7 @@ namespace winrt::runlock::implementation
         void Archive_Drop(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
         void PasswordRules_DragOver(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
         void PasswordRules_Drop(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
-        void GeneratePasswords_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        winrt::Windows::Foundation::IAsyncAction GeneratePasswords_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
         void CancelGenerate_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
         void UnlockButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
         void SaveProject_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
@@ -26,6 +30,16 @@ namespace winrt::runlock::implementation
     private:
         enum class UnlockState { Stopped, Running, Paused };
         UnlockState m_unlockState{ UnlockState::Stopped };
+        bool m_cancelGenerate{ false };
+
+        winrt::Windows::Foundation::IAsyncAction GeneratePasswordFileAsync(winrt::Windows::Storage::StorageFile const& file);
+        void GenerateRecursive(
+            std::vector<std::vector<std::wstring>> const& groups,
+            size_t index,
+            std::wstring& current,
+            int minLen,
+            int maxLen,
+            winrt::Windows::Storage::Streams::DataWriter& writer);
     };
 }
 


### PR DESCRIPTION
## Summary
- add async password generation that writes combinations to a user-selected file
- support canceling generation and closing file with partial results

## Testing
- `dotnet build Win/runlock/runlock.vcxproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c098e2e1b4833391caeae9a15b3db2