### PR TITLE
Flush password generation output in chunks

### DIFF
--- a/Win/runlock/MainWindow.xaml.h
+++ b/Win/runlock/MainWindow.xaml.h
@@ -39,7 +39,8 @@ namespace winrt::runlock::implementation
             std::wstring& current,
             int minLen,
             int maxLen,
-            winrt::Windows::Storage::Streams::DataWriter& writer);
+            winrt::Windows::Storage::Streams::DataWriter& writer,
+            size_t& bufferedBytes);
     };
 }
 


### PR DESCRIPTION
## Summary
- track buffered bytes while writing generated passwords
- flush the data writer once the buffer exceeds the chunk threshold to keep memory usage bounded

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f88f1293708333a7507340bb2d8fc0