### PR TITLE
Add timeline ticks and horizontal scrollbar with synced scrolling and auto-follow cursor

### DIFF
--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -51,7 +51,7 @@
                     </ScrollViewer>
 
                     <Border Grid.Row="1" Margin="0,2,0,0" Padding="2" Background="#202020" BorderBrush="#6A6A6A" BorderThickness="1" CornerRadius="2">
-                        <ScrollBar x:Name="TimelineHorizontalScrollBar" Orientation="Horizontal" Minimum="0" Height="16" MinWidth="120" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" Opacity="1" Background="#3A3A3A" Foreground="#FFFFFF" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
+                        <Slider x:Name="TimelineHorizontalScrollBar" Minimum="0" Height="16" MinWidth="120" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
                     </Border>
                 </Grid>
             </Border>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -34,12 +34,24 @@
             </StackPanel>
 
             <Border Grid.Row="1" BorderThickness="1" BorderBrush="#404040" Background="#111111" CornerRadius="4" Padding="6">
-                <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled">
-                    <Canvas x:Name="TimelineCanvas" Height="86" PointerPressed="TimelineCanvas_PointerPressed" Background="#111111">
-                        <Canvas x:Name="ThumbnailLayer" Height="86"/>
-                        <Rectangle x:Name="TimelineCursor" Canvas.Left="0" Width="2" Height="86" Fill="White"/>
-                    </Canvas>
-                </ScrollViewer>
+                <Grid RowSpacing="4">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Hidden" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled" ViewChanged="TimelineScrollViewer_ViewChanged">
+                        <StackPanel Orientation="Vertical" Spacing="4">
+                            <Canvas x:Name="TimelineTickCanvas" Height="24" Background="#111111"/>
+                            <Canvas x:Name="TimelineCanvas" Height="86" PointerPressed="TimelineCanvas_PointerPressed" Background="#111111">
+                                <Canvas x:Name="ThumbnailLayer" Height="86"/>
+                                <Rectangle x:Name="TimelineCursor" Canvas.Left="0" Width="2" Height="86" Fill="White"/>
+                            </Canvas>
+                        </StackPanel>
+                    </ScrollViewer>
+
+                    <ScrollBar Grid.Row="2" x:Name="TimelineHorizontalScrollBar" Orientation="Horizontal" Minimum="0" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
+                </Grid>
             </Border>
         </Grid>
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -37,7 +37,7 @@
                 <Grid RowSpacing="4">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="24"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
                     <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Hidden" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled" ViewChanged="TimelineScrollViewer_ViewChanged" SizeChanged="TimelineScrollViewer_SizeChanged">
@@ -50,8 +50,8 @@
                         </StackPanel>
                     </ScrollViewer>
 
-                    <Border Grid.Row="1" Margin="0,2,0,0" Padding="2" Background="#202020" BorderBrush="#6A6A6A" BorderThickness="1" CornerRadius="2">
-                        <Slider x:Name="TimelineHorizontalScrollBar" Minimum="0" Height="16" MinWidth="120" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
+                    <Border Grid.Row="1" Margin="0,4,0,0" Padding="0" MinHeight="28" Background="#202020" BorderBrush="#6A6A6A" BorderThickness="1" CornerRadius="2">
+                        <Slider x:Name="TimelineHorizontalScrollBar" Minimum="0" Height="20" MinWidth="120" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="6,2" Visibility="Visible" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
                     </Border>
                 </Grid>
             </Border>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -37,10 +37,10 @@
                 <Grid RowSpacing="4">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="18"/>
                     </Grid.RowDefinitions>
 
-                    <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Hidden" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled" ViewChanged="TimelineScrollViewer_ViewChanged">
+                    <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Hidden" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled" ViewChanged="TimelineScrollViewer_ViewChanged" SizeChanged="TimelineScrollViewer_SizeChanged">
                         <StackPanel Orientation="Vertical" Spacing="4">
                             <Canvas x:Name="TimelineTickCanvas" Height="24" Background="#111111"/>
                             <Canvas x:Name="TimelineCanvas" Height="86" PointerPressed="TimelineCanvas_PointerPressed" PointerMoved="TimelineCanvas_PointerMoved" PointerReleased="TimelineCanvas_PointerReleased" PointerCanceled="TimelineCanvas_PointerCanceled" PointerCaptureLost="TimelineCanvas_PointerCaptureLost" Background="#111111">
@@ -50,7 +50,7 @@
                         </StackPanel>
                     </ScrollViewer>
 
-                    <ScrollBar Grid.Row="1" x:Name="TimelineHorizontalScrollBar" Orientation="Horizontal" Minimum="0" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
+                    <ScrollBar Grid.Row="1" x:Name="TimelineHorizontalScrollBar" Orientation="Horizontal" Minimum="0" Height="14" MinWidth="80" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
                 </Grid>
             </Border>
         </Grid>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -37,7 +37,7 @@
                 <Grid RowSpacing="4">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="18"/>
+                        <RowDefinition Height="24"/>
                     </Grid.RowDefinitions>
 
                     <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Hidden" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled" ViewChanged="TimelineScrollViewer_ViewChanged" SizeChanged="TimelineScrollViewer_SizeChanged">
@@ -50,7 +50,7 @@
                         </StackPanel>
                     </ScrollViewer>
 
-                    <ScrollBar Grid.Row="1" x:Name="TimelineHorizontalScrollBar" Orientation="Horizontal" Minimum="0" Height="14" MinWidth="80" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
+                    <ScrollBar Grid.Row="1" x:Name="TimelineHorizontalScrollBar" Orientation="Horizontal" Minimum="0" Height="20" MinWidth="120" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="0,2,0,0" Visibility="Visible" Opacity="1" Background="#252525" Foreground="#D0D0D0" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
                 </Grid>
             </Border>
         </Grid>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -50,7 +50,9 @@
                         </StackPanel>
                     </ScrollViewer>
 
-                    <ScrollBar Grid.Row="1" x:Name="TimelineHorizontalScrollBar" Orientation="Horizontal" Minimum="0" Height="20" MinWidth="120" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="0,2,0,0" Visibility="Visible" Opacity="1" Background="#252525" Foreground="#D0D0D0" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
+                    <Border Grid.Row="1" Margin="0,2,0,0" Padding="2" Background="#202020" BorderBrush="#6A6A6A" BorderThickness="1" CornerRadius="2">
+                        <ScrollBar x:Name="TimelineHorizontalScrollBar" Orientation="Horizontal" Minimum="0" Height="16" MinWidth="120" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Visible" Opacity="1" Background="#3A3A3A" Foreground="#FFFFFF" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
+                    </Border>
                 </Grid>
             </Border>
         </Grid>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -43,14 +43,14 @@
                     <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Hidden" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled" ViewChanged="TimelineScrollViewer_ViewChanged">
                         <StackPanel Orientation="Vertical" Spacing="4">
                             <Canvas x:Name="TimelineTickCanvas" Height="24" Background="#111111"/>
-                            <Canvas x:Name="TimelineCanvas" Height="86" PointerPressed="TimelineCanvas_PointerPressed" Background="#111111">
+                            <Canvas x:Name="TimelineCanvas" Height="86" PointerPressed="TimelineCanvas_PointerPressed" PointerMoved="TimelineCanvas_PointerMoved" PointerReleased="TimelineCanvas_PointerReleased" PointerCanceled="TimelineCanvas_PointerCanceled" PointerCaptureLost="TimelineCanvas_PointerCaptureLost" Background="#111111">
                                 <Canvas x:Name="ThumbnailLayer" Height="86"/>
                                 <Rectangle x:Name="TimelineCursor" Canvas.Left="0" Width="2" Height="86" Fill="White"/>
                             </Canvas>
                         </StackPanel>
                     </ScrollViewer>
 
-                    <ScrollBar Grid.Row="2" x:Name="TimelineHorizontalScrollBar" Orientation="Horizontal" Minimum="0" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
+                    <ScrollBar Grid.Row="1" x:Name="TimelineHorizontalScrollBar" Orientation="Horizontal" Minimum="0" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
                 </Grid>
             </Border>
         </Grid>

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -318,18 +318,21 @@ void MainWindow::UpdateTimelineCursorFromPlayback(){
 
 void MainWindow::SyncTimelineHorizontalScrollBar(){
     const auto scrollViewer{TimelineScrollViewer()};
-    const double scrollableWidth{scrollViewer.ScrollableWidth()};
+    const double scrollableWidth{std::max(0.0, scrollViewer.ScrollableWidth())};
+    const double viewportWidth{std::max(1.0, scrollViewer.ViewportWidth())};
 
-    TimelineHorizontalScrollBar().Maximum(scrollableWidth);
-    TimelineHorizontalScrollBar().ViewportSize(scrollViewer.ViewportWidth());
-    TimelineHorizontalScrollBar().LargeChange(std::max(32.0, scrollViewer.ViewportWidth() * 0.8));
-    TimelineHorizontalScrollBar().SmallChange(24.0);
-    TimelineHorizontalScrollBar().IsEnabled(scrollableWidth > 0.5);
+    auto bar{TimelineHorizontalScrollBar()};
+    bar.Maximum(std::max(1.0, scrollableWidth));
+    bar.ViewportSize(viewportWidth);
+    bar.LargeChange(std::max(32.0, viewportWidth * 0.8));
+    bar.SmallChange(24.0);
+    bar.IsEnabled(true);
+    bar.Visibility(Visibility::Visible);
 
-    const double currentValue{TimelineHorizontalScrollBar().Value()};
-    const double offset{scrollViewer.HorizontalOffset()};
+    const double currentValue{bar.Value()};
+    const double offset{std::clamp(scrollViewer.HorizontalOffset(), 0.0, bar.Maximum())};
     if(std::fabs(currentValue - offset) > 0.5){
-        TimelineHorizontalScrollBar().Value(offset);
+        bar.Value(offset);
     }
 }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -323,7 +323,6 @@ void MainWindow::SyncTimelineHorizontalScrollBar(){
 
     auto bar{TimelineHorizontalScrollBar()};
     bar.Maximum(std::max(1.0, scrollableWidth));
-    bar.ViewportSize(viewportWidth);
     bar.LargeChange(std::max(32.0, viewportWidth * 0.8));
     bar.SmallChange(24.0);
     bar.IsEnabled(true);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -305,24 +305,7 @@ void MainWindow::UpdateTimelineCursorFromPlayback(){
     Controls::Canvas::SetLeft(TimelineCursor(), left);
 
     if(m_player.PlaybackSession().PlaybackState() == Windows::Media::Playback::MediaPlaybackState::Playing){
-        const auto scrollViewer{TimelineScrollViewer()};
-        const double currentOffset{scrollViewer.HorizontalOffset()};
-        const double viewportWidth{scrollViewer.ViewportWidth()};
-
-        if(viewportWidth > 0){
-            constexpr double cursorPadding{48.0};
-            const double minVisible{currentOffset + cursorPadding};
-            const double maxVisible{currentOffset + viewportWidth - cursorPadding};
-            const double maxOffset{std::max(0.0, TimelineCanvas().Width() - viewportWidth)};
-
-            if(left < minVisible){
-                const auto targetOffset{box_value(std::clamp(left - cursorPadding, 0.0, maxOffset)).as<Windows::Foundation::IReference<double>>()};
-                scrollViewer.ChangeView(targetOffset, nullptr, nullptr, true);
-            }else if(left > maxVisible){
-                const auto targetOffset{box_value(std::clamp(left + cursorPadding - viewportWidth, 0.0, maxOffset)).as<Windows::Foundation::IReference<double>>()};
-                scrollViewer.ChangeView(targetOffset, nullptr, nullptr, true);
-            }
-        }
+        EnsureTimelineCursorVisible(left);
     }
 
     SyncTimelineHorizontalScrollBar();
@@ -356,6 +339,29 @@ void MainWindow::SeekTimelineToCanvasX(const double pointerX){
 
     m_player.PlaybackSession().Position(SecondsToTimeSpan(targetSeconds));
     UpdateTimelineCursorFromPlayback();
+}
+
+void MainWindow::EnsureTimelineCursorVisible(const double cursorLeft){
+    const auto scrollViewer{TimelineScrollViewer()};
+    const double currentOffset{scrollViewer.HorizontalOffset()};
+    const double viewportWidth{scrollViewer.ViewportWidth()};
+
+    if(viewportWidth <= 0){
+        return;
+    }
+
+    constexpr double cursorPadding{48.0};
+    const double minVisible{currentOffset + cursorPadding};
+    const double maxVisible{currentOffset + viewportWidth - cursorPadding};
+    const double maxOffset{std::max(0.0, TimelineCanvas().Width() - viewportWidth)};
+
+    if(cursorLeft < minVisible){
+        const auto targetOffset{box_value(std::clamp(cursorLeft - cursorPadding, 0.0, maxOffset)).as<Windows::Foundation::IReference<double>>()};
+        scrollViewer.ChangeView(targetOffset, nullptr, nullptr, true);
+    }else if(cursorLeft > maxVisible){
+        const auto targetOffset{box_value(std::clamp(cursorLeft + cursorPadding - viewportWidth, 0.0, maxOffset)).as<Windows::Foundation::IReference<double>>()};
+        scrollViewer.ChangeView(targetOffset, nullptr, nullptr, true);
+    }
 }
 
 void MainWindow::RenderTimelineTicks(){
@@ -526,6 +532,8 @@ winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
         }
 
         UpdateTimelineCursorFromPlayback();
+        EnsureTimelineCursorVisible(Controls::Canvas::GetLeft(TimelineCursor()));
+        SyncTimelineHorizontalScrollBar();
 
         std::wstring status{L"Loaded: "};
         status += m_loadedFile.Name().c_str();

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -181,7 +181,8 @@ void MainWindow::TimelineHorizontalScrollBar_ValueChanged(IInspectable const&, C
     const auto scrollViewer{TimelineScrollViewer()};
     const double offset{scrollViewer.HorizontalOffset()};
     if(std::fabs(offset - args.NewValue()) > 0.5){
-        scrollViewer.ChangeView(box_value(args.NewValue()), nullptr, nullptr, true);
+        const auto targetOffset{box_value(args.NewValue()).as<Windows::Foundation::IReference<double>>()};
+        scrollViewer.ChangeView(targetOffset, nullptr, nullptr, true);
     }
 }
 
@@ -258,9 +259,11 @@ void MainWindow::UpdateTimelineCursorFromPlayback(){
             const double maxOffset{std::max(0.0, TimelineCanvas().Width() - viewportWidth)};
 
             if(left < minVisible){
-                scrollViewer.ChangeView(box_value(std::clamp(left - cursorPadding, 0.0, maxOffset)), nullptr, nullptr, true);
+                const auto targetOffset{box_value(std::clamp(left - cursorPadding, 0.0, maxOffset)).as<Windows::Foundation::IReference<double>>()};
+                scrollViewer.ChangeView(targetOffset, nullptr, nullptr, true);
             }else if(left > maxVisible){
-                scrollViewer.ChangeView(box_value(std::clamp(left + cursorPadding - viewportWidth, 0.0, maxOffset)), nullptr, nullptr, true);
+                const auto targetOffset{box_value(std::clamp(left + cursorPadding - viewportWidth, 0.0, maxOffset)).as<Windows::Foundation::IReference<double>>()};
+                scrollViewer.ChangeView(targetOffset, nullptr, nullptr, true);
             }
         }
     }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -191,22 +191,79 @@ void MainWindow::TimelineScrollViewer_ViewChanged(IInspectable const&, Controls:
 }
 
 void MainWindow::TimelineCanvas_PointerPressed(IInspectable const&, Input::PointerRoutedEventArgs const& e){
-    if(!m_player || m_timelineDurationSeconds <= 0){
+    if(m_timelineDurationSeconds <= 0 || TimelineCanvas().Width() <= 0){
         return;
     }
 
-    if(TimelineCanvas().Width() <= 0){
+    const auto point{e.GetCurrentPoint(TimelineCanvas())};
+    if(!point.Properties().IsLeftButtonPressed()){
+        return;
+    }
+
+    m_isTimelineDragging = true;
+    m_timelineDragMoved = false;
+    m_timelineDragPointerId = e.Pointer().PointerId();
+    m_timelineDragStartX = static_cast<double>(point.Position().X);
+    m_timelineDragStartOffset = TimelineScrollViewer().HorizontalOffset();
+
+    TimelineCanvas().CapturePointer(e.Pointer());
+    e.Handled(true);
+}
+
+void MainWindow::TimelineCanvas_PointerMoved(IInspectable const&, Input::PointerRoutedEventArgs const& e){
+    if(!m_isTimelineDragging || e.Pointer().PointerId() != m_timelineDragPointerId){
         return;
     }
 
     const auto point{e.GetCurrentPoint(TimelineCanvas())};
     const double pointerX{static_cast<double>(point.Position().X)};
-    const double x{std::clamp(pointerX, 0.0, TimelineCanvas().Width())};
-    const double ratio{x / TimelineCanvas().Width()};
-    const double targetSeconds{ratio * m_timelineDurationSeconds};
+    const double deltaX{pointerX - m_timelineDragStartX};
 
-    m_player.PlaybackSession().Position(SecondsToTimeSpan(targetSeconds));
-    UpdateTimelineCursorFromPlayback();
+    if(std::fabs(deltaX) > 4.0){
+        m_timelineDragMoved = true;
+    }
+
+    const auto scrollViewer{TimelineScrollViewer()};
+    const double viewportWidth{scrollViewer.ViewportWidth()};
+    const double maxOffset{std::max(0.0, TimelineCanvas().Width() - viewportWidth)};
+    const double target{std::clamp(m_timelineDragStartOffset - deltaX, 0.0, maxOffset)};
+    const auto targetOffset{box_value(target).as<Windows::Foundation::IReference<double>>()};
+    scrollViewer.ChangeView(targetOffset, nullptr, nullptr, true);
+    e.Handled(true);
+}
+
+void MainWindow::TimelineCanvas_PointerReleased(IInspectable const&, Input::PointerRoutedEventArgs const& e){
+    if(!m_isTimelineDragging || e.Pointer().PointerId() != m_timelineDragPointerId){
+        return;
+    }
+
+    const auto point{e.GetCurrentPoint(TimelineCanvas())};
+    const double pointerX{static_cast<double>(point.Position().X)};
+    const bool dragged{m_timelineDragMoved};
+
+    m_isTimelineDragging = false;
+    m_timelineDragMoved = false;
+    TimelineCanvas().ReleasePointerCapture(e.Pointer());
+
+    if(!dragged){
+        SeekTimelineToCanvasX(pointerX);
+    }
+
+    e.Handled(true);
+}
+
+void MainWindow::TimelineCanvas_PointerCanceled(IInspectable const&, Input::PointerRoutedEventArgs const& e){
+    if(m_isTimelineDragging && e.Pointer().PointerId() == m_timelineDragPointerId){
+        m_isTimelineDragging = false;
+        m_timelineDragMoved = false;
+        TimelineCanvas().ReleasePointerCapture(e.Pointer());
+        e.Handled(true);
+    }
+}
+
+void MainWindow::TimelineCanvas_PointerCaptureLost(IInspectable const&, Input::PointerRoutedEventArgs const&){
+    m_isTimelineDragging = false;
+    m_timelineDragMoved = false;
 }
 
 void MainWindow::OnNaturalDurationChanged(Windows::Media::Playback::MediaPlaybackSession const& sender, IInspectable const&){
@@ -286,6 +343,19 @@ void MainWindow::SyncTimelineHorizontalScrollBar(){
     if(std::fabs(currentValue - offset) > 0.5){
         TimelineHorizontalScrollBar().Value(offset);
     }
+}
+
+void MainWindow::SeekTimelineToCanvasX(const double pointerX){
+    if(!m_player || m_timelineDurationSeconds <= 0 || TimelineCanvas().Width() <= 0){
+        return;
+    }
+
+    const double x{std::clamp(pointerX, 0.0, TimelineCanvas().Width())};
+    const double ratio{x / TimelineCanvas().Width()};
+    const double targetSeconds{ratio * m_timelineDurationSeconds};
+
+    m_player.PlaybackSession().Position(SecondsToTimeSpan(targetSeconds));
+    UpdateTimelineCursorFromPlayback();
 }
 
 void MainWindow::RenderTimelineTicks(){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -500,32 +500,6 @@ winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
         RenderTimelineTicks();
         SyncTimelineHorizontalScrollBar();
 
-        const auto scrollViewer{TimelineScrollViewer()};
-        const double viewportWidth{std::max(0.0, scrollViewer.ViewportWidth())};
-        const double viewportLeft{scrollViewer.HorizontalOffset()};
-        const double viewportRight{viewportLeft + viewportWidth};
-        const int firstVisibleIndex{std::clamp(static_cast<int>(std::floor(viewportLeft / thumbnailWidth)), 0, thumbnailCount - 1)};
-        const int lastVisibleIndex{std::clamp(static_cast<int>(std::floor(std::max(viewportLeft, viewportRight - 1.0) / thumbnailWidth)), 0, thumbnailCount - 1)};
-
-        std::vector<int> thumbnailBuildOrder{};
-        thumbnailBuildOrder.reserve(static_cast<size_t>(thumbnailCount));
-        for(int i = firstVisibleIndex; i <= lastVisibleIndex; ++i){
-            thumbnailBuildOrder.push_back(i);
-        }
-
-        int left{firstVisibleIndex - 1};
-        int right{lastVisibleIndex + 1};
-        while(static_cast<int>(thumbnailBuildOrder.size()) < thumbnailCount){
-            if(right < thumbnailCount){
-                thumbnailBuildOrder.push_back(right);
-                ++right;
-            }
-            if(left >= 0){
-                thumbnailBuildOrder.push_back(left);
-                --left;
-            }
-        }
-
         const auto clip{co_await Windows::Media::Editing::MediaClip::CreateFromFileAsync(m_loadedFile)};
         Windows::Media::Editing::MediaComposition composition{};
         composition.Clips().Append(clip);
@@ -534,12 +508,51 @@ winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
             co_return;
         }
 
-        for(const int i: thumbnailBuildOrder){
+        std::vector<bool> thumbnailBuilt(static_cast<size_t>(thumbnailCount), false);
+
+        for(int builtCount = 0; builtCount < thumbnailCount; ++builtCount){
             if(renderVersion != m_timelineRenderVersion || m_isClosing){
                 co_return;
             }
 
-            const double t{(static_cast<double>(i) + 0.5) / static_cast<double>(thumbnailCount)};
+            const auto scrollViewer{TimelineScrollViewer()};
+            const double viewportWidth{std::max(0.0, scrollViewer.ViewportWidth())};
+            const double viewportLeft{scrollViewer.HorizontalOffset()};
+            const double viewportRight{viewportLeft + viewportWidth};
+            const int firstVisibleIndex{std::clamp(static_cast<int>(std::floor(viewportLeft / thumbnailWidth)), 0, thumbnailCount - 1)};
+            const int lastVisibleIndex{std::clamp(static_cast<int>(std::floor(std::max(viewportLeft, viewportRight - 1.0) / thumbnailWidth)), 0, thumbnailCount - 1)};
+
+            int nextIndex{-1};
+            for(int i = firstVisibleIndex; i <= lastVisibleIndex; ++i){
+                if(!thumbnailBuilt[static_cast<size_t>(i)]){
+                    nextIndex = i;
+                    break;
+                }
+            }
+
+            if(nextIndex < 0){
+                int left{firstVisibleIndex - 1};
+                int right{lastVisibleIndex + 1};
+                while(nextIndex < 0 && (left >= 0 || right < thumbnailCount)){
+                    if(right < thumbnailCount && !thumbnailBuilt[static_cast<size_t>(right)]){
+                        nextIndex = right;
+                        break;
+                    }
+                    ++right;
+
+                    if(left >= 0 && !thumbnailBuilt[static_cast<size_t>(left)]){
+                        nextIndex = left;
+                        break;
+                    }
+                    --left;
+                }
+            }
+
+            if(nextIndex < 0){
+                break;
+            }
+
+            const double t{(static_cast<double>(nextIndex) + 0.5) / static_cast<double>(thumbnailCount)};
             const auto stream{co_await composition.GetThumbnailAsync(SecondsToTimeSpan(t * m_timelineDurationSeconds), 180, 96, Windows::Media::Editing::VideoFramePrecision::NearestFrame)};
             if(renderVersion != m_timelineRenderVersion || m_isClosing){
                 co_return;
@@ -554,8 +567,9 @@ winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
             co_await bitmap.SetSourceAsync(stream);
             image.Source(bitmap);
 
-            Controls::Canvas::SetLeft(image, i * thumbnailWidth);
+            Controls::Canvas::SetLeft(image, nextIndex * thumbnailWidth);
             ThumbnailLayer().Children().Append(image);
+            thumbnailBuilt[static_cast<size_t>(nextIndex)] = true;
         }
 
         UpdateTimelineCursorFromPlayback();

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -10,6 +10,8 @@
 #include <winrt/Microsoft.UI.Input.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Media.Imaging.h>
+#include <winrt/Microsoft.UI.Xaml.Shapes.h>
+#include <winrt/Windows.UI.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 #include <winrt/Windows.Media.Core.h>
 #include <winrt/Windows.Media.Editing.h>
@@ -171,6 +173,22 @@ void MainWindow::TimelineZoomSlider_ValueChanged(IInspectable const&, Controls::
     }
 }
 
+void MainWindow::TimelineHorizontalScrollBar_ValueChanged(IInspectable const&, Controls::Primitives::RangeBaseValueChangedEventArgs const& args){
+    if(m_isClosing){
+        return;
+    }
+
+    const auto scrollViewer{TimelineScrollViewer()};
+    const double offset{scrollViewer.HorizontalOffset()};
+    if(std::fabs(offset - args.NewValue()) > 0.5){
+        scrollViewer.ChangeView(box_value(args.NewValue()), nullptr, nullptr, true);
+    }
+}
+
+void MainWindow::TimelineScrollViewer_ViewChanged(IInspectable const&, Controls::ScrollViewerViewChangedEventArgs const&){
+    SyncTimelineHorizontalScrollBar();
+}
+
 void MainWindow::TimelineCanvas_PointerPressed(IInspectable const&, Input::PointerRoutedEventArgs const& e){
     if(!m_player || m_timelineDurationSeconds <= 0){
         return;
@@ -227,6 +245,87 @@ void MainWindow::UpdateTimelineCursorFromPlayback(){
     const double ratio{std::clamp(seconds / m_timelineDurationSeconds, 0.0, 1.0)};
     const double left{ratio * TimelineCanvas().Width()};
     Controls::Canvas::SetLeft(TimelineCursor(), left);
+
+    if(m_player.PlaybackSession().PlaybackState() == Windows::Media::Playback::MediaPlaybackState::Playing){
+        const auto scrollViewer{TimelineScrollViewer()};
+        const double currentOffset{scrollViewer.HorizontalOffset()};
+        const double viewportWidth{scrollViewer.ViewportWidth()};
+
+        if(viewportWidth > 0){
+            constexpr double cursorPadding{48.0};
+            const double minVisible{currentOffset + cursorPadding};
+            const double maxVisible{currentOffset + viewportWidth - cursorPadding};
+            const double maxOffset{std::max(0.0, TimelineCanvas().Width() - viewportWidth)};
+
+            if(left < minVisible){
+                scrollViewer.ChangeView(box_value(std::clamp(left - cursorPadding, 0.0, maxOffset)), nullptr, nullptr, true);
+            }else if(left > maxVisible){
+                scrollViewer.ChangeView(box_value(std::clamp(left + cursorPadding - viewportWidth, 0.0, maxOffset)), nullptr, nullptr, true);
+            }
+        }
+    }
+
+    SyncTimelineHorizontalScrollBar();
+}
+
+void MainWindow::SyncTimelineHorizontalScrollBar(){
+    const auto scrollViewer{TimelineScrollViewer()};
+    const double scrollableWidth{scrollViewer.ScrollableWidth()};
+
+    TimelineHorizontalScrollBar().Maximum(scrollableWidth);
+    TimelineHorizontalScrollBar().ViewportSize(scrollViewer.ViewportWidth());
+    TimelineHorizontalScrollBar().LargeChange(std::max(32.0, scrollViewer.ViewportWidth() * 0.8));
+    TimelineHorizontalScrollBar().SmallChange(24.0);
+    TimelineHorizontalScrollBar().IsEnabled(scrollableWidth > 0.5);
+
+    const double currentValue{TimelineHorizontalScrollBar().Value()};
+    const double offset{scrollViewer.HorizontalOffset()};
+    if(std::fabs(currentValue - offset) > 0.5){
+        TimelineHorizontalScrollBar().Value(offset);
+    }
+}
+
+void MainWindow::RenderTimelineTicks(){
+    TimelineTickCanvas().Children().Clear();
+
+    const double width{TimelineCanvas().Width()};
+    TimelineTickCanvas().Width(width);
+    if(m_timelineDurationSeconds <= 0 || width <= 0){
+        return;
+    }
+
+    const int majorTickCount{std::clamp(static_cast<int>(std::ceil(width / 120.0)), 6, 36)};
+
+    for(int i = 0; i <= majorTickCount; ++i){
+        const double ratio{static_cast<double>(i) / static_cast<double>(majorTickCount)};
+        const double x{ratio * width};
+
+        Shapes::Line majorTick{};
+        majorTick.X1(x);
+        majorTick.X2(x);
+        majorTick.Y1(7);
+        majorTick.Y2(23);
+        majorTick.Stroke(Media::SolidColorBrush(Windows::UI::ColorHelper::FromArgb(255, 180, 180, 180)));
+        majorTick.StrokeThickness(1.0);
+        TimelineTickCanvas().Children().Append(majorTick);
+
+        Controls::TextBlock label{};
+        const int totalSeconds{static_cast<int>(std::round(ratio * m_timelineDurationSeconds))};
+        const int minutes{totalSeconds / 60};
+        const int seconds{totalSeconds % 60};
+        std::wstring text{std::to_wstring(minutes)};
+        text += L":";
+        if(seconds < 10){
+            text += L"0";
+        }
+        text += std::to_wstring(seconds);
+        label.Text(text);
+        label.FontSize(11);
+        label.Foreground(Media::SolidColorBrush(Windows::UI::ColorHelper::FromArgb(255, 200, 200, 200)));
+        Controls::Canvas::SetLeft(label, std::max(0.0, x + 3.0));
+        Controls::Canvas::SetTop(label, 0);
+        TimelineTickCanvas().Children().Append(label);
+    }
 }
 
 Windows::Foundation::TimeSpan MainWindow::SecondsToTimeSpan(const double seconds){
@@ -277,8 +376,11 @@ Windows::Foundation::IAsyncAction MainWindow::LoadVideoFileAsync(Windows::Storag
 
     ThumbnailLayer().Children().Clear();
     TimelineCanvas().Width(640.0);
+    TimelineTickCanvas().Width(640.0);
+    TimelineTickCanvas().Children().Clear();
     m_timelineDurationSeconds = 0;
     Controls::Canvas::SetLeft(TimelineCursor(), 0);
+    SyncTimelineHorizontalScrollBar();
 
     std::wstring status{L"Loaded: "};
     status += file.Name().c_str();
@@ -315,6 +417,8 @@ winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
         TimelineCanvas().Width(totalWidth);
         ThumbnailLayer().Children().Clear();
         Controls::Canvas::SetLeft(TimelineCursor(), 0);
+        RenderTimelineTicks();
+        SyncTimelineHorizontalScrollBar();
 
         const auto clip{co_await Windows::Media::Editing::MediaClip::CreateFromFileAsync(m_loadedFile)};
         Windows::Media::Editing::MediaComposition composition{};

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cwctype>
+#include <vector>
 
 #include <microsoft.ui.xaml.window.h>
 #include <winrt/Microsoft.UI.Input.h>
@@ -499,6 +500,32 @@ winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
         RenderTimelineTicks();
         SyncTimelineHorizontalScrollBar();
 
+        const auto scrollViewer{TimelineScrollViewer()};
+        const double viewportWidth{std::max(0.0, scrollViewer.ViewportWidth())};
+        const double viewportLeft{scrollViewer.HorizontalOffset()};
+        const double viewportRight{viewportLeft + viewportWidth};
+        const int firstVisibleIndex{std::clamp(static_cast<int>(std::floor(viewportLeft / thumbnailWidth)), 0, thumbnailCount - 1)};
+        const int lastVisibleIndex{std::clamp(static_cast<int>(std::floor(std::max(viewportLeft, viewportRight - 1.0) / thumbnailWidth)), 0, thumbnailCount - 1)};
+
+        std::vector<int> thumbnailBuildOrder{};
+        thumbnailBuildOrder.reserve(static_cast<size_t>(thumbnailCount));
+        for(int i = firstVisibleIndex; i <= lastVisibleIndex; ++i){
+            thumbnailBuildOrder.push_back(i);
+        }
+
+        int left{firstVisibleIndex - 1};
+        int right{lastVisibleIndex + 1};
+        while(static_cast<int>(thumbnailBuildOrder.size()) < thumbnailCount){
+            if(right < thumbnailCount){
+                thumbnailBuildOrder.push_back(right);
+                ++right;
+            }
+            if(left >= 0){
+                thumbnailBuildOrder.push_back(left);
+                --left;
+            }
+        }
+
         const auto clip{co_await Windows::Media::Editing::MediaClip::CreateFromFileAsync(m_loadedFile)};
         Windows::Media::Editing::MediaComposition composition{};
         composition.Clips().Append(clip);
@@ -507,7 +534,7 @@ winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
             co_return;
         }
 
-        for(int i = 0; i < thumbnailCount; ++i){
+        for(const int i: thumbnailBuildOrder){
             if(renderVersion != m_timelineRenderVersion || m_isClosing){
                 co_return;
             }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -191,6 +191,10 @@ void MainWindow::TimelineScrollViewer_ViewChanged(IInspectable const&, Controls:
     SyncTimelineHorizontalScrollBar();
 }
 
+void MainWindow::TimelineScrollViewer_SizeChanged(IInspectable const&, SizeChangedEventArgs const&){
+    SyncTimelineHorizontalScrollBar();
+}
+
 void MainWindow::TimelineCanvas_PointerPressed(IInspectable const&, Input::PointerRoutedEventArgs const& e){
     if(m_timelineDurationSeconds <= 0 || TimelineCanvas().Width() <= 0){
         return;

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -2,6 +2,8 @@
 
 #include "MainWindow.g.h"
 
+#include <cstdint>
+
 namespace winrt::llvc::implementation{
 
 struct MainWindow: MainWindowT<MainWindow>{
@@ -14,6 +16,10 @@ struct MainWindow: MainWindowT<MainWindow>{
     void TimelineHorizontalScrollBar_ValueChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& args);
     void TimelineScrollViewer_ViewChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::ScrollViewerViewChangedEventArgs const& args);
     void TimelineCanvas_PointerPressed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    void TimelineCanvas_PointerMoved(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    void TimelineCanvas_PointerReleased(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    void TimelineCanvas_PointerCanceled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    void TimelineCanvas_PointerCaptureLost(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void Window_DragOver(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction Window_Drop(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
     void OnClosed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::WindowEventArgs const& args);
@@ -28,6 +34,11 @@ private:
     double m_timelineDurationSeconds{0};
     std::uint64_t m_timelineRenderVersion{0};
     bool m_isClosing{false};
+    bool m_isTimelineDragging{false};
+    bool m_timelineDragMoved{false};
+    std::uint32_t m_timelineDragPointerId{0};
+    double m_timelineDragStartX{0};
+    double m_timelineDragStartOffset{0};
     HWND GetWindowHandle() const;
 
 private:
@@ -38,6 +49,7 @@ private:
     void UpdateTimelineCursorFromPlayback();
     void SyncTimelineHorizontalScrollBar();
     void RenderTimelineTicks();
+    void SeekTimelineToCanvasX(double pointerX);
     static winrt::Windows::Foundation::TimeSpan SecondsToTimeSpan(double seconds);
     static bool IsRectVisibleOnAnyMonitor(RECT const& rect);
 };

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -11,6 +11,8 @@ struct MainWindow: MainWindowT<MainWindow>{
     void PauseButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     void StopButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     void TimelineZoomSlider_ValueChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& args);
+    void TimelineHorizontalScrollBar_ValueChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& args);
+    void TimelineScrollViewer_ViewChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::ScrollViewerViewChangedEventArgs const& args);
     void TimelineCanvas_PointerPressed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void Window_DragOver(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction Window_Drop(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
@@ -34,6 +36,8 @@ private:
     winrt::Windows::Foundation::IAsyncAction LoadVideoFileAsync(winrt::Windows::Storage::StorageFile const& file);
     winrt::fire_and_forget RenderTimelineAsync();
     void UpdateTimelineCursorFromPlayback();
+    void SyncTimelineHorizontalScrollBar();
+    void RenderTimelineTicks();
     static winrt::Windows::Foundation::TimeSpan SecondsToTimeSpan(double seconds);
     static bool IsRectVisibleOnAnyMonitor(RECT const& rect);
 };

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -50,6 +50,7 @@ private:
     void SyncTimelineHorizontalScrollBar();
     void RenderTimelineTicks();
     void SeekTimelineToCanvasX(double pointerX);
+    void EnsureTimelineCursorVisible(double cursorLeft);
     static winrt::Windows::Foundation::TimeSpan SecondsToTimeSpan(double seconds);
     static bool IsRectVisibleOnAnyMonitor(RECT const& rect);
 };

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -15,6 +15,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     void TimelineZoomSlider_ValueChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& args);
     void TimelineHorizontalScrollBar_ValueChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& args);
     void TimelineScrollViewer_ViewChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::ScrollViewerViewChangedEventArgs const& args);
+    void TimelineScrollViewer_SizeChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::SizeChangedEventArgs const& args);
     void TimelineCanvas_PointerPressed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerMoved(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerReleased(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);


### PR DESCRIPTION
### Motivation
- Improve timeline navigation for long videos by adding visible time cues and a dedicated horizontal scrollbar. 
- Keep the playback position cursor in view while the video plays so users can follow the current position without manual scrolling.

### Description
- Updated the UI in `Win/llvc/MainWindow.xaml` to add a `TimelineTickCanvas` above the thumbnail `TimelineCanvas` and a dedicated `TimelineHorizontalScrollBar` below the storyline area, and wired `ViewChanged`/`ValueChanged` events for scroll sync. 
- Added handlers and helpers in `Win/llvc/MainWindow.xaml.h/.cpp`: `TimelineHorizontalScrollBar_ValueChanged`, `TimelineScrollViewer_ViewChanged`, `SyncTimelineHorizontalScrollBar`, and `RenderTimelineTicks`, and hooked `RenderTimelineTicks`/`SyncTimelineHorizontalScrollBar` into timeline render/reset paths. 
- Updated `UpdateTimelineCursorFromPlayback` to auto-scroll the `TimelineScrollViewer` while playback is `Playing`, keeping the cursor inside a padded visible region; kept scrollbar in sync after adjustments. 
- Added small include and utility fixes (`Microsoft.UI.Xaml.Shapes`, `Windows.UI`, and `std::to_wstring` usage) required for tick rendering.

### Testing
- Ran `git diff --check` with no issues reported. 
- Attempted to run `msbuild Win/llvc/llvc.vcxproj /t:Build /p:Configuration=Debug` but the build tool is not available in this environment (`msbuild: command not found`). 
- Verified modified source files for consistent wiring of event handlers and helper calls by inspecting diffs and file content; no compile-time checks were available in this container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f304bc988333babe26ebabf630eb)