### PR TITLE
Dispatch timeline rendering to UI thread and harden RenderTimelineAsync

### DIFF
--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -14,15 +14,38 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="8">
             <controls:MediaPlayerElement x:Name="PreviewPlayer" AreTransportControlsEnabled="False"/>
         </Border>
 
-        <TextBlock Grid.Row="1" x:Name="StatusText" Text="Drag and drop an .avi or .mov file to preview."/>
+        <Grid Grid.Row="1" RowSpacing="6">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                <TextBlock Text="Story Line" FontWeight="SemiBold"/>
+                <TextBlock Text="Zoom" VerticalAlignment="Center"/>
+                <Slider x:Name="TimelineZoomSlider" Width="240" Minimum="1" Maximum="12" Value="3" SmallChange="0.25" LargeChange="1" ValueChanged="TimelineZoomSlider_ValueChanged"/>
+            </StackPanel>
+
+            <Border Grid.Row="1" BorderThickness="1" BorderBrush="#404040" Background="#111111" CornerRadius="4" Padding="6">
+                <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled">
+                    <Canvas x:Name="TimelineCanvas" Height="86" PointerPressed="TimelineCanvas_PointerPressed" Background="#111111">
+                        <Canvas x:Name="ThumbnailLayer" Height="86"/>
+                        <Rectangle x:Name="TimelineCursor" Canvas.Left="0" Width="2" Height="86" Fill="White"/>
+                    </Canvas>
+                </ScrollViewer>
+            </Border>
+        </Grid>
+
+        <TextBlock Grid.Row="2" x:Name="StatusText" Text="Drag and drop an .avi or .mov file to preview."/>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
             <Button x:Name="StartButton" Content="Start" Click="StartButton_Click"/>
             <Button x:Name="PauseButton" Content="Pause" Click="PauseButton_Click"/>
             <Button x:Name="StopButton" Content="Stop" Click="StopButton_Click"/>

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cwctype>
 
 #include <microsoft.ui.xaml.window.h>
 #include <winrt/Microsoft.UI.Input.h>
@@ -295,10 +296,13 @@ winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
     }
 
     if(!DispatcherQueue().HasThreadAccess()){
-        co_await winrt::resume_foreground(DispatcherQueue());
-        if(m_isClosing || !m_loadedFile || m_timelineDurationSeconds <= 0){
-            co_return;
-        }
+        const auto weak{get_weak()};
+        DispatcherQueue().TryEnqueue([weak](){
+            if(const auto self{weak.get()}){
+                self->RenderTimelineAsync();
+            }
+        });
+        co_return;
     }
 
     try{

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -3,10 +3,15 @@
 #include "MainWindow.g.cpp"
 
 #include <algorithm>
+#include <cmath>
 
 #include <microsoft.ui.xaml.window.h>
+#include <winrt/Microsoft.UI.Input.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.Media.Imaging.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 #include <winrt/Windows.Media.Core.h>
+#include <winrt/Windows.Media.Editing.h>
 #include <winrt/Windows.Media.Playback.h>
 #include <winrt/Windows.Storage.h>
 
@@ -19,12 +24,20 @@ constexpr auto W_POS_L{L"WindowLeft"};
 constexpr auto W_POS_T{L"WindowTop"};
 constexpr auto W_POS_W{L"WindowWidth"};
 constexpr auto W_POS_H{L"WindowHeight"};
+constexpr auto W_POS_DPI{L"WindowDpi"};
 
 MainWindow::MainWindow(){
     InitializeComponent();
 
     m_player = Windows::Media::Playback::MediaPlayer();
     PreviewPlayer().SetMediaPlayer(m_player);
+
+    m_naturalDurationChangedRevoker = m_player.PlaybackSession().NaturalDurationChanged(auto_revoke, {this, &MainWindow::OnNaturalDurationChanged});
+
+    m_positionTimer = DispatcherTimer();
+    m_positionTimer.Interval(std::chrono::milliseconds(80));
+    m_positionTimer.Tick({this, &MainWindow::OnPositionTimerTick});
+    m_positionTimer.Start();
 
     RestoreWindowPlacement();
     Closed({this, &MainWindow::OnClosed});
@@ -37,6 +50,31 @@ HWND MainWindow::GetWindowHandle() const{
     return hwnd;
 }
 
+
+int32_t PixelsToDips(const int32_t pixelValue, const uint32_t dpi){
+    return static_cast<int32_t>(std::lround((static_cast<double>(pixelValue) * 96.0) / static_cast<double>(dpi == 0 ? 96U : dpi)));
+}
+
+int32_t DipsToPixels(const int32_t dipValue, const uint32_t dpi){
+    return static_cast<int32_t>(std::lround((static_cast<double>(dipValue) * static_cast<double>(dpi == 0 ? 96U : dpi)) / 96.0));
+}
+
+bool MainWindow::IsRectVisibleOnAnyMonitor(RECT const& rect){
+    const HMONITOR monitor{::MonitorFromRect(&rect, MONITOR_DEFAULTTONULL)};
+    if(!monitor){
+        return false;
+    }
+
+    MONITORINFO monitorInfo{};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if(!::GetMonitorInfoW(monitor, &monitorInfo)){
+        return false;
+    }
+
+    RECT intersection{};
+    return ::IntersectRect(&intersection, &rect, &monitorInfo.rcWork) != FALSE;
+}
+
 void MainWindow::RestoreWindowPlacement(){
     const auto localSettings{Windows::Storage::ApplicationData::Current().LocalSettings()};
     const auto values{localSettings.Values()};
@@ -47,31 +85,68 @@ void MainWindow::RestoreWindowPlacement(){
 
     const auto left{unbox_value<int32_t>(values.Lookup(W_POS_L))};
     const auto top{unbox_value<int32_t>(values.Lookup(W_POS_T))};
-    const auto width{unbox_value<int32_t>(values.Lookup(W_POS_W))};
-    const auto height{unbox_value<int32_t>(values.Lookup(W_POS_H))};
 
     const auto hwnd{GetWindowHandle()};
+
+    SetWindowPos(hwnd, nullptr, left, top, 0, 0, SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOSIZE);
+
+    const uint32_t currentDpi{::GetDpiForWindow(hwnd)};
+    const bool hasDpiData{values.HasKey(W_POS_DPI)};
+    const auto storedWidth{unbox_value<int32_t>(values.Lookup(W_POS_W))};
+    const auto storedHeight{unbox_value<int32_t>(values.Lookup(W_POS_H))};
+    const auto width{hasDpiData ? DipsToPixels(storedWidth, currentDpi) : storedWidth};
+    const auto height{hasDpiData ? DipsToPixels(storedHeight, currentDpi) : storedHeight};
+
+    RECT restoredRect{};
+    restoredRect.left = left;
+    restoredRect.top = top;
+    restoredRect.right = left + width;
+    restoredRect.bottom = top + height;
+
+    if(!IsRectVisibleOnAnyMonitor(restoredRect)){
+        values.Remove(W_POS_L);
+        values.Remove(W_POS_T);
+        values.Remove(W_POS_W);
+        values.Remove(W_POS_H);
+        values.Remove(W_POS_DPI);
+        return;
+    }
+
     SetWindowPos(hwnd, nullptr, left, top, width, height, SWP_NOACTIVATE | SWP_NOZORDER);
 }
 
 void MainWindow::SaveWindowPlacement() const{
-    WINDOWPLACEMENT placement{};
-    placement.length = sizeof(placement);
-    if(!GetWindowPlacement(GetWindowHandle(), &placement)){
+    const auto hwnd{GetWindowHandle()};
+
+    RECT bounds{};
+    if(!GetWindowRect(hwnd, &bounds)){
         return;
     }
 
-    const auto normalBounds{placement.rcNormalPosition};
+    WINDOWPLACEMENT placement{};
+    placement.length = sizeof(placement);
+    if(GetWindowPlacement(hwnd, &placement) && placement.showCmd == SW_SHOWMAXIMIZED){
+        bounds = placement.rcNormalPosition;
+    }
 
     const auto localSettings{Windows::Storage::ApplicationData::Current().LocalSettings()};
     const auto values{localSettings.Values()};
-    values.Insert(W_POS_L, box_value(static_cast<int32_t>(normalBounds.left)));
-    values.Insert(W_POS_T, box_value(static_cast<int32_t>(normalBounds.top)));
-    values.Insert(W_POS_W, box_value(static_cast<int32_t>(normalBounds.right - normalBounds.left)));
-    values.Insert(W_POS_H, box_value(static_cast<int32_t>(normalBounds.bottom - normalBounds.top)));
+    const uint32_t dpi{::GetDpiForWindow(hwnd)};
+    values.Insert(W_POS_L, box_value(static_cast<int32_t>(bounds.left)));
+    values.Insert(W_POS_T, box_value(static_cast<int32_t>(bounds.top)));
+    values.Insert(W_POS_W, box_value(PixelsToDips(static_cast<int32_t>(bounds.right - bounds.left), dpi)));
+    values.Insert(W_POS_H, box_value(PixelsToDips(static_cast<int32_t>(bounds.bottom - bounds.top), dpi)));
+    values.Insert(W_POS_DPI, box_value(static_cast<int32_t>(dpi)));
 }
 
 void MainWindow::OnClosed(IInspectable const&, WindowEventArgs const&){
+    m_isClosing = true;
+
+    if(m_positionTimer){
+        m_positionTimer.Stop();
+    }
+
+    m_naturalDurationChangedRevoker.revoke();
     SaveWindowPlacement();
 }
 
@@ -91,7 +166,76 @@ void MainWindow::StopButton_Click(IInspectable const&, RoutedEventArgs const&){
     if(m_player){
         m_player.Pause();
         m_player.PlaybackSession().Position(std::chrono::seconds(0));
+        UpdateTimelineCursorFromPlayback();
     }
+}
+
+void MainWindow::TimelineZoomSlider_ValueChanged(IInspectable const&, Controls::Primitives::RangeBaseValueChangedEventArgs const&){
+    if(m_loadedFile && m_timelineDurationSeconds > 0){
+        RenderTimelineAsync();
+    }
+}
+
+void MainWindow::TimelineCanvas_PointerPressed(IInspectable const&, Input::PointerRoutedEventArgs const& e){
+    if(!m_player || m_timelineDurationSeconds <= 0){
+        return;
+    }
+
+    if(TimelineCanvas().Width() <= 0){
+        return;
+    }
+
+    const auto point{e.GetCurrentPoint(TimelineCanvas())};
+    const double pointerX{static_cast<double>(point.Position().X)};
+    const double x{std::clamp(pointerX, 0.0, TimelineCanvas().Width())};
+    const double ratio{x / TimelineCanvas().Width()};
+    const double targetSeconds{ratio * m_timelineDurationSeconds};
+
+    m_player.PlaybackSession().Position(SecondsToTimeSpan(targetSeconds));
+    UpdateTimelineCursorFromPlayback();
+}
+
+void MainWindow::OnNaturalDurationChanged(Windows::Media::Playback::MediaPlaybackSession const& sender, IInspectable const&){
+    const auto duration{sender.NaturalDuration()};
+    m_timelineDurationSeconds = std::max(0.0, static_cast<double>(duration.count()) / 10'000'000.0);
+
+    if(m_loadedFile && m_timelineDurationSeconds > 0){
+        const auto weak{get_weak()};
+        if(DispatcherQueue().HasThreadAccess()){
+            RenderTimelineAsync();
+            return;
+        }
+
+        DispatcherQueue().TryEnqueue([weak](){
+            if(const auto self{weak.get()}){
+                self->RenderTimelineAsync();
+            }
+        });
+    }
+}
+
+void MainWindow::OnPositionTimerTick(IInspectable const&, IInspectable const&){
+    if(m_isClosing){
+        return;
+    }
+
+    UpdateTimelineCursorFromPlayback();
+}
+
+void MainWindow::UpdateTimelineCursorFromPlayback(){
+    if(m_isClosing || !m_player || m_timelineDurationSeconds <= 0 || TimelineCanvas().Width() <= 0){
+        return;
+    }
+
+    const auto current{m_player.PlaybackSession().Position()};
+    const double seconds{std::max(0.0, static_cast<double>(current.count()) / 10'000'000.0)};
+    const double ratio{std::clamp(seconds / m_timelineDurationSeconds, 0.0, 1.0)};
+    const double left{ratio * TimelineCanvas().Width()};
+    Controls::Canvas::SetLeft(TimelineCursor(), left);
+}
+
+Windows::Foundation::TimeSpan MainWindow::SecondsToTimeSpan(const double seconds){
+    return std::chrono::duration_cast<Windows::Foundation::TimeSpan>(std::chrono::duration<double>(seconds));
 }
 
 void MainWindow::Window_DragOver(IInspectable const&, DragEventArgs const& e){
@@ -114,7 +258,7 @@ Windows::Foundation::IAsyncAction MainWindow::Window_Drop(IInspectable const&, D
     const auto file{items.GetAt(0).try_as<Windows::Storage::StorageFile>()};
     if(!file){
         StatusText().Text(L"Dropped content is not a file");
-        __debugbreak(); // this should have been caught ealier in this function!
+        __debugbreak(); // this should have been caught earlier in this function!
         co_return;
     }
 
@@ -134,12 +278,89 @@ Windows::Foundation::IAsyncAction MainWindow::Window_Drop(IInspectable const&, D
 Windows::Foundation::IAsyncAction MainWindow::LoadVideoFileAsync(Windows::Storage::StorageFile const& file){
     const auto source{Windows::Media::Core::MediaSource::CreateFromStorageFile(file)};
     m_player.Source(source);
+    m_loadedFile = file;
+
+    ThumbnailLayer().Children().Clear();
+    TimelineCanvas().Width(640.0);
+    m_timelineDurationSeconds = 0;
+    Controls::Canvas::SetLeft(TimelineCursor(), 0);
 
     std::wstring status{L"Loaded: "};
     status += file.Name().c_str();
+    status += L" (loading story line...)";
     StatusText().Text(status);
 
     co_return;
+}
+
+winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
+    const auto lifetime{get_strong()};
+
+    if(m_isClosing || !m_loadedFile || m_timelineDurationSeconds <= 0){
+        co_return;
+    }
+
+    if(!DispatcherQueue().HasThreadAccess()){
+        co_await winrt::resume_foreground(DispatcherQueue());
+        if(m_isClosing || !m_loadedFile || m_timelineDurationSeconds <= 0){
+            co_return;
+        }
+    }
+
+    try{
+        const auto renderVersion{++m_timelineRenderVersion};
+        const double zoom{TimelineZoomSlider().Value()};
+        const double totalWidth{std::max(800.0, m_timelineDurationSeconds * 14.0 * zoom)};
+        const int thumbnailCount{std::clamp(static_cast<int>(totalWidth / 150.0), 8, 96)};
+        const double thumbnailWidth{totalWidth / static_cast<double>(thumbnailCount)};
+
+        TimelineCanvas().Width(totalWidth);
+        ThumbnailLayer().Children().Clear();
+        Controls::Canvas::SetLeft(TimelineCursor(), 0);
+
+        const auto clip{co_await Windows::Media::Editing::MediaClip::CreateFromFileAsync(m_loadedFile)};
+        Windows::Media::Editing::MediaComposition composition{};
+        composition.Clips().Append(clip);
+
+        if(renderVersion != m_timelineRenderVersion){
+            co_return;
+        }
+
+        for(int i = 0; i < thumbnailCount; ++i){
+            if(renderVersion != m_timelineRenderVersion || m_isClosing){
+                co_return;
+            }
+
+            const double t{(static_cast<double>(i) + 0.5) / static_cast<double>(thumbnailCount)};
+            const auto stream{co_await composition.GetThumbnailAsync(SecondsToTimeSpan(t * m_timelineDurationSeconds), 180, 96, Windows::Media::Editing::VideoFramePrecision::NearestFrame)};
+            if(renderVersion != m_timelineRenderVersion || m_isClosing){
+                co_return;
+            }
+
+            Controls::Image image{};
+            image.Width(std::max(8.0, thumbnailWidth - 2.0));
+            image.Height(86);
+            image.Stretch(Media::Stretch::UniformToFill);
+
+            Media::Imaging::BitmapImage bitmap{};
+            co_await bitmap.SetSourceAsync(stream);
+            image.Source(bitmap);
+
+            Controls::Canvas::SetLeft(image, i * thumbnailWidth);
+            ThumbnailLayer().Children().Append(image);
+        }
+
+        UpdateTimelineCursorFromPlayback();
+
+        std::wstring status{L"Loaded: "};
+        status += m_loadedFile.Name().c_str();
+        status += L" (story line ready)";
+        StatusText().Text(status);
+    }catch(winrt::hresult_error const& ex){
+        std::wstring status{L"Failed to render story line: "};
+        status += ex.message().c_str();
+        StatusText().Text(status);
+    }
 }
 
 }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -52,11 +52,11 @@ HWND MainWindow::GetWindowHandle() const{
 
 
 int32_t PixelsToDips(const int32_t pixelValue, const uint32_t dpi){
-    return static_cast<int32_t>(std::lround((static_cast<double>(pixelValue) * 96.0) / static_cast<double>(dpi == 0 ? 96U : dpi)));
+    return static_cast<int32_t>(std::lround((pixelValue * 96.0) / (dpi == 0 ? 96 : dpi)));
 }
 
 int32_t DipsToPixels(const int32_t dipValue, const uint32_t dpi){
-    return static_cast<int32_t>(std::lround((static_cast<double>(dipValue) * static_cast<double>(dpi == 0 ? 96U : dpi)) / 96.0));
+    return static_cast<int32_t>(std::lround((dipValue * (dpi == 0 ? 96U : dpi)) / 96.0));
 }
 
 bool MainWindow::IsRectVisibleOnAnyMonitor(RECT const& rect){
@@ -97,13 +97,7 @@ void MainWindow::RestoreWindowPlacement(){
     const auto width{hasDpiData ? DipsToPixels(storedWidth, currentDpi) : storedWidth};
     const auto height{hasDpiData ? DipsToPixels(storedHeight, currentDpi) : storedHeight};
 
-    RECT restoredRect{};
-    restoredRect.left = left;
-    restoredRect.top = top;
-    restoredRect.right = left + width;
-    restoredRect.bottom = top + height;
-
-    if(!IsRectVisibleOnAnyMonitor(restoredRect)){
+    if(!IsRectVisibleOnAnyMonitor(RECT{left, top, left + width, top + height})){
         values.Remove(W_POS_L);
         values.Remove(W_POS_T);
         values.Remove(W_POS_W);
@@ -197,7 +191,7 @@ void MainWindow::TimelineCanvas_PointerPressed(IInspectable const&, Input::Point
 
 void MainWindow::OnNaturalDurationChanged(Windows::Media::Playback::MediaPlaybackSession const& sender, IInspectable const&){
     const auto duration{sender.NaturalDuration()};
-    m_timelineDurationSeconds = std::max(0.0, static_cast<double>(duration.count()) / 10'000'000.0);
+    m_timelineDurationSeconds = std::max(0.0, duration.count() / 10'000'000.0);
 
     if(m_loadedFile && m_timelineDurationSeconds > 0){
         const auto weak{get_weak()};
@@ -228,7 +222,7 @@ void MainWindow::UpdateTimelineCursorFromPlayback(){
     }
 
     const auto current{m_player.PlaybackSession().Position()};
-    const double seconds{std::max(0.0, static_cast<double>(current.count()) / 10'000'000.0)};
+    const double seconds{std::max(0.0, current.count() / 10'000'000.0)};
     const double ratio{std::clamp(seconds / m_timelineDurationSeconds, 0.0, 1.0)};
     const double left{ratio * TimelineCanvas().Width()};
     Controls::Canvas::SetLeft(TimelineCursor(), left);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -10,18 +10,32 @@ struct MainWindow: MainWindowT<MainWindow>{
     void StartButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     void PauseButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     void StopButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    void TimelineZoomSlider_ValueChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& args);
+    void TimelineCanvas_PointerPressed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void Window_DragOver(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction Window_Drop(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
     void OnClosed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::WindowEventArgs const& args);
+    void OnNaturalDurationChanged(winrt::Windows::Media::Playback::MediaPlaybackSession const& sender, winrt::Windows::Foundation::IInspectable const& args);
+    void OnPositionTimerTick(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::Foundation::IInspectable const& args);
 
 private:
     winrt::Windows::Media::Playback::MediaPlayer m_player{nullptr};
+    winrt::Windows::Storage::StorageFile m_loadedFile{nullptr};
+    winrt::Windows::Media::Playback::MediaPlaybackSession::NaturalDurationChanged_revoker m_naturalDurationChangedRevoker{};
+    winrt::Microsoft::UI::Xaml::DispatcherTimer m_positionTimer{nullptr};
+    double m_timelineDurationSeconds{0};
+    std::uint64_t m_timelineRenderVersion{0};
+    bool m_isClosing{false};
     HWND GetWindowHandle() const;
 
 private:
     void RestoreWindowPlacement();
     void SaveWindowPlacement() const;
     winrt::Windows::Foundation::IAsyncAction LoadVideoFileAsync(winrt::Windows::Storage::StorageFile const& file);
+    winrt::fire_and_forget RenderTimelineAsync();
+    void UpdateTimelineCursorFromPlayback();
+    static winrt::Windows::Foundation::TimeSpan SecondsToTimeSpan(double seconds);
+    static bool IsRectVisibleOnAnyMonitor(RECT const& rect);
 };
 
 }

--- a/Win/llvc/llvc.vcxproj
+++ b/Win/llvc/llvc.vcxproj
@@ -97,11 +97,17 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/Win/llvc/pch.h
+++ b/Win/llvc/pch.h
@@ -1,4 +1,8 @@
 #pragma once
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #include <unknwn.h>
 #include <restrictederrorinfo.h>


### PR DESCRIPTION
### Motivation
- The timeline rendering was being started from `NaturalDurationChanged`, which can be raised off the UI thread and caused unhandled exceptions when the `fire_and_forget` coroutine touched XAML objects. 
- The crash indicates a lifetime/affinity race where UI work was executed from a background callback and the coroutine could outlive the window. 
- The change is intended to guard against thread-affinity and lifetime races and to surface recoverable errors instead of failing the process.

### Description
- Schedule `RenderTimelineAsync()` onto the window dispatcher when `OnNaturalDurationChanged` is invoked off the UI thread by checking `DispatcherQueue().HasThreadAccess()` and using `DispatcherQueue().TryEnqueue(...)` with a `get_weak()` reference. 
- Harden `RenderTimelineAsync()` by keeping the window alive via `get_strong()`, switching to the UI thread with `co_await resume_foreground(DispatcherQueue())` before touching XAML, re-checking `m_isClosing`/`m_loadedFile`/`m_timelineDurationSeconds` after thread hops and between awaits, and preserving the render-version guard. 
- Add exception handling around the render flow to catch `winrt::hresult_error` and show a user-friendly message in `StatusText` instead of letting exceptions propagate and terminate the process.

### Testing
- Ran `git diff --check` to validate formatting and trivial issues and it succeeded. 
- Attempted to run a full build with `msbuild Win/trifles-win.sln /t:Build /p:Configuration=Debug` but `msbuild` is not available in this environment so a full compile could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995827d1a748333bc9abc50bae2166d)