### PR TITLE
Bind save picker to main window

### DIFF
--- a/Win/runlock/MainWindow.xaml.cpp
+++ b/Win/runlock/MainWindow.xaml.cpp
@@ -14,6 +14,8 @@
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.Storage.Pickers.h>
 #include <winrt/Windows.Storage.Streams.h>
+#include <microsoft.ui.xaml.windowinterop.h>
+#include <shobjidl_core.h>
 
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
@@ -64,9 +66,16 @@ namespace winrt::runlock::implementation
 
     Windows::Foundation::IAsyncAction MainWindow::GeneratePasswords_Click(IInspectable const&, RoutedEventArgs const&)
     {
+        auto hwnd = winrt::Microsoft::UI::Windowing::WindowNative::GetWindowHandle(*this);
         Windows::Storage::Pickers::FileSavePicker picker;
         picker.SuggestedStartLocation(Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
         picker.FileTypeChoices().Insert(L"Text", single_threaded_vector<hstring>({ L".txt" }));
+
+        auto initialize = picker.as<::IInitializeWithWindow>();
+        if (initialize)
+        {
+            initialize->Initialize(hwnd);
+        }
 
         auto file = co_await picker.PickSaveFileAsync();
         if (!file)


### PR DESCRIPTION
## Summary
- include the Win32 interop headers required to initialize file pickers with a window handle
- obtain the main window HWND and initialize the save picker with it before showing the dialog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f88f099a64833381fe4a29bba047a2