### PR TITLE
Offload password generation to background thread

### DIFF
--- a/Win/runlock/MainWindow.xaml.cpp
+++ b/Win/runlock/MainWindow.xaml.cpp
@@ -14,6 +14,8 @@
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.Storage.Pickers.h>
 #include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Microsoft.UI.Dispatching.h>
+#include <winrt/Windows.System.h>
 
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
@@ -138,11 +140,19 @@ namespace winrt::runlock::implementation
         using namespace Windows::Storage;
         using namespace Windows::Storage::Streams;
 
+        auto uiDispatcher = DispatcherQueue();
+
+        auto rulesText = PasswordRulesBox().Text();
+        int minLen = static_cast<int>(MinLengthBox().Value());
+        int maxLen = static_cast<int>(MaxLengthBox().Value());
+
+        co_await winrt::resume_background();
+
         auto stream = co_await file.OpenAsync(FileAccessMode::ReadWrite);
         DataWriter writer(stream);
 
         std::vector<std::vector<std::wstring>> groups;
-        std::wstring rules = PasswordRulesBox().Text().c_str();
+        std::wstring rules = rulesText.c_str();
         std::wstringstream ss(rules);
         std::wstring line;
         while (std::getline(ss, line))
@@ -169,14 +179,14 @@ namespace winrt::runlock::implementation
             groups.push_back(std::move(options));
         }
 
-        int minLen = static_cast<int>(MinLengthBox().Value());
-        int maxLen = static_cast<int>(MaxLengthBox().Value());
         std::wstring current;
         GenerateRecursive(groups, 0, current, minLen, maxLen, writer);
 
         co_await writer.StoreAsync();
         writer.DetachStream();
         stream.Close();
+
+        co_await winrt::resume_foreground(uiDispatcher);
     }
 
     void MainWindow::GenerateRecursive(


### PR DESCRIPTION
## Summary
- capture the window dispatcher before starting password file generation
- move password enumeration and file writes onto a background thread and resume on the UI dispatcher afterward

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f88f0eea4083339d7c7fa770cc2e99