### PR TITLE
Add menu actions and strict Media Foundation media validation

### DIFF
--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="llvc - Lossless Video Cut">
 
-    <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop" KeyDown="Window_KeyDown">
+    <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop" PreviewKeyDown="Window_PreviewKeyDown" KeyDown="Window_KeyDown" PointerReleased="RootGrid_PointerReleased" TabFocusNavigation="None">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -18,7 +18,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <controls:MenuBar x:Name="MainMenuBar" Grid.Row="0" IsTabStop="True">
+        <controls:MenuBar x:Name="MainMenuBar" Grid.Row="0" IsTabStop="False">
             <controls:MenuBarItem Title="_File">
                 <MenuFlyoutItem Text="_New project	Ctrl+N" Click="NewProjectMenuItem_Click"/>
                 <MenuFlyoutItem Text="_Open project..." Click="OpenProjectMenuItem_Click"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="llvc - Lossless Video Cut">
 
-    <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop" KeyDown="Window_KeyDown" IsTabStop="True">
+    <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -18,7 +18,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <controls:MenuBar Grid.Row="0">
+        <controls:MenuBar Grid.Row="0" IsTabStop="False">
             <controls:MenuBarItem Title="_File">
                 <MenuFlyoutItem Text="_New project	Ctrl+N" Click="NewProjectMenuItem_Click"/>
                 <MenuFlyoutItem Text="_Open project..." Click="OpenProjectMenuItem_Click"/>
@@ -66,14 +66,14 @@
 
                 <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
                     <TextBlock Text="Zoom" VerticalAlignment="Center" Margin="-4,0,0,0"/>
-                    <Slider x:Name="TimelineZoomSlider" Width="240" Minimum="1" Maximum="12" Value="3" SmallChange="0.25" LargeChange="1" ValueChanged="TimelineZoomSlider_ValueChanged"/>
+                    <Slider x:Name="TimelineZoomSlider" Width="240" IsTabStop="False" Minimum="1" Maximum="12" Value="3" SmallChange="0.25" LargeChange="1" ValueChanged="TimelineZoomSlider_ValueChanged"/>
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" VerticalAlignment="Center">
                     <TextBlock Text="Key frame snap" VerticalAlignment="Center"/>
-                    <RadioButton x:Name="LeftSnapRadio" Content="Left" GroupName="KeyFrameSnapMode" Tag="Left" Checked="KeyFrameSnapMode_Checked"/>
-                    <RadioButton x:Name="RightSnapRadio" Content="Right" GroupName="KeyFrameSnapMode" Tag="Right" Checked="KeyFrameSnapMode_Checked"/>
-                    <RadioButton x:Name="NearestSnapRadio" Content="Nearest" GroupName="KeyFrameSnapMode" Tag="Nearest" IsChecked="True" Checked="KeyFrameSnapMode_Checked"/>
+                    <RadioButton x:Name="LeftSnapRadio" IsTabStop="False" Content="Left" GroupName="KeyFrameSnapMode" Tag="Left" Checked="KeyFrameSnapMode_Checked"/>
+                    <RadioButton x:Name="RightSnapRadio" IsTabStop="False" Content="Right" GroupName="KeyFrameSnapMode" Tag="Right" Checked="KeyFrameSnapMode_Checked"/>
+                    <RadioButton x:Name="NearestSnapRadio" IsTabStop="False" Content="Nearest" GroupName="KeyFrameSnapMode" Tag="Nearest" IsChecked="True" Checked="KeyFrameSnapMode_Checked"/>
                 </StackPanel>
             </Grid>
 
@@ -87,7 +87,7 @@
                     <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Hidden" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled" ViewChanged="TimelineScrollViewer_ViewChanged" SizeChanged="TimelineScrollViewer_SizeChanged">
                         <StackPanel Orientation="Vertical" Spacing="4">
                             <Canvas x:Name="TimelineTickCanvas" Height="24" Background="#111111"/>
-                            <Canvas x:Name="TimelineCanvas" Height="86" PointerPressed="TimelineCanvas_PointerPressed" PointerMoved="TimelineCanvas_PointerMoved" PointerReleased="TimelineCanvas_PointerReleased" PointerCanceled="TimelineCanvas_PointerCanceled" PointerCaptureLost="TimelineCanvas_PointerCaptureLost" Background="#111111">
+                            <Canvas x:Name="TimelineCanvas" Height="86" IsTabStop="True" Loaded="TimelineCanvas_Loaded" KeyDown="Window_KeyDown" PointerPressed="TimelineCanvas_PointerPressed" PointerMoved="TimelineCanvas_PointerMoved" PointerReleased="TimelineCanvas_PointerReleased" PointerCanceled="TimelineCanvas_PointerCanceled" PointerCaptureLost="TimelineCanvas_PointerCaptureLost" Background="#111111">
                                 <Canvas x:Name="ThumbnailLayer" Height="86"/>
                                 <Rectangle x:Name="TimelineCursor" Canvas.Left="0" Width="2" Height="86" Fill="White"/>
                             </Canvas>
@@ -95,7 +95,7 @@
                     </ScrollViewer>
 
                     <Border Grid.Row="1" Margin="0,4,0,0" Padding="0" MinHeight="28" Background="#202020" BorderBrush="#6A6A6A" BorderThickness="1" CornerRadius="2">
-                        <Slider x:Name="TimelineHorizontalScrollBar" Minimum="0" Height="20" MinWidth="120" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="6,2" Visibility="Visible" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
+                        <Slider x:Name="TimelineHorizontalScrollBar" Minimum="0" IsTabStop="False" Height="20" MinWidth="120" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="6,2" Visibility="Visible" ValueChanged="TimelineHorizontalScrollBar_ValueChanged"/>
                     </Border>
                 </Grid>
             </Border>
@@ -104,9 +104,9 @@
         <TextBlock Grid.Row="3" x:Name="StatusText" Text="Load or drag-and-drop a .mp4/.mov file to preview."/>
 
         <StackPanel Grid.Row="4" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-            <Button x:Name="StartButton" Content="Start" Click="StartButton_Click"/>
-            <Button x:Name="PauseButton" Content="Pause" Click="PauseButton_Click"/>
-            <Button x:Name="StopButton" Content="Stop" Click="StopButton_Click"/>
+            <Button x:Name="StartButton" Content="Start" IsTabStop="False" Click="StartButton_Click"/>
+            <Button x:Name="PauseButton" Content="Pause" IsTabStop="False" Click="PauseButton_Click"/>
+            <Button x:Name="StopButton" Content="Stop" IsTabStop="False" Click="StopButton_Click"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="llvc - Lossless Video Cut">
 
-    <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop" PreviewKeyDown="Window_PreviewKeyDown" KeyDown="Window_KeyDown" PointerReleased="RootGrid_PointerReleased" TabFocusNavigation="None">
+    <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop" PreviewKeyDown="Window_PreviewKeyDown" KeyDown="Window_KeyDown" PointerReleased="RootGrid_PointerReleased">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -24,9 +24,7 @@
                 <MenuFlyoutItem Text="Load _video..." Click="LoadVideoMenuItem_Click"/>
                 <MenuFlyoutItem Text="_Close project" IsEnabled="False"/>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutSubItem Text="_Recent projects">
-                    <MenuFlyoutItem Text="(not implemented)" IsEnabled="False"/>
-                </MenuFlyoutSubItem>
+                <MenuFlyoutSubItem x:Name="RecentProjectsMenu" Text="_Recent projects"/>
                 <MenuFlyoutSubItem x:Name="RecentVideosMenu" Text="Recent videos"/>
                 <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="_Properties" Click="PropertiesMenuItem_Click"/>
@@ -40,7 +38,7 @@
             </controls:MenuBarItem>
 
             <controls:MenuBarItem Title="_Tools">
-                <MenuFlyoutItem Text="_Options" IsEnabled="False"/>
+                <MenuFlyoutItem Text="_Options" Click="OptionsMenuItem_Click"/>
             </controls:MenuBarItem>
 
             <controls:MenuBarItem Title="_Help">

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -86,7 +86,7 @@
 
                     <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Hidden" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled" ViewChanged="TimelineScrollViewer_ViewChanged" SizeChanged="TimelineScrollViewer_SizeChanged">
                         <StackPanel Orientation="Vertical" Spacing="4">
-                            <Canvas x:Name="TimelineTickCanvas" Height="24" Background="#111111"/>
+                            <Canvas x:Name="TimelineTickCanvas" Height="24" Background="#111111" PointerReleased="TimelineTickCanvas_PointerReleased"/>
                             <Canvas x:Name="TimelineCanvas" Height="86" IsTabStop="True" Loaded="TimelineCanvas_Loaded" PointerPressed="TimelineCanvas_PointerPressed" PointerMoved="TimelineCanvas_PointerMoved" PointerReleased="TimelineCanvas_PointerReleased" PointerCanceled="TimelineCanvas_PointerCanceled" PointerCaptureLost="TimelineCanvas_PointerCaptureLost" Background="#111111">
                                 <Canvas x:Name="ThumbnailLayer" Height="86"/>
                                 <Rectangle x:Name="TimelineCursor" Canvas.Left="0" Width="2" Height="86" Fill="White"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -18,7 +18,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <controls:MenuBar Grid.Row="0" IsTabStop="False">
+        <controls:MenuBar x:Name="MainMenuBar" Grid.Row="0" IsTabStop="True">
             <controls:MenuBarItem Title="_File">
                 <MenuFlyoutItem Text="_New project	Ctrl+N" Click="NewProjectMenuItem_Click"/>
                 <MenuFlyoutItem Text="_Open project..." Click="OpenProjectMenuItem_Click"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="llvc - Lossless Video Cut">
+    Title="llvc - Lossless Video Cut" KeyDown="Window_KeyDown">
 
     <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop">
         <Grid.RowDefinitions>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -7,9 +7,9 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="llvc - Lossless Video Cut" KeyDown="Window_KeyDown">
+    Title="llvc - Lossless Video Cut">
 
-    <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop">
+    <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop" KeyDown="Window_KeyDown" IsTabStop="True">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -56,11 +56,24 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                <TextBlock Text="Story Line" FontWeight="SemiBold"/>
-                <TextBlock Text="Zoom" VerticalAlignment="Center"/>
-                <Slider x:Name="TimelineZoomSlider" Width="240" Minimum="1" Maximum="12" Value="3" SmallChange="0.25" LargeChange="1" ValueChanged="TimelineZoomSlider_ValueChanged"/>
-            </StackPanel>
+            <Grid ColumnSpacing="10" VerticalAlignment="Center">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                    <TextBlock Text="Zoom" VerticalAlignment="Center" Margin="-4,0,0,0"/>
+                    <Slider x:Name="TimelineZoomSlider" Width="240" Minimum="1" Maximum="12" Value="3" SmallChange="0.25" LargeChange="1" ValueChanged="TimelineZoomSlider_ValueChanged"/>
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <TextBlock Text="Key frame snap" VerticalAlignment="Center"/>
+                    <RadioButton Content="Left" GroupName="KeyFrameSnapMode" Tag="Left" Checked="KeyFrameSnapMode_Checked"/>
+                    <RadioButton Content="Right" GroupName="KeyFrameSnapMode" Tag="Right" Checked="KeyFrameSnapMode_Checked"/>
+                    <RadioButton Content="Nearest" GroupName="KeyFrameSnapMode" Tag="Nearest" IsChecked="True" Checked="KeyFrameSnapMode_Checked"/>
+                </StackPanel>
+            </Grid>
 
             <Border Grid.Row="1" BorderThickness="1" BorderBrush="#404040" Background="#111111" CornerRadius="4" Padding="6">
                 <Grid RowSpacing="4">

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -20,9 +20,11 @@
 
         <controls:MenuBar Grid.Row="0">
             <controls:MenuBarItem Title="_File">
-                <MenuFlyoutItem Text="_Open project..." IsEnabled="False"/>
+                <MenuFlyoutItem Text="_New project	Ctrl+N" Click="NewProjectMenuItem_Click"/>
+                <MenuFlyoutItem Text="_Open project..." Click="OpenProjectMenuItem_Click"/>
+                <MenuFlyoutItem Text="_Save project	Ctrl+S" Click="SaveProjectMenuItem_Click"/>
                 <MenuFlyoutItem Text="Load _video..." Click="LoadVideoMenuItem_Click"/>
-                <MenuFlyoutItem Text="_Close project" IsEnabled="False"/>
+                <MenuFlyoutItem Text="_Close project" Click="CloseProjectMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
                 <MenuFlyoutSubItem x:Name="RecentProjectsMenu" Text="_Recent projects"/>
                 <MenuFlyoutSubItem x:Name="RecentVideosMenu" Text="Recent videos"/>
@@ -69,9 +71,9 @@
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" VerticalAlignment="Center">
                     <TextBlock Text="Key frame snap" VerticalAlignment="Center"/>
-                    <RadioButton Content="Left" GroupName="KeyFrameSnapMode" Tag="Left" Checked="KeyFrameSnapMode_Checked"/>
-                    <RadioButton Content="Right" GroupName="KeyFrameSnapMode" Tag="Right" Checked="KeyFrameSnapMode_Checked"/>
-                    <RadioButton Content="Nearest" GroupName="KeyFrameSnapMode" Tag="Nearest" IsChecked="True" Checked="KeyFrameSnapMode_Checked"/>
+                    <RadioButton x:Name="LeftSnapRadio" Content="Left" GroupName="KeyFrameSnapMode" Tag="Left" Checked="KeyFrameSnapMode_Checked"/>
+                    <RadioButton x:Name="RightSnapRadio" Content="Right" GroupName="KeyFrameSnapMode" Tag="Right" Checked="KeyFrameSnapMode_Checked"/>
+                    <RadioButton x:Name="NearestSnapRadio" Content="Nearest" GroupName="KeyFrameSnapMode" Tag="Nearest" IsChecked="True" Checked="KeyFrameSnapMode_Checked"/>
                 </StackPanel>
             </Grid>
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d"
     Title="llvc - Lossless Video Cut">
 
-    <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop">
+    <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop" KeyDown="Window_KeyDown">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -87,7 +87,7 @@
                     <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Hidden" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled" ViewChanged="TimelineScrollViewer_ViewChanged" SizeChanged="TimelineScrollViewer_SizeChanged">
                         <StackPanel Orientation="Vertical" Spacing="4">
                             <Canvas x:Name="TimelineTickCanvas" Height="24" Background="#111111"/>
-                            <Canvas x:Name="TimelineCanvas" Height="86" IsTabStop="True" Loaded="TimelineCanvas_Loaded" KeyDown="Window_KeyDown" PointerPressed="TimelineCanvas_PointerPressed" PointerMoved="TimelineCanvas_PointerMoved" PointerReleased="TimelineCanvas_PointerReleased" PointerCanceled="TimelineCanvas_PointerCanceled" PointerCaptureLost="TimelineCanvas_PointerCaptureLost" Background="#111111">
+                            <Canvas x:Name="TimelineCanvas" Height="86" IsTabStop="True" Loaded="TimelineCanvas_Loaded" PointerPressed="TimelineCanvas_PointerPressed" PointerMoved="TimelineCanvas_PointerMoved" PointerReleased="TimelineCanvas_PointerReleased" PointerCanceled="TimelineCanvas_PointerCanceled" PointerCaptureLost="TimelineCanvas_PointerCaptureLost" Background="#111111">
                                 <Canvas x:Name="ThumbnailLayer" Height="86"/>
                                 <Rectangle x:Name="TimelineCursor" Canvas.Left="0" Width="2" Height="86" Fill="White"/>
                             </Canvas>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -11,17 +11,48 @@
 
     <Grid Padding="12" RowSpacing="10" AllowDrop="True" DragOver="Window_DragOver" Drop="Window_Drop">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="8">
+        <controls:MenuBar Grid.Row="0">
+            <controls:MenuBarItem Title="_File">
+                <MenuFlyoutItem Text="_Open project..." IsEnabled="False"/>
+                <MenuFlyoutItem Text="Load _video..." Click="LoadVideoMenuItem_Click"/>
+                <MenuFlyoutItem Text="_Close project" IsEnabled="False"/>
+                <MenuFlyoutSeparator/>
+                <MenuFlyoutSubItem Text="_Recent projects">
+                    <MenuFlyoutItem Text="(not implemented)" IsEnabled="False"/>
+                </MenuFlyoutSubItem>
+                <MenuFlyoutSubItem x:Name="RecentVideosMenu" Text="Recent videos"/>
+                <MenuFlyoutSeparator/>
+                <MenuFlyoutItem Text="_Properties" Click="PropertiesMenuItem_Click"/>
+                <MenuFlyoutSeparator/>
+                <MenuFlyoutItem Text="E_xit" Click="ExitMenuItem_Click"/>
+            </controls:MenuBarItem>
+
+            <controls:MenuBarItem Title="_Edit">
+                <MenuFlyoutItem Text="_Undo Ctrl+Z" IsEnabled="False"/>
+                <MenuFlyoutItem Text="Redo Ctrl+Y" IsEnabled="False"/>
+            </controls:MenuBarItem>
+
+            <controls:MenuBarItem Title="_Tools">
+                <MenuFlyoutItem Text="_Options" IsEnabled="False"/>
+            </controls:MenuBarItem>
+
+            <controls:MenuBarItem Title="_Help">
+                <MenuFlyoutItem Text="_About" Click="AboutMenuItem_Click"/>
+            </controls:MenuBarItem>
+        </controls:MenuBar>
+
+        <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="8">
             <controls:MediaPlayerElement x:Name="PreviewPlayer" AreTransportControlsEnabled="False"/>
         </Border>
 
-        <Grid Grid.Row="1" RowSpacing="6">
+        <Grid Grid.Row="2" RowSpacing="6">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -57,9 +88,9 @@
             </Border>
         </Grid>
 
-        <TextBlock Grid.Row="2" x:Name="StatusText" Text="Drag and drop an .avi or .mov file to preview."/>
+        <TextBlock Grid.Row="3" x:Name="StatusText" Text="Load or drag-and-drop a .mp4/.mov file to preview."/>
 
-        <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+        <StackPanel Grid.Row="4" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
             <Button x:Name="StartButton" Content="Start" Click="StartButton_Click"/>
             <Button x:Name="PauseButton" Content="Pause" Click="PauseButton_Click"/>
             <Button x:Name="StopButton" Content="Stop" Click="StopButton_Click"/>

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -122,11 +122,21 @@ std::vector<hstring> SplitRecentItems(std::wstring const& source){
     return items;
 }
 
-bool IsDescendantOf(DependencyObject const& object, std::wstring_view const& typeName){
+bool IsInMenuSubtree(DependencyObject const& object){
     DependencyObject current{object};
     while(current){
-        const auto fullName{current.as<IInspectable>().GetRuntimeClassName()};
-        if(std::wstring_view(fullName.c_str()).find(typeName) != std::wstring_view::npos){
+        if(current.try_as<Controls::MenuBar>() || current.try_as<Controls::MenuFlyoutItem>() || current.try_as<Controls::MenuFlyoutSubItem>() || current.try_as<Controls::MenuFlyoutPresenter>()){
+            return true;
+        }
+        current = Media::VisualTreeHelper::GetParent(current);
+    }
+    return false;
+}
+
+bool IsInDialogSubtree(DependencyObject const& object){
+    DependencyObject current{object};
+    while(current){
+        if(current.try_as<Controls::ContentDialog>() || current.try_as<Controls::Primitives::Popup>()){
             return true;
         }
         current = Media::VisualTreeHelper::GetParent(current);
@@ -907,9 +917,9 @@ void MainWindow::StepByKeyframe(const int delta){
 }
 
 void MainWindow::Window_KeyDown(IInspectable const&, Input::KeyRoutedEventArgs const& args){
-    const auto focused{FocusManager::GetFocusedElement(Content().XamlRoot()).try_as<DependencyObject>()};
-    const bool focusOnMenu = focused && IsDescendantOf(focused, L"MenuBar");
-    const bool focusInDialog = focused && IsDescendantOf(focused, L"ContentDialog");
+    const auto focused{Input::FocusManager::GetFocusedElement(Content().XamlRoot()).try_as<DependencyObject>()};
+    const bool focusOnMenu = focused && IsInMenuSubtree(focused);
+    const bool focusInDialog = focused && IsInDialogSubtree(focused);
 
     if(args.Key() == Windows::System::VirtualKey::Menu){
         MainMenuBar().Focus(Microsoft::UI::Xaml::FocusState::Keyboard);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -555,6 +555,7 @@ void MainWindow::TimelineCanvas_PointerPressed(IInspectable const&, Input::Point
     m_timelineDragStartX = static_cast<double>(point.Position().X);
     m_timelineDragStartOffset = TimelineScrollViewer().HorizontalOffset();
 
+    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
     TimelineCanvas().CapturePointer(e.Pointer());
     e.Handled(true);
 }
@@ -611,6 +612,10 @@ void MainWindow::TimelineCanvas_PointerCanceled(IInspectable const&, Input::Poin
 void MainWindow::TimelineCanvas_PointerCaptureLost(IInspectable const&, Input::PointerRoutedEventArgs const&){
     m_isTimelineDragging = false;
     m_timelineDragMoved = false;
+}
+
+void MainWindow::TimelineCanvas_Loaded(IInspectable const&, RoutedEventArgs const&){
+    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
 }
 
 void MainWindow::OnNaturalDurationChanged(Windows::Media::Playback::MediaPlaybackSession const& sender, IInspectable const&){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -605,6 +605,52 @@ void MainWindow::TimelineCanvas_PointerMoved(IInspectable const&, Input::Pointer
     e.Handled(true);
 }
 
+bool MainWindow::ToggleSelectedKeyframeAtCanvasX(const double pointerX){
+    if(m_frameIndex.empty() || m_timelineDurationSeconds <= 0 || TimelineTickCanvas().Width() <= 0){
+        return false;
+    }
+
+    constexpr double hitTolerancePx{4.0};
+    const auto width{TimelineTickCanvas().Width()};
+    const auto total100ns{m_timelineDurationSeconds * 10'000'000.0};
+
+    std::int64_t nearestKeyTime{-1};
+    double nearestDistance{hitTolerancePx + 1.0};
+    for(auto const& frame : m_frameIndex){
+        if(!frame.cleanPoint){
+            continue;
+        }
+
+        const auto x{std::clamp((static_cast<double>(frame.time100ns) / total100ns) * width, 0.0, width)};
+        const auto distance{std::fabs(pointerX - x)};
+        if(distance <= hitTolerancePx && distance < nearestDistance){
+            nearestDistance = distance;
+            nearestKeyTime = frame.time100ns;
+        }
+    }
+
+    if(nearestKeyTime < 0){
+        return false;
+    }
+
+    const auto keySeconds{static_cast<double>(nearestKeyTime) / 10'000'000.0};
+    constexpr double duplicateToleranceSeconds{0.000001};
+    const auto it = std::find_if(m_selectedKeyFrames.begin(), m_selectedKeyFrames.end(), [keySeconds](double t){
+        return std::fabs(t - keySeconds) <= duplicateToleranceSeconds;
+    });
+
+    if(it == m_selectedKeyFrames.end()){
+        m_selectedKeyFrames.push_back(keySeconds);
+    }else{
+        m_selectedKeyFrames.erase(it);
+    }
+
+    std::sort(m_selectedKeyFrames.begin(), m_selectedKeyFrames.end());
+    RenderTimelineTicks();
+    RenderKeyframeTicks();
+    return true;
+}
+
 void MainWindow::TimelineCanvas_PointerReleased(IInspectable const&, Input::PointerRoutedEventArgs const& e){
     if(!m_isTimelineDragging || e.Pointer().PointerId() != m_timelineDragPointerId){
         return;
@@ -618,7 +664,9 @@ void MainWindow::TimelineCanvas_PointerReleased(IInspectable const&, Input::Poin
     TimelineCanvas().ReleasePointerCapture(e.Pointer());
 
     if(!dragged){
-        SeekTimelineToCanvasX(point.Position().X, (e.KeyModifiers() & Windows::System::VirtualKeyModifiers::Shift) == Windows::System::VirtualKeyModifiers::Shift);
+        if(!ToggleSelectedKeyframeAtCanvasX(point.Position().X)){
+            SeekTimelineToCanvasX(point.Position().X, (e.KeyModifiers() & Windows::System::VirtualKeyModifiers::Shift) == Windows::System::VirtualKeyModifiers::Shift);
+        }
     }
 
     e.Handled(true);
@@ -641,6 +689,15 @@ void MainWindow::TimelineCanvas_PointerCaptureLost(IInspectable const&, Input::P
 void MainWindow::TimelineCanvas_Loaded(IInspectable const&, RoutedEventArgs const&){
     TryFocusTimelineCanvas(Microsoft::UI::Xaml::FocusState::Programmatic);
 }
+
+void MainWindow::TimelineTickCanvas_PointerReleased(IInspectable const&, Input::PointerRoutedEventArgs const& e){
+    const auto point{e.GetCurrentPoint(TimelineTickCanvas())};
+    if(ToggleSelectedKeyframeAtCanvasX(point.Position().X)){
+        TryFocusTimelineCanvas(Microsoft::UI::Xaml::FocusState::Programmatic);
+        e.Handled(true);
+    }
+}
+
 
 void MainWindow::OnNaturalDurationChanged(Windows::Media::Playback::MediaPlaybackSession const& sender, IInspectable const&){
     const auto duration{sender.NaturalDuration()};
@@ -842,13 +899,21 @@ void MainWindow::RenderKeyframeTicks(){
         }
 
         const auto x = std::clamp((frame.time100ns / total100ns) * width, 0.0, width);
+        const auto keySeconds = static_cast<double>(frame.time100ns) / 10'000'000.0;
+        constexpr double selectedToleranceSeconds{0.000001};
+        const bool isSelected = std::any_of(m_selectedKeyFrames.begin(), m_selectedKeyFrames.end(), [keySeconds](double t){
+            return std::fabs(t - keySeconds) <= selectedToleranceSeconds;
+        });
+
         Shapes::Line tick{};
         tick.X1(x);
         tick.X2(x);
         tick.Y1(0);
-        tick.Y2(5);
-        tick.Stroke(Media::SolidColorBrush(Windows::UI::ColorHelper::FromArgb(255, 80, 200, 255)));
-        tick.StrokeThickness(1.0);
+        tick.Y2(isSelected ? 8.0 : 5.0);
+        tick.Stroke(Media::SolidColorBrush(isSelected
+            ? Windows::UI::ColorHelper::FromArgb(255, 255, 80, 80)
+            : Windows::UI::ColorHelper::FromArgb(255, 80, 200, 255)));
+        tick.StrokeThickness(isSelected ? 2.0 : 1.0);
         TimelineTickCanvas().Children().Append(tick);
     }
 }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -26,6 +26,7 @@
 #include <winrt/Microsoft.UI.Xaml.Media.Imaging.h>
 #include <winrt/Microsoft.UI.Xaml.Shapes.h>
 #include <winrt/Windows.UI.h>
+#include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 #include <winrt/Windows.Media.Core.h>
 #include <winrt/Windows.Media.Editing.h>
@@ -119,6 +120,18 @@ std::vector<hstring> SplitRecentItems(std::wstring const& source){
         start = pos + 1;
     }
     return items;
+}
+
+bool IsDescendantOf(DependencyObject const& object, std::wstring_view const& typeName){
+    DependencyObject current{object};
+    while(current){
+        const auto fullName{current.as<IInspectable>().GetRuntimeClassName()};
+        if(std::wstring_view(fullName.c_str()).find(typeName) != std::wstring_view::npos){
+            return true;
+        }
+        current = Media::VisualTreeHelper::GetParent(current);
+    }
+    return false;
 }
 
 std::wstring Trim(std::wstring value){
@@ -894,15 +907,48 @@ void MainWindow::StepByKeyframe(const int delta){
 }
 
 void MainWindow::Window_KeyDown(IInspectable const&, Input::KeyRoutedEventArgs const& args){
-    switch(args.Key()){
-    case Windows::System::VirtualKey::Tab:
-        TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
-        args.Handled(true);
-        break;
-    case Windows::System::VirtualKey::Menu:
+    const auto focused{FocusManager::GetFocusedElement(Content().XamlRoot()).try_as<DependencyObject>()};
+    const bool focusOnMenu = focused && IsDescendantOf(focused, L"MenuBar");
+    const bool focusInDialog = focused && IsDescendantOf(focused, L"ContentDialog");
+
+    if(args.Key() == Windows::System::VirtualKey::Menu){
         MainMenuBar().Focus(Microsoft::UI::Xaml::FocusState::Keyboard);
         args.Handled(true);
-        break;
+        return;
+    }
+
+    if(args.Key() == Windows::System::VirtualKey::Tab && !focusOnMenu && !focusInDialog){
+        TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
+        args.Handled(true);
+        return;
+    }
+
+    if(focusOnMenu || focusInDialog){
+        return;
+    }
+
+    const auto ctrlState{Microsoft::UI::Input::InputKeyboardSource::GetKeyStateForCurrentThread(Windows::System::VirtualKey::Control)};
+    const bool ctrlDown{(ctrlState & Windows::UI::Core::CoreVirtualKeyStates::Down) == Windows::UI::Core::CoreVirtualKeyStates::Down};
+
+    if(ctrlDown){
+        if(args.Key() == Windows::System::VirtualKey::O){
+            (void)OpenProjectMenuItem_Click(nullptr, RoutedEventArgs{});
+            args.Handled(true);
+            return;
+        }
+        if(args.Key() == Windows::System::VirtualKey::S){
+            (void)SaveProjectMenuItem_Click(nullptr, RoutedEventArgs{});
+            args.Handled(true);
+            return;
+        }
+        if(args.Key() == Windows::System::VirtualKey::N){
+            (void)NewProjectMenuItem_Click(nullptr, RoutedEventArgs{});
+            args.Handled(true);
+            return;
+        }
+    }
+
+    switch(args.Key()){
     case Windows::System::VirtualKey::Left:
         StepByFrame(-1);
         args.Handled(true);
@@ -923,7 +969,6 @@ void MainWindow::Window_KeyDown(IInspectable const&, Input::KeyRoutedEventArgs c
         break;
     }
 }
-
 
 Windows::Foundation::TimeSpan MainWindow::SecondsToTimeSpan(const double seconds){
     return std::chrono::duration_cast<Windows::Foundation::TimeSpan>(std::chrono::duration<double>(seconds));

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -504,11 +504,16 @@ Windows::Foundation::IAsyncAction MainWindow::RecentVideoMenuItem_Click(IInspect
         co_return;
     }
 
+    bool openFailed{false};
     const auto path{unbox_value<hstring>(item.Tag())};
     try{
         const auto file{co_await Windows::Storage::StorageFile::GetFileFromPathAsync(path)};
         co_await LoadVideoFileAsync(file);
     }catch(winrt::hresult_error const&){
+        openFailed = true;
+    }
+
+    if(openFailed){
         co_await ShowInfoDialogAsync(L"Open failed", L"Could not open selected recent video.");
     }
 }
@@ -718,7 +723,7 @@ MediaInspectionResult MainWindow::InspectMediaFile(std::wstring const& filePath)
 
     PROPVARIANT duration{};
     PropVariantInit(&duration);
-    if(SUCCEEDED(reader->GetPresentationAttribute(MF_SOURCE_READER_MEDIASOURCE, MF_PD_DURATION, &duration)) && duration.vt == VT_UI8){
+    if(SUCCEEDED(reader->GetPresentationAttribute(static_cast<DWORD>(MF_SOURCE_READER_MEDIASOURCE), MF_PD_DURATION, &duration)) && duration.vt == VT_UI8){
         const auto seconds = static_cast<double>(duration.uhVal.QuadPart) / 10'000'000.0;
         std::wstringstream ss;
         ss << std::fixed << std::setprecision(3) << seconds << L" s";

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1390,8 +1390,15 @@ Windows::Foundation::IAsyncAction MainWindow::OpenProjectFileAsync(Windows::Stor
     for(auto const& lineH : lines){
         const std::wstring line{lineH.c_str()};
         const auto trimmed{Trim(line)};
-        if(trimmed.empty() || trimmed[0] == L'#'){
+        if(trimmed.empty()){
             unknownLines.push_back(line);
+            continue;
+        }
+
+        if(trimmed[0] == L'#'){
+            if(trimmed != L"# llvc project file"){
+                unknownLines.push_back(line);
+            }
             continue;
         }
 
@@ -1469,6 +1476,9 @@ Windows::Foundation::IAsyncAction MainWindow::SaveProjectFileAsync(Windows::Stor
     lines.emplace_back(L"keyframe_index=" + SerializeKeyframeVector(m_frameIndex));
 
     for(auto const& unknown : m_projectUnknownLines){
+        if(Trim(unknown) == L"# llvc project file"){
+            continue;
+        }
         lines.emplace_back(unknown);
     }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -593,7 +593,7 @@ void MainWindow::TimelineCanvas_PointerReleased(IInspectable const&, Input::Poin
     TimelineCanvas().ReleasePointerCapture(e.Pointer());
 
     if(!dragged){
-        SeekTimelineToCanvasX(point.Position().X, e.KeyModifiers().HasFlag(Windows::System::VirtualKeyModifiers::Shift));
+        SeekTimelineToCanvasX(point.Position().X, (e.KeyModifiers() & Windows::System::VirtualKeyModifiers::Shift) == Windows::System::VirtualKeyModifiers::Shift);
     }
 
     e.Handled(true);
@@ -1544,7 +1544,7 @@ std::vector<IndexedFrameSample> MainWindow::BuildKeyframeIndexForFile(std::wstri
         return index;
     }
 
-    check_hresult(reader->SetStreamSelection(MF_SOURCE_READER_ALL_STREAMS, FALSE));
+    check_hresult(reader->SetStreamSelection(static_cast<DWORD>(MF_SOURCE_READER_ALL_STREAMS), FALSE));
     check_hresult(reader->SetStreamSelection(videoStreamIndex, TRUE));
 
     for(std::uint32_t sampleIndex = 0;; ++sampleIndex){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -532,6 +532,7 @@ Windows::Foundation::IAsyncAction MainWindow::AboutMenuItem_Click(IInspectable c
 
 Windows::Foundation::IAsyncAction MainWindow::PickAndLoadVideoAsync(){
     Windows::Storage::Pickers::FileOpenPicker picker{};
+    picker.SuggestedStartLocation(Windows::Storage::Pickers::PickerLocationId::VideosLibrary);
     picker.FileTypeFilter().Append(L".mp4");
     picker.FileTypeFilter().Append(L".mov");
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -120,6 +120,70 @@ std::vector<hstring> SplitRecentItems(std::wstring const& source){
     return items;
 }
 
+std::wstring Trim(std::wstring value){
+    const auto first = value.find_first_not_of(L" \t\r\n");
+    if(first == std::wstring::npos){
+        return L"";
+    }
+    const auto last = value.find_last_not_of(L" \t\r\n");
+    return value.substr(first, last - first + 1);
+}
+
+std::vector<double> ParseNumberList(std::wstring const& text){
+    std::vector<double> values;
+    size_t start{};
+    while(start <= text.size()){
+        const auto pos = text.find(L',', start);
+        auto token = Trim(text.substr(start, pos == std::wstring::npos ? std::wstring::npos : pos - start));
+        if(!token.empty()){
+            try{ values.push_back(std::stod(token)); }catch(...){ }
+        }
+        if(pos == std::wstring::npos){ break; }
+        start = pos + 1;
+    }
+    return values;
+}
+
+std::vector<std::pair<double, double>> ParseNumberPairs(std::wstring const& text){
+    std::vector<std::pair<double, double>> pairs;
+    size_t start{};
+    while(start <= text.size()){
+        const auto sep = text.find(L';', start);
+        const auto chunk = Trim(text.substr(start, sep == std::wstring::npos ? std::wstring::npos : sep - start));
+        if(!chunk.empty()){
+            const auto comma = chunk.find(L',');
+            if(comma != std::wstring::npos){
+                try{
+                    const auto a = std::stod(Trim(chunk.substr(0, comma)));
+                    const auto b = std::stod(Trim(chunk.substr(comma + 1)));
+                    pairs.emplace_back(a, b);
+                }catch(...){ }
+            }
+        }
+        if(sep == std::wstring::npos){ break; }
+        start = sep + 1;
+    }
+    return pairs;
+}
+
+std::wstring SerializeNumberList(std::vector<double> const& values){
+    std::wstringstream ss;
+    for(size_t i = 0; i < values.size(); ++i){
+        if(i > 0){ ss << L","; }
+        ss << std::setprecision(15) << values[i];
+    }
+    return ss.str();
+}
+
+std::wstring SerializeNumberPairs(std::vector<std::pair<double, double>> const& values){
+    std::wstringstream ss;
+    for(size_t i = 0; i < values.size(); ++i){
+        if(i > 0){ ss << L";"; }
+        ss << std::setprecision(15) << values[i].first << L"," << values[i].second;
+    }
+    return ss.str();
+}
+
 bool HasDecoderForSubtype(GUID const& subtype){
     MFT_REGISTER_TYPE_INFO inType{};
     inType.guidMajorType = MFMediaType_Video;
@@ -669,6 +733,58 @@ void MainWindow::KeyFrameSnapMode_Checked(IInspectable const& sender, RoutedEven
     m_keyFrameSnapMode = unbox_value<hstring>(radio.Tag()).c_str();
 }
 
+void MainWindow::NewProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    ResetProjectState(false);
+    StatusText().Text(L"New project created");
+}
+
+Windows::Foundation::IAsyncAction MainWindow::OpenProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    Windows::Storage::Pickers::FileOpenPicker picker{};
+    picker.FileTypeFilter().Append(L".llvc");
+    picker.SuggestedStartLocation(Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
+
+    auto initWithWindow{picker.as<IInitializeWithWindow>()};
+    check_hresult(initWithWindow->Initialize(GetWindowHandle()));
+
+    if(const auto file{co_await picker.PickSingleFileAsync()}){
+        co_await OpenProjectFileAsync(file);
+    }
+}
+
+Windows::Foundation::IAsyncAction MainWindow::SaveProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    Windows::Storage::StorageFile target{nullptr};
+
+    if(!m_projectPath.empty()){
+        try{
+            target = co_await Windows::Storage::StorageFile::GetFileFromPathAsync(m_projectPath);
+        }catch(...){
+            target = nullptr;
+        }
+    }
+
+    if(!target){
+        Windows::Storage::Pickers::FileSavePicker picker{};
+        picker.SuggestedStartLocation(Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
+        picker.FileTypeChoices().Insert(L"llvc project", single_threaded_vector<hstring>({L".llvc"}));
+        picker.SuggestedFileName(L"project");
+
+        auto initWithWindow{picker.as<IInitializeWithWindow>()};
+        check_hresult(initWithWindow->Initialize(GetWindowHandle()));
+
+        target = co_await picker.PickSaveFileAsync();
+        if(!target){
+            co_return;
+        }
+    }
+
+    co_await SaveProjectFileAsync(target);
+}
+
+void MainWindow::CloseProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    ResetProjectState(true);
+    StatusText().Text(L"Project closed");
+}
+
 Windows::Foundation::IAsyncAction MainWindow::LoadVideoMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
     co_await PickAndLoadVideoAsync();
 }
@@ -690,6 +806,21 @@ Windows::Foundation::IAsyncAction MainWindow::RecentVideoMenuItem_Click(IInspect
 
     if(openFailed){
         co_await ShowInfoDialogAsync(L"Open failed", L"Could not open selected recent video.");
+    }
+}
+
+Windows::Foundation::IAsyncAction MainWindow::RecentProjectMenuItem_Click(IInspectable const& sender, RoutedEventArgs const&){
+    const auto item{sender.try_as<Controls::MenuFlyoutItem>()};
+    if(!item || !item.Tag()){
+        co_return;
+    }
+
+    const auto path{unbox_value<hstring>(item.Tag())};
+    try{
+        const auto file{co_await Windows::Storage::StorageFile::GetFileFromPathAsync(path)};
+        co_await OpenProjectFileAsync(file);
+    }catch(...){
+        co_await ShowInfoDialogAsync(L"Open failed", L"Could not open selected recent project.");
     }
 }
 
@@ -760,7 +891,8 @@ void MainWindow::RefreshRecentProjectsMenu(){
     for(auto const& path : m_recentProjects){
         Controls::MenuFlyoutItem item{};
         item.Text(path);
-        item.IsEnabled(false);
+        item.Tag(box_value(path));
+        item.Click({this, &MainWindow::RecentProjectMenuItem_Click});
         menu.Items().Append(item);
     }
 }
@@ -791,6 +923,114 @@ void MainWindow::AddRecentProject(hstring const& path){
     }
     RefreshRecentProjectsMenu();
     SaveAppSettings();
+}
+
+void MainWindow::ResetProjectState(const bool clearLoadedVideo){
+    m_projectPath.clear();
+    m_projectUnknownLines.clear();
+    m_selectedKeyFrames.clear();
+    m_cutIntervals.clear();
+    m_keyFrameSnapMode = L"Nearest";
+    NearestSnapRadio().IsChecked(true);
+
+    if(clearLoadedVideo){
+        m_loadedFile = nullptr;
+        m_player.Source(nullptr);
+    }
+}
+
+Windows::Foundation::IAsyncAction MainWindow::OpenProjectFileAsync(Windows::Storage::StorageFile const& file){
+    const auto lines{co_await Windows::Storage::FileIO::ReadLinesAsync(file)};
+
+    std::vector<std::wstring> unknownLines;
+    std::vector<double> selectedKeyFrames;
+    std::vector<std::pair<double, double>> cutIntervals;
+    std::wstring loadedFilePath;
+    std::wstring snapMode{L"Nearest"};
+    double zoomLevel{TimelineZoomSlider().Value()};
+
+    for(auto const& lineH : lines){
+        const std::wstring line{lineH.c_str()};
+        const auto trimmed{Trim(line)};
+        if(trimmed.empty() || trimmed[0] == L'#'){
+            unknownLines.push_back(line);
+            continue;
+        }
+
+        const auto eqPos{line.find(L'=')};
+        if(eqPos == std::wstring::npos){
+            unknownLines.push_back(line);
+            continue;
+        }
+
+        const auto key{Trim(line.substr(0, eqPos))};
+        const auto value{Trim(line.substr(eqPos + 1))};
+
+        if(key == L"file_path"){
+            loadedFilePath = value;
+        }else if(key == L"storyline_zoom"){
+            try{ zoomLevel = std::stod(value); }catch(...){ unknownLines.push_back(line); }
+        }else if(key == L"keyframe_snap_mode"){
+            if(value == L"Left" || value == L"Right" || value == L"Nearest"){
+                snapMode = value;
+            }else{
+                unknownLines.push_back(line);
+            }
+        }else if(key == L"selected_key_frames"){
+            selectedKeyFrames = ParseNumberList(value);
+        }else if(key == L"cut_intervals"){
+            cutIntervals = ParseNumberPairs(value);
+        }else{
+            unknownLines.push_back(line);
+        }
+    }
+
+    if(!loadedFilePath.empty()){
+        try{
+            const auto videoFile{co_await Windows::Storage::StorageFile::GetFileFromPathAsync(loadedFilePath)};
+            co_await LoadVideoFileAsync(videoFile);
+        }catch(...){
+            StatusText().Text(L"Project opened, but referenced video could not be loaded");
+        }
+    }
+
+    zoomLevel = std::clamp(zoomLevel, TimelineZoomSlider().Minimum(), TimelineZoomSlider().Maximum());
+    TimelineZoomSlider().Value(zoomLevel);
+    m_keyFrameSnapMode = snapMode;
+    m_selectedKeyFrames = std::move(selectedKeyFrames);
+    m_cutIntervals = std::move(cutIntervals);
+    m_projectUnknownLines = std::move(unknownLines);
+    m_projectPath = file.Path();
+
+    if(snapMode == L"Left"){
+        LeftSnapRadio().IsChecked(true);
+    }else if(snapMode == L"Right"){
+        RightSnapRadio().IsChecked(true);
+    }else{
+        NearestSnapRadio().IsChecked(true);
+    }
+
+    AddRecentProject(file.Path());
+    StatusText().Text(L"Project loaded");
+}
+
+Windows::Foundation::IAsyncAction MainWindow::SaveProjectFileAsync(Windows::Storage::StorageFile const& file){
+    std::vector<hstring> lines;
+    lines.emplace_back(L"# llvc project file");
+    lines.emplace_back(L"file_path=" + std::wstring(m_loadedFile ? m_loadedFile.Path().c_str() : L""));
+    lines.emplace_back(L"storyline_zoom=" + std::to_wstring(TimelineZoomSlider().Value()));
+    lines.emplace_back(L"keyframe_snap_mode=" + m_keyFrameSnapMode);
+    lines.emplace_back(L"selected_key_frames=" + SerializeNumberList(m_selectedKeyFrames));
+    lines.emplace_back(L"cut_intervals=" + SerializeNumberPairs(m_cutIntervals));
+
+    for(auto const& unknown : m_projectUnknownLines){
+        lines.emplace_back(unknown);
+    }
+
+    co_await Windows::Storage::FileIO::WriteLinesAsync(file, single_threaded_vector<hstring>(std::move(lines)));
+    m_projectPath = file.Path();
+    AddRecentProject(file.Path());
+    StatusText().Text(L"Project saved");
 }
 
 Windows::Foundation::IAsyncAction MainWindow::ShowInfoDialogAsync(hstring const& title, hstring const& message){
@@ -1093,7 +1333,6 @@ Windows::Foundation::IAsyncAction MainWindow::LoadVideoFileAsync(Windows::Storag
     m_player.Source(source);
     m_loadedFile = file;
     AddRecentVideo(file.Path());
-    AddRecentProject(file.Path());
 
     ThumbnailLayer().Children().Clear();
     TimelineCanvas().Width(640.0);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -539,7 +539,7 @@ void MainWindow::TimelineZoomSlider_ValueChanged(IInspectable const&, Controls::
     if(m_loadedFile && m_timelineDurationSeconds > 0){
         RenderTimelineAsync();
     }
-    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
+    TryFocusTimelineCanvas(Microsoft::UI::Xaml::FocusState::Programmatic);
 }
 
 void MainWindow::TimelineHorizontalScrollBar_ValueChanged(IInspectable const&, Controls::Primitives::RangeBaseValueChangedEventArgs const& args){
@@ -579,7 +579,7 @@ void MainWindow::TimelineCanvas_PointerPressed(IInspectable const&, Input::Point
     m_timelineDragStartX = static_cast<double>(point.Position().X);
     m_timelineDragStartOffset = TimelineScrollViewer().HorizontalOffset();
 
-    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
+    TryFocusTimelineCanvas(Microsoft::UI::Xaml::FocusState::Programmatic);
     TimelineCanvas().CapturePointer(e.Pointer());
     e.Handled(true);
 }
@@ -639,7 +639,7 @@ void MainWindow::TimelineCanvas_PointerCaptureLost(IInspectable const&, Input::P
 }
 
 void MainWindow::TimelineCanvas_Loaded(IInspectable const&, RoutedEventArgs const&){
-    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
+    TryFocusTimelineCanvas(Microsoft::UI::Xaml::FocusState::Programmatic);
 }
 
 void MainWindow::OnNaturalDurationChanged(Windows::Media::Playback::MediaPlaybackSession const& sender, IInspectable const&){
@@ -917,6 +917,13 @@ void MainWindow::StepByKeyframe(const int delta){
     UpdateTimelineCursorFromPlayback();
 }
 
+void MainWindow::TryFocusTimelineCanvas(Microsoft::UI::Xaml::FocusState const focusState){
+    const auto canvas{TimelineCanvas()};
+    if(canvas && canvas.XamlRoot()){
+        canvas.Focus(focusState);
+    }
+}
+
 bool MainWindow::HandleStorylineKeyDown(Input::KeyRoutedEventArgs const& args){
     const auto focused{Input::FocusManager::GetFocusedElement(Content().XamlRoot()).try_as<DependencyObject>()};
     const bool focusOnMenu = focused && IsInMenuSubtree(focused);
@@ -929,7 +936,7 @@ bool MainWindow::HandleStorylineKeyDown(Input::KeyRoutedEventArgs const& args){
     }
 
     if(args.Key() == Windows::System::VirtualKey::Tab && !focusOnMenu && !focusInDialog){
-        TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
+        TryFocusTimelineCanvas(Microsoft::UI::Xaml::FocusState::Programmatic);
         args.Handled(true);
         return true;
     }
@@ -938,7 +945,7 @@ bool MainWindow::HandleStorylineKeyDown(Input::KeyRoutedEventArgs const& args){
         return false;
     }
 
-    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
+    TryFocusTimelineCanvas(Microsoft::UI::Xaml::FocusState::Programmatic);
 
     const auto ctrlState{Microsoft::UI::Input::InputKeyboardSource::GetKeyStateForCurrentThread(Windows::System::VirtualKey::Control)};
     const bool ctrlDown{(ctrlState & Windows::UI::Core::CoreVirtualKeyStates::Down) == Windows::UI::Core::CoreVirtualKeyStates::Down};
@@ -1010,7 +1017,7 @@ void MainWindow::RootGrid_PointerReleased(IInspectable const&, Input::PointerRou
     if(IsInMenuSubtree(source) || IsInDialogSubtree(source)){
         return;
     }
-    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
+    TryFocusTimelineCanvas(Microsoft::UI::Xaml::FocusState::Programmatic);
 }
 
 Windows::Foundation::TimeSpan MainWindow::SecondsToTimeSpan(const double seconds){
@@ -1024,7 +1031,7 @@ void MainWindow::KeyFrameSnapMode_Checked(IInspectable const& sender, RoutedEven
     }
 
     m_keyFrameSnapMode = unbox_value<hstring>(radio.Tag()).c_str();
-    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
+    TryFocusTimelineCanvas(Microsoft::UI::Xaml::FocusState::Programmatic);
 }
 
 Windows::Foundation::IAsyncAction MainWindow::NewProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -32,6 +32,7 @@
 #include <winrt/Windows.Media.Playback.h>
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.Storage.Pickers.h>
+#include <winrt/Windows.System.h>
 
 #pragma comment(lib, "mfplat.lib")
 #pragma comment(lib, "mfreadwrite.lib")
@@ -180,6 +181,40 @@ std::wstring SerializeNumberPairs(std::vector<std::pair<double, double>> const& 
     for(size_t i = 0; i < values.size(); ++i){
         if(i > 0){ ss << L";"; }
         ss << std::setprecision(15) << values[i].first << L"," << values[i].second;
+    }
+    return ss.str();
+}
+
+std::vector<IndexedFrameSample> ParseKeyframeVector(std::wstring const& text){
+    std::vector<IndexedFrameSample> out;
+    size_t start{};
+    while(start <= text.size()){
+        const auto sep = text.find(L';', start);
+        const auto item = Trim(text.substr(start, sep == std::wstring::npos ? std::wstring::npos : sep - start));
+        if(!item.empty()){
+            const auto at = item.find(L'@');
+            if(at != std::wstring::npos){
+                try{
+                    const auto t = static_cast<std::int64_t>(std::stoll(Trim(item.substr(0, at))));
+                    const auto i = static_cast<std::uint32_t>(std::stoul(Trim(item.substr(at + 1))));
+                    out.push_back(IndexedFrameSample{.time100ns=t, .duration100ns=0, .cleanPoint=true, .sampleIndex=i});
+                }catch(...){ }
+            }
+        }
+        if(sep == std::wstring::npos){ break; }
+        start = sep + 1;
+    }
+    return out;
+}
+
+std::wstring SerializeKeyframeVector(std::vector<IndexedFrameSample> const& index){
+    std::wstringstream ss;
+    bool first{true};
+    for(auto const& k : index){
+        if(!k.cleanPoint){ continue; }
+        if(!first){ ss << L";"; }
+        first = false;
+        ss << k.time100ns << L"@" << k.sampleIndex;
     }
     return ss.str();
 }
@@ -558,7 +593,7 @@ void MainWindow::TimelineCanvas_PointerReleased(IInspectable const&, Input::Poin
     TimelineCanvas().ReleasePointerCapture(e.Pointer());
 
     if(!dragged){
-        SeekTimelineToCanvasX(point.Position().X);
+        SeekTimelineToCanvasX(point.Position().X, e.KeyModifiers().HasFlag(Windows::System::VirtualKeyModifiers::Shift));
     }
 
     e.Handled(true);
@@ -642,16 +677,60 @@ void MainWindow::SyncTimelineHorizontalScrollBar(){
     }
 }
 
-void MainWindow::SeekTimelineToCanvasX(const double pointerX){
+void MainWindow::SeekTimelineToCanvasX(const double pointerX, const bool bypassSnap){
     if(!m_player || m_timelineDurationSeconds <= 0 || TimelineCanvas().Width() <= 0){
         return;
     }
 
     const auto x{std::clamp(pointerX, 0.0, TimelineCanvas().Width())};
     const auto ratio{x / TimelineCanvas().Width()};
-    const auto targetSeconds{ratio * m_timelineDurationSeconds};
+    auto target100ns{static_cast<std::int64_t>(ratio * (m_timelineDurationSeconds * 10'000'000.0))};
 
-    m_player.PlaybackSession().Position(SecondsToTimeSpan(targetSeconds));
+    if(!bypassSnap && !m_frameIndex.empty()){
+        const auto toSeconds = [](std::int64_t v){ return static_cast<double>(v) / 10'000'000.0; };
+        const auto it = std::lower_bound(m_frameIndex.begin(), m_frameIndex.end(), target100ns, [](IndexedFrameSample const& a, std::int64_t v){
+            return a.time100ns < v;
+        });
+
+        auto useTime = target100ns;
+        if(m_keyFrameSnapMode == L"Left"){
+            for(auto rit = (it == m_frameIndex.begin() ? m_frameIndex.begin() : it);;){
+                if(rit == m_frameIndex.begin()){
+                    if(rit->cleanPoint){ useTime = rit->time100ns; }
+                    break;
+                }
+                --rit;
+                if(rit->cleanPoint){ useTime = rit->time100ns; break; }
+            }
+        }else if(m_keyFrameSnapMode == L"Right"){
+            for(auto fit = it; fit != m_frameIndex.end(); ++fit){
+                if(fit->cleanPoint){ useTime = fit->time100ns; break; }
+            }
+        }else{
+            std::int64_t left = -1;
+            std::int64_t right = -1;
+            if(it != m_frameIndex.begin()){
+                for(auto rit = it;;){
+                    --rit;
+                    if(rit->cleanPoint){ left = rit->time100ns; break; }
+                    if(rit == m_frameIndex.begin()){ break; }
+                }
+            }
+            for(auto fit = it; fit != m_frameIndex.end(); ++fit){
+                if(fit->cleanPoint){ right = fit->time100ns; break; }
+            }
+            if(left >= 0 && right >= 0){
+                useTime = (std::llabs(target100ns - left) <= std::llabs(right - target100ns)) ? left : right;
+            }else if(left >= 0){
+                useTime = left;
+            }else if(right >= 0){
+                useTime = right;
+            }
+        }
+        target100ns = useTime;
+    }
+
+    m_player.PlaybackSession().Position(Windows::Foundation::TimeSpan{target100ns});
     UpdateTimelineCursorFromPlayback();
 }
 
@@ -720,6 +799,92 @@ void MainWindow::RenderTimelineTicks(){
         TimelineTickCanvas().Children().Append(label);
     }
 }
+
+void MainWindow::RenderKeyframeTicks(){
+    if(m_frameIndex.empty() || m_timelineDurationSeconds <= 0 || TimelineTickCanvas().Width() <= 0){
+        return;
+    }
+
+    const auto width = TimelineTickCanvas().Width();
+    const auto total100ns = static_cast<double>(m_timelineDurationSeconds * 10'000'000.0);
+    for(auto const& frame : m_frameIndex){
+        if(!frame.cleanPoint){
+            continue;
+        }
+
+        const auto x = std::clamp((frame.time100ns / total100ns) * width, 0.0, width);
+        Shapes::Line tick{};
+        tick.X1(x);
+        tick.X2(x);
+        tick.Y1(0);
+        tick.Y2(5);
+        tick.Stroke(Media::SolidColorBrush(Windows::UI::ColorHelper::FromArgb(255, 80, 200, 255)));
+        tick.StrokeThickness(1.0);
+        TimelineTickCanvas().Children().Append(tick);
+    }
+}
+
+void MainWindow::StepByFrame(const int delta){
+    if(!m_player || m_frameIndex.empty()){
+        return;
+    }
+
+    const auto current = m_player.PlaybackSession().Position().count();
+    auto idx = std::lower_bound(m_frameIndex.begin(), m_frameIndex.end(), current, [](IndexedFrameSample const& a, std::int64_t t){ return a.time100ns < t; });
+    std::ptrdiff_t pos = idx - m_frameIndex.begin();
+    if(delta < 0){
+        pos = std::max<std::ptrdiff_t>(0, pos - 1);
+    }else{
+        pos = std::min<std::ptrdiff_t>(static_cast<std::ptrdiff_t>(m_frameIndex.size()) - 1, pos + 1);
+    }
+
+    m_player.PlaybackSession().Position(Windows::Foundation::TimeSpan{m_frameIndex[static_cast<size_t>(pos)].time100ns});
+    UpdateTimelineCursorFromPlayback();
+}
+
+void MainWindow::StepByKeyframe(const int delta){
+    if(!m_player || m_frameIndex.empty()){
+        return;
+    }
+
+    std::vector<std::int64_t> keys;
+    keys.reserve(m_frameIndex.size());
+    for(auto const& f : m_frameIndex){ if(f.cleanPoint){ keys.push_back(f.time100ns); } }
+    if(keys.empty()) return;
+
+    const auto current = m_player.PlaybackSession().Position().count();
+    auto it = std::lower_bound(keys.begin(), keys.end(), current);
+    std::ptrdiff_t pos = it - keys.begin();
+    if(delta < 0){ pos = std::max<std::ptrdiff_t>(0, pos - 1); }
+    else{ pos = std::min<std::ptrdiff_t>(static_cast<std::ptrdiff_t>(keys.size()) - 1, pos + 1); }
+
+    m_player.PlaybackSession().Position(Windows::Foundation::TimeSpan{keys[static_cast<size_t>(pos)]});
+    UpdateTimelineCursorFromPlayback();
+}
+
+void MainWindow::Window_KeyDown(IInspectable const&, Input::KeyRoutedEventArgs const& args){
+    switch(args.Key()){
+    case Windows::System::VirtualKey::Left:
+        StepByFrame(-1);
+        args.Handled(true);
+        break;
+    case Windows::System::VirtualKey::Right:
+        StepByFrame(1);
+        args.Handled(true);
+        break;
+    case Windows::System::VirtualKey::Up:
+        StepByKeyframe(-1);
+        args.Handled(true);
+        break;
+    case Windows::System::VirtualKey::Down:
+        StepByKeyframe(1);
+        args.Handled(true);
+        break;
+    default:
+        break;
+    }
+}
+
 
 Windows::Foundation::TimeSpan MainWindow::SecondsToTimeSpan(const double seconds){
     return std::chrono::duration_cast<Windows::Foundation::TimeSpan>(std::chrono::duration<double>(seconds));
@@ -956,6 +1121,7 @@ void MainWindow::ResetProjectState(const bool clearLoadedVideo){
     m_projectUnknownLines.clear();
     m_selectedKeyFrames.clear();
     m_cutIntervals.clear();
+    m_frameIndex.clear();
     m_keyFrameSnapMode = L"Nearest";
     NearestSnapRadio().IsChecked(true);
     TimelineZoomSlider().Value(3);
@@ -1019,6 +1185,7 @@ Windows::Foundation::IAsyncAction MainWindow::OpenProjectFileAsync(Windows::Stor
     std::wstring loadedFilePath;
     std::wstring snapMode{L"Nearest"};
     double zoomLevel{TimelineZoomSlider().Value()};
+    std::vector<IndexedFrameSample> loadedKeyframeIndex;
 
     for(auto const& lineH : lines){
         const std::wstring line{lineH.c_str()};
@@ -1051,6 +1218,8 @@ Windows::Foundation::IAsyncAction MainWindow::OpenProjectFileAsync(Windows::Stor
             selectedKeyFrames = ParseNumberList(value);
         }else if(key == L"cut_intervals"){
             cutIntervals = ParseNumberPairs(value);
+        }else if(key == L"keyframe_index"){
+            loadedKeyframeIndex = ParseKeyframeVector(value);
         }else{
             unknownLines.push_back(line);
         }
@@ -1072,6 +1241,9 @@ Windows::Foundation::IAsyncAction MainWindow::OpenProjectFileAsync(Windows::Stor
     m_cutIntervals = std::move(cutIntervals);
     m_projectUnknownLines = std::move(unknownLines);
     m_projectPath = file.Path();
+    if(!loadedKeyframeIndex.empty()){
+        m_frameIndex = std::move(loadedKeyframeIndex);
+    }
 
     if(snapMode == L"Left"){
         LeftSnapRadio().IsChecked(true);
@@ -1094,6 +1266,7 @@ Windows::Foundation::IAsyncAction MainWindow::SaveProjectFileAsync(Windows::Stor
     lines.emplace_back(L"keyframe_snap_mode=" + m_keyFrameSnapMode);
     lines.emplace_back(L"selected_key_frames=" + SerializeNumberList(m_selectedKeyFrames));
     lines.emplace_back(L"cut_intervals=" + SerializeNumberPairs(m_cutIntervals));
+    lines.emplace_back(L"keyframe_index=" + SerializeKeyframeVector(m_frameIndex));
 
     for(auto const& unknown : m_projectUnknownLines){
         lines.emplace_back(unknown);
@@ -1342,6 +1515,67 @@ MediaInspectionResult MainWindow::InspectMediaFile(std::wstring const& filePath)
     return result;
 }
 
+std::vector<IndexedFrameSample> MainWindow::BuildKeyframeIndexForFile(std::wstring const& filePath){
+    std::vector<IndexedFrameSample> index;
+    MFLifetime mf{};
+
+    com_ptr<IMFSourceReader> reader;
+    check_hresult(MFCreateSourceReaderFromURL(filePath.c_str(), nullptr, reader.put()));
+
+    constexpr DWORD invalidStream{std::numeric_limits<DWORD>::max()};
+    DWORD videoStreamIndex{invalidStream};
+    for(DWORD streamIndex = 0;; ++streamIndex){
+        com_ptr<IMFMediaType> type;
+        const HRESULT hr = reader->GetNativeMediaType(streamIndex, 0, type.put());
+        if(hr == MF_E_INVALIDSTREAMNUMBER){
+            break;
+        }
+        check_hresult(hr);
+
+        GUID major{GUID_NULL};
+        check_hresult(type->GetGUID(MF_MT_MAJOR_TYPE, &major));
+        if(major == MFMediaType_Video){
+            videoStreamIndex = streamIndex;
+            break;
+        }
+    }
+
+    if(videoStreamIndex == invalidStream){
+        return index;
+    }
+
+    check_hresult(reader->SetStreamSelection(MF_SOURCE_READER_ALL_STREAMS, FALSE));
+    check_hresult(reader->SetStreamSelection(videoStreamIndex, TRUE));
+
+    for(std::uint32_t sampleIndex = 0;; ++sampleIndex){
+        DWORD actualStream{};
+        DWORD flags{};
+        LONGLONG timestamp{};
+        com_ptr<IMFSample> sample;
+        const HRESULT hr = reader->ReadSample(videoStreamIndex, 0, &actualStream, &flags, &timestamp, sample.put());
+        if(FAILED(hr) || (flags & MF_SOURCE_READERF_ENDOFSTREAM)){
+            break;
+        }
+        if(!sample){
+            continue;
+        }
+
+        LONGLONG duration{};
+        (void)sample->GetSampleDuration(&duration);
+        UINT32 clean{};
+        const bool cleanPoint = SUCCEEDED(sample->GetUINT32(MFSampleExtension_CleanPoint, &clean)) && clean != 0;
+
+        index.push_back(IndexedFrameSample{
+            .time100ns = timestamp,
+            .duration100ns = duration,
+            .cleanPoint = cleanPoint,
+            .sampleIndex = sampleIndex,
+        });
+    }
+
+    return index;
+}
+
 void MainWindow::Window_DragOver(IInspectable const&, DragEventArgs const& e){
     e.AcceptedOperation(Windows::ApplicationModel::DataTransfer::DataPackageOperation::Copy);
 }
@@ -1401,10 +1635,15 @@ Windows::Foundation::IAsyncAction MainWindow::LoadVideoFileAsync(Windows::Storag
     const auto basicProperties{co_await file.GetBasicPropertiesAsync()};
     inspected.fileSize = FormatFileSize(basicProperties.Size());
     m_mediaInfo = inspected;
+    m_frameIndex = BuildKeyframeIndexForFile(file.Path().c_str());
 
     const auto source{Windows::Media::Core::MediaSource::CreateFromStorageFile(file)};
     m_player.Source(source);
     m_loadedFile = file;
+    if(m_projectPath.empty()){
+        m_selectedKeyFrames.clear();
+        m_cutIntervals.clear();
+    }
     AddRecentVideo(file.Path());
 
     ThumbnailLayer().Children().Clear();
@@ -1449,6 +1688,7 @@ winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
         ThumbnailLayer().Children().Clear();
         Controls::Canvas::SetLeft(TimelineCursor(), 0);
         RenderTimelineTicks();
+        RenderKeyframeTicks();
         SyncTimelineHorizontalScrollBar();
 
         const auto clip{co_await Windows::Media::Editing::MediaClip::CreateFromFileAsync(m_loadedFile)};

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -47,6 +47,12 @@ constexpr auto W_POS_T{L"WindowTop"};
 constexpr auto W_POS_W{L"WindowWidth"};
 constexpr auto W_POS_H{L"WindowHeight"};
 constexpr auto W_POS_DPI{L"WindowDpi"};
+constexpr auto S_RECENT_VIDEOS{L"RecentVideos"};
+constexpr auto S_RECENT_PROJECTS{L"RecentProjects"};
+constexpr auto S_MAX_RECENT_VIDEOS{L"MaxRecentVideos"};
+constexpr auto S_MAX_RECENT_PROJECTS{L"MaxRecentProjects"};
+constexpr auto S_DEFAULT_MAX_RECENT{5};
+constexpr wchar_t RECENT_DELIMITER{0x1F};
 
 struct MFLifetime{
     MFLifetime(){
@@ -84,6 +90,34 @@ std::wstring FormatRatio(uint32_t num, uint32_t den){
     std::wstringstream ss;
     ss << std::fixed << std::setprecision(3) << (static_cast<double>(num) / den);
     return ss.str();
+}
+
+std::wstring JoinRecentItems(std::vector<hstring> const& values){
+    std::wstring out;
+    for(size_t i = 0; i < values.size(); ++i){
+        if(i > 0){
+            out.push_back(RECENT_DELIMITER);
+        }
+        out += values[i].c_str();
+    }
+    return out;
+}
+
+std::vector<hstring> SplitRecentItems(std::wstring const& source){
+    std::vector<hstring> items;
+    size_t start{};
+    while(start <= source.size()){
+        const auto pos = source.find(RECENT_DELIMITER, start);
+        const auto len = (pos == std::wstring::npos) ? (source.size() - start) : (pos - start);
+        if(len > 0){
+            items.emplace_back(source.substr(start, len));
+        }
+        if(pos == std::wstring::npos){
+            break;
+        }
+        start = pos + 1;
+    }
+    return items;
 }
 
 bool HasDecoderForSubtype(GUID const& subtype){
@@ -214,8 +248,10 @@ MainWindow::MainWindow(){
     m_positionTimer.Start();
 
     RestoreWindowPlacement();
+    LoadAppSettings();
     Closed({this, &MainWindow::OnClosed});
     RefreshRecentVideosMenu();
+    RefreshRecentProjectsMenu();
 }
 
 HWND MainWindow::GetWindowHandle() const{
@@ -283,6 +319,44 @@ void MainWindow::RestoreWindowPlacement(){
     SetWindowPos(hwnd, nullptr, left, top, width, height, SWP_NOACTIVATE | SWP_NOZORDER);
 }
 
+void MainWindow::LoadAppSettings(){
+    const auto values{Windows::Storage::ApplicationData::Current().LocalSettings().Values()};
+
+    m_maxRecentVideos = S_DEFAULT_MAX_RECENT;
+    m_maxRecentProjects = S_DEFAULT_MAX_RECENT;
+
+    if(values.HasKey(S_MAX_RECENT_VIDEOS)){
+        const auto parsed{unbox_value<int32_t>(values.Lookup(S_MAX_RECENT_VIDEOS))};
+        m_maxRecentVideos = static_cast<std::uint32_t>(std::clamp(parsed, 1, 20));
+    }
+    if(values.HasKey(S_MAX_RECENT_PROJECTS)){
+        const auto parsed{unbox_value<int32_t>(values.Lookup(S_MAX_RECENT_PROJECTS))};
+        m_maxRecentProjects = static_cast<std::uint32_t>(std::clamp(parsed, 1, 20));
+    }
+
+    if(values.HasKey(S_RECENT_VIDEOS)){
+        m_recentVideos = SplitRecentItems(unbox_value<hstring>(values.Lookup(S_RECENT_VIDEOS)).c_str());
+    }
+    if(values.HasKey(S_RECENT_PROJECTS)){
+        m_recentProjects = SplitRecentItems(unbox_value<hstring>(values.Lookup(S_RECENT_PROJECTS)).c_str());
+    }
+
+    if(m_recentVideos.size() > m_maxRecentVideos){
+        m_recentVideos.resize(m_maxRecentVideos);
+    }
+    if(m_recentProjects.size() > m_maxRecentProjects){
+        m_recentProjects.resize(m_maxRecentProjects);
+    }
+}
+
+void MainWindow::SaveAppSettings() const{
+    const auto values{Windows::Storage::ApplicationData::Current().LocalSettings().Values()};
+    values.Insert(S_MAX_RECENT_VIDEOS, box_value(static_cast<int32_t>(m_maxRecentVideos)));
+    values.Insert(S_MAX_RECENT_PROJECTS, box_value(static_cast<int32_t>(m_maxRecentProjects)));
+    values.Insert(S_RECENT_VIDEOS, box_value(hstring(JoinRecentItems(m_recentVideos))));
+    values.Insert(S_RECENT_PROJECTS, box_value(hstring(JoinRecentItems(m_recentProjects))));
+}
+
 void MainWindow::SaveWindowPlacement() const{
     const auto hwnd{GetWindowHandle()};
 
@@ -315,6 +389,7 @@ void MainWindow::OnClosed(IInspectable const&, WindowEventArgs const&){
 
     m_naturalDurationChangedRevoker.revoke();
     SaveWindowPlacement();
+    SaveAppSettings();
 }
 
 void MainWindow::StartButton_Click(IInspectable const&, RoutedEventArgs const&){
@@ -621,6 +696,10 @@ Windows::Foundation::IAsyncAction MainWindow::AboutMenuItem_Click(IInspectable c
     co_await ShowInfoDialogAsync(L"About llvc", L"llvc - Lossless Video Cut\nPreview and timeline exploration tool.");
 }
 
+Windows::Foundation::IAsyncAction MainWindow::OptionsMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    co_await ShowOptionsDialogAsync();
+}
+
 Windows::Foundation::IAsyncAction MainWindow::PickAndLoadVideoAsync(){
     Windows::Storage::Pickers::FileOpenPicker picker{};
     picker.SuggestedStartLocation(Windows::Storage::Pickers::PickerLocationId::VideosLibrary);
@@ -657,6 +736,26 @@ void MainWindow::RefreshRecentVideosMenu(){
     }
 }
 
+void MainWindow::RefreshRecentProjectsMenu(){
+    auto menu{RecentProjectsMenu()};
+    menu.Items().Clear();
+
+    if(m_recentProjects.empty()){
+        Controls::MenuFlyoutItem empty{};
+        empty.Text(L"(none)");
+        empty.IsEnabled(false);
+        menu.Items().Append(empty);
+        return;
+    }
+
+    for(auto const& path : m_recentProjects){
+        Controls::MenuFlyoutItem item{};
+        item.Text(path);
+        item.IsEnabled(false);
+        menu.Items().Append(item);
+    }
+}
+
 void MainWindow::AddRecentVideo(hstring const& path){
     if(path.empty()){
         return;
@@ -664,11 +763,25 @@ void MainWindow::AddRecentVideo(hstring const& path){
 
     m_recentVideos.erase(std::remove(m_recentVideos.begin(), m_recentVideos.end(), path), m_recentVideos.end());
     m_recentVideos.insert(m_recentVideos.begin(), path);
-    constexpr size_t maxRecent = 10;
-    if(m_recentVideos.size() > maxRecent){
-        m_recentVideos.resize(maxRecent);
+    if(m_recentVideos.size() > m_maxRecentVideos){
+        m_recentVideos.resize(m_maxRecentVideos);
     }
     RefreshRecentVideosMenu();
+    SaveAppSettings();
+}
+
+void MainWindow::AddRecentProject(hstring const& path){
+    if(path.empty()){
+        return;
+    }
+
+    m_recentProjects.erase(std::remove(m_recentProjects.begin(), m_recentProjects.end(), path), m_recentProjects.end());
+    m_recentProjects.insert(m_recentProjects.begin(), path);
+    if(m_recentProjects.size() > m_maxRecentProjects){
+        m_recentProjects.resize(m_maxRecentProjects);
+    }
+    RefreshRecentProjectsMenu();
+    SaveAppSettings();
 }
 
 Windows::Foundation::IAsyncAction MainWindow::ShowInfoDialogAsync(hstring const& title, hstring const& message){
@@ -703,6 +816,58 @@ Windows::Foundation::IAsyncAction MainWindow::ShowPropertiesDialogAsync(){
     content += L"Audio bitrate: "; content += m_mediaInfo.audioBitrate;
 
     co_await ShowInfoDialogAsync(L"Properties", hstring(content));
+}
+
+Windows::Foundation::IAsyncAction MainWindow::ShowOptionsDialogAsync(){
+    Controls::StackPanel panel{};
+    panel.Spacing(10);
+
+    Controls::TextBlock videosLabel{};
+    videosLabel.Text(L"Recent videos to keep (1-20)");
+    Controls::NumberBox videosCount{};
+    videosCount.Minimum(1);
+    videosCount.Maximum(20);
+    videosCount.SpinButtonPlacementMode(Controls::NumberBoxSpinButtonPlacementMode::Inline);
+    videosCount.Value(static_cast<double>(m_maxRecentVideos));
+
+    Controls::TextBlock projectsLabel{};
+    projectsLabel.Text(L"Recent projects to keep (1-20)");
+    Controls::NumberBox projectsCount{};
+    projectsCount.Minimum(1);
+    projectsCount.Maximum(20);
+    projectsCount.SpinButtonPlacementMode(Controls::NumberBoxSpinButtonPlacementMode::Inline);
+    projectsCount.Value(static_cast<double>(m_maxRecentProjects));
+
+    panel.Children().Append(videosLabel);
+    panel.Children().Append(videosCount);
+    panel.Children().Append(projectsLabel);
+    panel.Children().Append(projectsCount);
+
+    Controls::ContentDialog dialog{};
+    dialog.XamlRoot(Content().XamlRoot());
+    dialog.Title(box_value(L"Options"));
+    dialog.Content(panel);
+    dialog.PrimaryButtonText(L"Save");
+    dialog.CloseButtonText(L"Cancel");
+
+    const auto dialogResult{co_await dialog.ShowAsync()};
+    if(dialogResult != Controls::ContentDialogResult::Primary){
+        co_return;
+    }
+
+    m_maxRecentVideos = static_cast<std::uint32_t>(std::clamp(static_cast<int>(std::lround(videosCount.Value())), 1, 20));
+    m_maxRecentProjects = static_cast<std::uint32_t>(std::clamp(static_cast<int>(std::lround(projectsCount.Value())), 1, 20));
+
+    if(m_recentVideos.size() > m_maxRecentVideos){
+        m_recentVideos.resize(m_maxRecentVideos);
+    }
+    if(m_recentProjects.size() > m_maxRecentProjects){
+        m_recentProjects.resize(m_maxRecentProjects);
+    }
+
+    RefreshRecentVideosMenu();
+    RefreshRecentProjectsMenu();
+    SaveAppSettings();
 }
 
 bool MainWindow::IsSupportedVideoSubtype(GUID const& subtype){
@@ -919,6 +1084,7 @@ Windows::Foundation::IAsyncAction MainWindow::LoadVideoFileAsync(Windows::Storag
     m_player.Source(source);
     m_loadedFile = file;
     AddRecentVideo(file.Path());
+    AddRecentProject(file.Path());
 
     ThumbnailLayer().Children().Clear();
     TimelineCanvas().Width(640.0);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -859,22 +859,37 @@ void MainWindow::StepByFrame(const int delta){
 }
 
 void MainWindow::StepByKeyframe(const int delta){
-    if(!m_player || m_frameIndex.empty()){
+    if(!m_player || m_frameIndex.empty() || delta == 0){
         return;
     }
 
     std::vector<std::int64_t> keys;
     keys.reserve(m_frameIndex.size());
-    for(auto const& f : m_frameIndex){ if(f.cleanPoint){ keys.push_back(f.time100ns); } }
-    if(keys.empty()) return;
+    for(auto const& f : m_frameIndex){
+        if(f.cleanPoint){
+            keys.push_back(f.time100ns);
+        }
+    }
+    if(keys.empty()){
+        return;
+    }
 
     const auto current = m_player.PlaybackSession().Position().count();
-    auto it = std::lower_bound(keys.begin(), keys.end(), current);
-    std::ptrdiff_t pos = it - keys.begin();
-    if(delta < 0){ pos = std::max<std::ptrdiff_t>(0, pos - 1); }
-    else{ pos = std::min<std::ptrdiff_t>(static_cast<std::ptrdiff_t>(keys.size()) - 1, pos + 1); }
+    std::int64_t target = keys.front();
 
-    m_player.PlaybackSession().Position(Windows::Foundation::TimeSpan{keys[static_cast<size_t>(pos)]});
+    if(delta > 0){
+        const auto it = std::upper_bound(keys.begin(), keys.end(), current);
+        target = (it != keys.end()) ? *it : keys.back();
+    }else{
+        const auto it = std::lower_bound(keys.begin(), keys.end(), current);
+        if(it == keys.begin()){
+            target = keys.front();
+        }else{
+            target = *(it - 1);
+        }
+    }
+
+    m_player.PlaybackSession().Position(Windows::Foundation::TimeSpan{target});
     UpdateTimelineCursorFromPlayback();
 }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -660,6 +660,15 @@ Windows::Foundation::TimeSpan MainWindow::SecondsToTimeSpan(const double seconds
     return std::chrono::duration_cast<Windows::Foundation::TimeSpan>(std::chrono::duration<double>(seconds));
 }
 
+void MainWindow::KeyFrameSnapMode_Checked(IInspectable const& sender, RoutedEventArgs const&){
+    const auto radio{sender.try_as<Controls::RadioButton>()};
+    if(!radio || !radio.Tag()){
+        return;
+    }
+
+    m_keyFrameSnapMode = unbox_value<hstring>(radio.Tag()).c_str();
+}
+
 Windows::Foundation::IAsyncAction MainWindow::LoadVideoMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
     co_await PickAndLoadVideoAsync();
 }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -7,6 +7,7 @@
 #include <cwctype>
 #include <iomanip>
 #include <numeric>
+#include <limits>
 #include <sstream>
 #include <string_view>
 #include <vector>
@@ -753,7 +754,8 @@ MediaInspectionResult MainWindow::InspectMediaFile(std::wstring const& filePath)
     uint32_t fpsDen{};
     uint32_t videoBitrate{};
     uint32_t audioBitrate{};
-    DWORD videoStreamIndex{DWORD_MAX};
+    constexpr DWORD invalidStreamIndex{std::numeric_limits<DWORD>::max()};
+    DWORD videoStreamIndex{invalidStreamIndex};
     uint32_t allSamplesIndependent{};
     uint32_t maxKeyFrameSpacing{};
 
@@ -846,7 +848,7 @@ MediaInspectionResult MainWindow::InspectMediaFile(std::wstring const& filePath)
     result.frameRate = (fpsNum > 0 && fpsDen > 0) ? (FormatRatio(fpsNum, fpsDen) + L" fps") : L"-";
     result.videoBitrate = videoBitrate > 0 ? (std::to_wstring(videoBitrate / 1000) + L" kbps") : L"-";
     result.audioBitrate = audioBitrate > 0 ? (std::to_wstring((audioBitrate * 8) / 1000) + L" kbps") : L"none";
-    if(videoStreamIndex != DWORD_MAX){
+    if(videoStreamIndex != invalidStreamIndex){
         AnalyzeKeyFrameCadence(reader.get(), videoStreamIndex, fpsNum, fpsDen, result);
     }
     result.isValid = true;

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -539,6 +539,7 @@ void MainWindow::TimelineZoomSlider_ValueChanged(IInspectable const&, Controls::
     if(m_loadedFile && m_timelineDurationSeconds > 0){
         RenderTimelineAsync();
     }
+    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
 }
 
 void MainWindow::TimelineHorizontalScrollBar_ValueChanged(IInspectable const&, Controls::Primitives::RangeBaseValueChangedEventArgs const& args){
@@ -916,26 +917,28 @@ void MainWindow::StepByKeyframe(const int delta){
     UpdateTimelineCursorFromPlayback();
 }
 
-void MainWindow::Window_KeyDown(IInspectable const&, Input::KeyRoutedEventArgs const& args){
+bool MainWindow::HandleStorylineKeyDown(Input::KeyRoutedEventArgs const& args){
     const auto focused{Input::FocusManager::GetFocusedElement(Content().XamlRoot()).try_as<DependencyObject>()};
     const bool focusOnMenu = focused && IsInMenuSubtree(focused);
     const bool focusInDialog = focused && IsInDialogSubtree(focused);
 
-    if(args.Key() == Windows::System::VirtualKey::Menu){
+    if(args.Key() == Windows::System::VirtualKey::Menu || args.Key() == Windows::System::VirtualKey::LeftMenu || args.Key() == Windows::System::VirtualKey::RightMenu){
         MainMenuBar().Focus(Microsoft::UI::Xaml::FocusState::Keyboard);
         args.Handled(true);
-        return;
+        return true;
     }
 
     if(args.Key() == Windows::System::VirtualKey::Tab && !focusOnMenu && !focusInDialog){
         TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
         args.Handled(true);
-        return;
+        return true;
     }
 
     if(focusOnMenu || focusInDialog){
-        return;
+        return false;
     }
+
+    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
 
     const auto ctrlState{Microsoft::UI::Input::InputKeyboardSource::GetKeyStateForCurrentThread(Windows::System::VirtualKey::Control)};
     const bool ctrlDown{(ctrlState & Windows::UI::Core::CoreVirtualKeyStates::Down) == Windows::UI::Core::CoreVirtualKeyStates::Down};
@@ -944,40 +947,70 @@ void MainWindow::Window_KeyDown(IInspectable const&, Input::KeyRoutedEventArgs c
         if(args.Key() == Windows::System::VirtualKey::O){
             (void)OpenProjectMenuItem_Click(nullptr, RoutedEventArgs{});
             args.Handled(true);
-            return;
+            return true;
         }
         if(args.Key() == Windows::System::VirtualKey::S){
             (void)SaveProjectMenuItem_Click(nullptr, RoutedEventArgs{});
             args.Handled(true);
-            return;
+            return true;
         }
         if(args.Key() == Windows::System::VirtualKey::N){
             (void)NewProjectMenuItem_Click(nullptr, RoutedEventArgs{});
             args.Handled(true);
-            return;
+            return true;
         }
     }
 
     switch(args.Key()){
+    case Windows::System::VirtualKey::Space:
+        if(m_player){
+            const auto state = m_player.PlaybackSession().PlaybackState();
+            if(state == Windows::Media::Playback::MediaPlaybackState::Playing){
+                m_player.Pause();
+            }else{
+                m_player.Play();
+            }
+        }
+        args.Handled(true);
+        return true;
     case Windows::System::VirtualKey::Left:
         StepByFrame(-1);
         args.Handled(true);
-        break;
+        return true;
     case Windows::System::VirtualKey::Right:
         StepByFrame(1);
         args.Handled(true);
-        break;
+        return true;
     case Windows::System::VirtualKey::Up:
         StepByKeyframe(-1);
         args.Handled(true);
-        break;
+        return true;
     case Windows::System::VirtualKey::Down:
         StepByKeyframe(1);
         args.Handled(true);
-        break;
+        return true;
     default:
-        break;
+        return false;
     }
+}
+
+void MainWindow::Window_PreviewKeyDown(IInspectable const&, Input::KeyRoutedEventArgs const& args){
+    (void)HandleStorylineKeyDown(args);
+}
+
+void MainWindow::Window_KeyDown(IInspectable const&, Input::KeyRoutedEventArgs const& args){
+    (void)HandleStorylineKeyDown(args);
+}
+
+void MainWindow::RootGrid_PointerReleased(IInspectable const&, Input::PointerRoutedEventArgs const& args){
+    const auto source = args.OriginalSource().try_as<DependencyObject>();
+    if(!source){
+        return;
+    }
+    if(IsInMenuSubtree(source) || IsInDialogSubtree(source)){
+        return;
+    }
+    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
 }
 
 Windows::Foundation::TimeSpan MainWindow::SecondsToTimeSpan(const double seconds){
@@ -991,6 +1024,7 @@ void MainWindow::KeyFrameSnapMode_Checked(IInspectable const& sender, RoutedEven
     }
 
     m_keyFrameSnapMode = unbox_value<hstring>(radio.Tag()).c_str();
+    TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
 }
 
 Windows::Foundation::IAsyncAction MainWindow::NewProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
@@ -1780,7 +1814,6 @@ winrt::fire_and_forget MainWindow::RenderTimelineAsync(){
 
         TimelineCanvas().Width(totalWidth);
         ThumbnailLayer().Children().Clear();
-        Controls::Canvas::SetLeft(TimelineCursor(), 0);
         RenderTimelineTicks();
         RenderKeyframeTicks();
         SyncTimelineHorizontalScrollBar();

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -830,20 +830,31 @@ void MainWindow::RenderKeyframeTicks(){
 }
 
 void MainWindow::StepByFrame(const int delta){
-    if(!m_player || m_frameIndex.empty()){
+    if(!m_player || m_frameIndex.empty() || delta == 0){
         return;
     }
 
     const auto current = m_player.PlaybackSession().Position().count();
-    auto idx = std::lower_bound(m_frameIndex.begin(), m_frameIndex.end(), current, [](IndexedFrameSample const& a, std::int64_t t){ return a.time100ns < t; });
-    std::ptrdiff_t pos = idx - m_frameIndex.begin();
-    if(delta < 0){
-        pos = std::max<std::ptrdiff_t>(0, pos - 1);
+    auto nearest = std::lower_bound(m_frameIndex.begin(), m_frameIndex.end(), current, [](IndexedFrameSample const& a, std::int64_t t){ return a.time100ns < t; });
+
+    std::ptrdiff_t currentIndex{};
+    if(nearest == m_frameIndex.end()){
+        currentIndex = static_cast<std::ptrdiff_t>(m_frameIndex.size()) - 1;
+    }else if(nearest == m_frameIndex.begin()){
+        currentIndex = 0;
     }else{
-        pos = std::min<std::ptrdiff_t>(static_cast<std::ptrdiff_t>(m_frameIndex.size()) - 1, pos + 1);
+        const auto prev = nearest - 1;
+        currentIndex = (std::llabs(nearest->time100ns - current) < std::llabs(current - prev->time100ns))
+            ? static_cast<std::ptrdiff_t>(nearest - m_frameIndex.begin())
+            : static_cast<std::ptrdiff_t>(prev - m_frameIndex.begin());
     }
 
-    m_player.PlaybackSession().Position(Windows::Foundation::TimeSpan{m_frameIndex[static_cast<size_t>(pos)].time100ns});
+    const auto targetIndex = std::clamp<std::ptrdiff_t>(
+        currentIndex + (delta < 0 ? -1 : 1),
+        0,
+        static_cast<std::ptrdiff_t>(m_frameIndex.size()) - 1);
+
+    m_player.PlaybackSession().Position(Windows::Foundation::TimeSpan{m_frameIndex[static_cast<size_t>(targetIndex)].time100ns});
     UpdateTimelineCursorFromPlayback();
 }
 
@@ -869,6 +880,14 @@ void MainWindow::StepByKeyframe(const int delta){
 
 void MainWindow::Window_KeyDown(IInspectable const&, Input::KeyRoutedEventArgs const& args){
     switch(args.Key()){
+    case Windows::System::VirtualKey::Tab:
+        TimelineCanvas().Focus(Microsoft::UI::Xaml::FocusState::Programmatic);
+        args.Handled(true);
+        break;
+    case Windows::System::VirtualKey::Menu:
+        MainMenuBar().Focus(Microsoft::UI::Xaml::FocusState::Keyboard);
+        args.Handled(true);
+        break;
     case Windows::System::VirtualKey::Left:
         StepByFrame(-1);
         args.Handled(true);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cwctype>
 #include <iomanip>
+#include <numeric>
 #include <sstream>
 #include <string_view>
 #include <vector>
@@ -107,6 +108,95 @@ bool HasDecoderForSubtype(GUID const& subtype){
     }
 
     return SUCCEEDED(hr) && count > 0;
+}
+
+void AnalyzeKeyFrameCadence(IMFSourceReader* reader, DWORD videoStreamIndex, uint32_t fpsNum, uint32_t fpsDen, MediaInspectionResult& result){
+    constexpr uint32_t maxSamplesToInspect{1500};
+    constexpr LONGLONG maxSpan100ns{120LL * 10'000'000LL};
+
+    uint32_t sampledFrames{};
+    uint32_t keyFrames{};
+    bool cleanPointSeen{};
+    LONGLONG firstTimestamp{-1};
+    LONGLONG previousKeyTimestamp{-1};
+    std::vector<double> keyIntervalsSec{};
+
+    for(uint32_t i = 0; i < maxSamplesToInspect; ++i){
+        DWORD actualStreamIndex{};
+        DWORD flags{};
+        LONGLONG timestamp{};
+        com_ptr<IMFSample> sample{};
+
+        const HRESULT hr = reader->ReadSample(videoStreamIndex, 0, &actualStreamIndex, &flags, &timestamp, sample.put());
+        if(FAILED(hr)){
+            break;
+        }
+        if(flags & MF_SOURCE_READERF_ENDOFSTREAM){
+            break;
+        }
+        if(!sample){
+            continue;
+        }
+
+        ++sampledFrames;
+        if(firstTimestamp < 0){
+            firstTimestamp = timestamp;
+        }
+
+        UINT32 cleanPoint{};
+        if(SUCCEEDED(sample->GetUINT32(MFSampleExtension_CleanPoint, &cleanPoint)) && cleanPoint != 0){
+            cleanPointSeen = true;
+            ++keyFrames;
+            if(previousKeyTimestamp >= 0 && timestamp > previousKeyTimestamp){
+                keyIntervalsSec.push_back((timestamp - previousKeyTimestamp) / 10'000'000.0);
+            }
+            previousKeyTimestamp = timestamp;
+        }
+
+        if(firstTimestamp >= 0 && timestamp - firstTimestamp >= maxSpan100ns){
+            break;
+        }
+    }
+
+    if(sampledFrames == 0){
+        result.keyFrameSummary = L"unknown (no samples read)";
+        result.keyFrameInterval = L"unknown";
+        return;
+    }
+
+    if(!cleanPointSeen){
+        result.keyFrameSummary = L"unknown (clean-point flags unavailable)";
+        result.keyFrameInterval = L"unknown";
+        return;
+    }
+
+    const auto ratio = static_cast<double>(keyFrames) / static_cast<double>(sampledFrames);
+    {
+        std::wstringstream ss;
+        ss << keyFrames << L" key frames / " << sampledFrames << L" sampled frames (" << std::fixed << std::setprecision(2) << (ratio * 100.0) << L"%)";
+        result.keyFrameSummary = ss.str();
+    }
+
+    if(keyIntervalsSec.empty()){
+        result.keyFrameInterval = L"unknown (insufficient key frames sampled)";
+        return;
+    }
+
+    const auto sum = std::accumulate(keyIntervalsSec.begin(), keyIntervalsSec.end(), 0.0);
+    const auto avg = sum / static_cast<double>(keyIntervalsSec.size());
+    const auto minIt = std::min_element(keyIntervalsSec.begin(), keyIntervalsSec.end());
+    const auto maxIt = std::max_element(keyIntervalsSec.begin(), keyIntervalsSec.end());
+
+    std::wstringstream ss;
+    ss << std::fixed << std::setprecision(3)
+       << L"avg " << avg << L" s, min " << *minIt << L" s, max " << *maxIt << L" s";
+
+    if(fpsNum > 0 && fpsDen > 0){
+        const double fps = static_cast<double>(fpsNum) / fpsDen;
+        ss << L" (~" << std::setprecision(1) << (avg * fps) << L" frames avg)";
+    }
+
+    result.keyFrameInterval = ss.str();
 }
 
 MainWindow::MainWindow(){
@@ -604,6 +694,10 @@ Windows::Foundation::IAsyncAction MainWindow::ShowPropertiesDialogAsync(){
     content += L"Resolution: "; content += m_mediaInfo.resolution; content += L"\n";
     content += L"FPS: "; content += m_mediaInfo.frameRate; content += L"\n";
     content += L"Video bitrate: "; content += m_mediaInfo.videoBitrate; content += L"\n";
+    content += L"Key frames: "; content += m_mediaInfo.keyFrameSummary; content += L"\n";
+    content += L"Key frame interval: "; content += m_mediaInfo.keyFrameInterval; content += L"\n";
+    content += L"All samples independent: "; content += m_mediaInfo.allSamplesIndependent; content += L"\n";
+    content += L"Max key frame spacing: "; content += m_mediaInfo.maxKeyFrameSpacing; content += L"\n";
     content += L"Audio codec: "; content += m_mediaInfo.audioCodec; content += L"\n";
     content += L"Audio bitrate: "; content += m_mediaInfo.audioBitrate;
 
@@ -639,6 +733,10 @@ std::wstring MainWindow::GuidToCodecName(GUID const& subtype, bool isVideo){
 
 MediaInspectionResult MainWindow::InspectMediaFile(std::wstring const& filePath){
     MediaInspectionResult result{};
+    result.keyFrameSummary = L"unknown";
+    result.keyFrameInterval = L"unknown";
+    result.allSamplesIndependent = L"unknown";
+    result.maxKeyFrameSpacing = L"unknown";
     MFLifetime mf{};
 
     com_ptr<IMFSourceReader> reader;
@@ -655,6 +753,9 @@ MediaInspectionResult MainWindow::InspectMediaFile(std::wstring const& filePath)
     uint32_t fpsDen{};
     uint32_t videoBitrate{};
     uint32_t audioBitrate{};
+    DWORD videoStreamIndex{DWORD_MAX};
+    uint32_t allSamplesIndependent{};
+    uint32_t maxKeyFrameSpacing{};
 
     for(DWORD streamIndex = 0;; ++streamIndex){
         com_ptr<IMFMediaType> type;
@@ -672,9 +773,16 @@ MediaInspectionResult MainWindow::InspectMediaFile(std::wstring const& filePath)
         if(major == MFMediaType_Video){
             ++videoCount;
             videoSubtype = subtype;
+            videoStreamIndex = streamIndex;
             MFGetAttributeSize(type.get(), MF_MT_FRAME_SIZE, &width, &height);
             MFGetAttributeRatio(type.get(), MF_MT_FRAME_RATE, &fpsNum, &fpsDen);
             (void)type->GetUINT32(MF_MT_AVG_BITRATE, &videoBitrate);
+            if(SUCCEEDED(type->GetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, &allSamplesIndependent))){
+                result.allSamplesIndependent = allSamplesIndependent != 0 ? L"yes" : L"no";
+            }
+            if(SUCCEEDED(type->GetUINT32(MF_MT_MAX_KEYFRAME_SPACING, &maxKeyFrameSpacing))){
+                result.maxKeyFrameSpacing = std::to_wstring(maxKeyFrameSpacing) + L" frames";
+            }
         }else if(major == MFMediaType_Audio){
             ++audioCount;
             audioSubtype = subtype;
@@ -738,6 +846,9 @@ MediaInspectionResult MainWindow::InspectMediaFile(std::wstring const& filePath)
     result.frameRate = (fpsNum > 0 && fpsDen > 0) ? (FormatRatio(fpsNum, fpsDen) + L" fps") : L"-";
     result.videoBitrate = videoBitrate > 0 ? (std::to_wstring(videoBitrate / 1000) + L" kbps") : L"-";
     result.audioBitrate = audioBitrate > 0 ? (std::to_wstring((audioBitrate * 8) / 1000) + L" kbps") : L"none";
+    if(videoStreamIndex != DWORD_MAX){
+        AnalyzeKeyFrameCadence(reader.get(), videoStreamIndex, fpsNum, fpsDen, result);
+    }
     result.isValid = true;
     return result;
 }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -5,9 +5,20 @@
 #include <algorithm>
 #include <cmath>
 #include <cwctype>
+#include <iomanip>
+#include <sstream>
+#include <string_view>
 #include <vector>
 
+#include <mfapi.h>
+#include <mferror.h>
+#include <mfidl.h>
+#include <mfobjects.h>
+#include <mfreadwrite.h>
+#include <mftransform.h>
 #include <microsoft.ui.xaml.window.h>
+#include <shobjidl_core.h>
+#include <winrt/Windows.Storage.FileProperties.h>
 #include <winrt/Microsoft.UI.Input.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Media.Imaging.h>
@@ -18,6 +29,11 @@
 #include <winrt/Windows.Media.Editing.h>
 #include <winrt/Windows.Media.Playback.h>
 #include <winrt/Windows.Storage.h>
+#include <winrt/Windows.Storage.Pickers.h>
+
+#pragma comment(lib, "mfplat.lib")
+#pragma comment(lib, "mfreadwrite.lib")
+#pragma comment(lib, "mfuuid.lib")
 
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
@@ -29,6 +45,69 @@ constexpr auto W_POS_T{L"WindowTop"};
 constexpr auto W_POS_W{L"WindowWidth"};
 constexpr auto W_POS_H{L"WindowHeight"};
 constexpr auto W_POS_DPI{L"WindowDpi"};
+
+struct MFLifetime{
+    MFLifetime(){
+        check_hresult(MFStartup(MF_VERSION, MFSTARTUP_FULL));
+    }
+    ~MFLifetime(){
+        MFShutdown();
+    }
+};
+
+std::wstring FormatGuid(GUID const& guid){
+    OLECHAR raw[40]{};
+    StringFromGUID2(guid, raw, static_cast<int>(std::size(raw)));
+    return std::wstring(raw);
+}
+
+std::wstring FormatFileSize(uint64_t bytes){
+    std::wstringstream ss;
+    constexpr double KB = 1024.0;
+    constexpr double MB = KB * 1024.0;
+    constexpr double GB = MB * 1024.0;
+    ss << bytes << L" bytes";
+    if(bytes >= static_cast<uint64_t>(GB)){
+        ss << L" (" << std::fixed << std::setprecision(2) << (bytes / GB) << L" GB)";
+    }else if(bytes >= static_cast<uint64_t>(MB)){
+        ss << L" (" << std::fixed << std::setprecision(2) << (bytes / MB) << L" MB)";
+    }
+    return ss.str();
+}
+
+std::wstring FormatRatio(uint32_t num, uint32_t den){
+    if(den == 0){
+        return L"-";
+    }
+    std::wstringstream ss;
+    ss << std::fixed << std::setprecision(3) << (static_cast<double>(num) / den);
+    return ss.str();
+}
+
+bool HasDecoderForSubtype(GUID const& subtype){
+    MFT_REGISTER_TYPE_INFO inType{};
+    inType.guidMajorType = MFMediaType_Video;
+    inType.guidSubtype = subtype;
+
+    IMFActivate** activates{};
+    UINT32 count{};
+    const HRESULT hr = MFTEnumEx(
+        MFT_CATEGORY_VIDEO_DECODER,
+        MFT_ENUM_FLAG_SYNCMFT | MFT_ENUM_FLAG_ASYNCMFT | MFT_ENUM_FLAG_HARDWARE,
+        &inType,
+        nullptr,
+        &activates,
+        &count);
+
+    if(SUCCEEDED(hr) && activates){
+        for(UINT32 i = 0; i < count; ++i){
+            activates[i]->Release();
+        }
+        CoTaskMemFree(activates);
+    }
+
+    return SUCCEEDED(hr) && count > 0;
+}
 
 MainWindow::MainWindow(){
     InitializeComponent();
@@ -45,6 +124,7 @@ MainWindow::MainWindow(){
 
     RestoreWindowPlacement();
     Closed({this, &MainWindow::OnClosed});
+    RefreshRecentVideosMenu();
 }
 
 HWND MainWindow::GetWindowHandle() const{
@@ -414,6 +494,248 @@ Windows::Foundation::TimeSpan MainWindow::SecondsToTimeSpan(const double seconds
     return std::chrono::duration_cast<Windows::Foundation::TimeSpan>(std::chrono::duration<double>(seconds));
 }
 
+Windows::Foundation::IAsyncAction MainWindow::LoadVideoMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    co_await PickAndLoadVideoAsync();
+}
+
+Windows::Foundation::IAsyncAction MainWindow::RecentVideoMenuItem_Click(IInspectable const& sender, RoutedEventArgs const&){
+    const auto item{sender.try_as<Controls::MenuFlyoutItem>()};
+    if(!item || !item.Tag()){
+        co_return;
+    }
+
+    const auto path{unbox_value<hstring>(item.Tag())};
+    try{
+        const auto file{co_await Windows::Storage::StorageFile::GetFileFromPathAsync(path)};
+        co_await LoadVideoFileAsync(file);
+    }catch(winrt::hresult_error const&){
+        co_await ShowInfoDialogAsync(L"Open failed", L"Could not open selected recent video.");
+    }
+}
+
+Windows::Foundation::IAsyncAction MainWindow::PropertiesMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    co_await ShowPropertiesDialogAsync();
+}
+
+void MainWindow::ExitMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    Close();
+}
+
+Windows::Foundation::IAsyncAction MainWindow::AboutMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    co_await ShowInfoDialogAsync(L"About llvc", L"llvc - Lossless Video Cut\nPreview and timeline exploration tool.");
+}
+
+Windows::Foundation::IAsyncAction MainWindow::PickAndLoadVideoAsync(){
+    Windows::Storage::Pickers::FileOpenPicker picker{};
+    picker.FileTypeFilter().Append(L".mp4");
+    picker.FileTypeFilter().Append(L".mov");
+
+    const auto hwnd{GetWindowHandle()};
+    auto initWithWindow{picker.as<IInitializeWithWindow>()};
+    check_hresult(initWithWindow->Initialize(hwnd));
+
+    if(const auto file{co_await picker.PickSingleFileAsync()}){
+        co_await LoadVideoFileAsync(file);
+    }
+}
+
+void MainWindow::RefreshRecentVideosMenu(){
+    auto menu{RecentVideosMenu()};
+    menu.Items().Clear();
+
+    if(m_recentVideos.empty()){
+        Controls::MenuFlyoutItem empty{};
+        empty.Text(L"(none)");
+        empty.IsEnabled(false);
+        menu.Items().Append(empty);
+        return;
+    }
+
+    for(auto const& path : m_recentVideos){
+        Controls::MenuFlyoutItem item{};
+        item.Text(path);
+        item.Tag(box_value(path));
+        item.Click({this, &MainWindow::RecentVideoMenuItem_Click});
+        menu.Items().Append(item);
+    }
+}
+
+void MainWindow::AddRecentVideo(hstring const& path){
+    if(path.empty()){
+        return;
+    }
+
+    m_recentVideos.erase(std::remove(m_recentVideos.begin(), m_recentVideos.end(), path), m_recentVideos.end());
+    m_recentVideos.insert(m_recentVideos.begin(), path);
+    constexpr size_t maxRecent = 10;
+    if(m_recentVideos.size() > maxRecent){
+        m_recentVideos.resize(maxRecent);
+    }
+    RefreshRecentVideosMenu();
+}
+
+Windows::Foundation::IAsyncAction MainWindow::ShowInfoDialogAsync(hstring const& title, hstring const& message){
+    Controls::ContentDialog dialog{};
+    dialog.XamlRoot(Content().XamlRoot());
+    dialog.Title(box_value(title));
+    dialog.Content(box_value(message));
+    dialog.CloseButtonText(L"OK");
+    co_await dialog.ShowAsync();
+}
+
+Windows::Foundation::IAsyncAction MainWindow::ShowPropertiesDialogAsync(){
+    if(!m_loadedFile || !m_mediaInfo.isValid){
+        co_await ShowInfoDialogAsync(L"Properties", L"No video is currently loaded.");
+        co_return;
+    }
+
+    std::wstring content;
+    content += L"File: "; content += m_loadedFile.Path().c_str(); content += L"\n";
+    content += L"Container: "; content += m_mediaInfo.container; content += L"\n";
+    content += L"Duration: "; content += m_mediaInfo.duration; content += L"\n";
+    content += L"Size: "; content += m_mediaInfo.fileSize; content += L"\n";
+    content += L"Video codec: "; content += m_mediaInfo.videoCodec; content += L"\n";
+    content += L"Resolution: "; content += m_mediaInfo.resolution; content += L"\n";
+    content += L"FPS: "; content += m_mediaInfo.frameRate; content += L"\n";
+    content += L"Video bitrate: "; content += m_mediaInfo.videoBitrate; content += L"\n";
+    content += L"Audio codec: "; content += m_mediaInfo.audioCodec; content += L"\n";
+    content += L"Audio bitrate: "; content += m_mediaInfo.audioBitrate;
+
+    co_await ShowInfoDialogAsync(L"Properties", hstring(content));
+}
+
+bool MainWindow::IsSupportedVideoSubtype(GUID const& subtype){
+    return subtype == MFVideoFormat_H264 || subtype == MFVideoFormat_HEVC || subtype == MFVideoFormat_H265;
+}
+
+std::wstring MainWindow::GuidToCodecName(GUID const& subtype, bool isVideo){
+    if(isVideo){
+        if(subtype == MFVideoFormat_H264){
+            return L"H.264";
+        }
+        if(subtype == MFVideoFormat_HEVC || subtype == MFVideoFormat_H265){
+            return L"HEVC";
+        }
+    }else{
+        if(subtype == MFAudioFormat_AAC){
+            return L"AAC";
+        }
+        if(subtype == MFAudioFormat_MP3){
+            return L"MP3";
+        }
+        if(subtype == MFAudioFormat_PCM){
+            return L"PCM";
+        }
+    }
+
+    return FormatGuid(subtype);
+}
+
+MediaInspectionResult MainWindow::InspectMediaFile(std::wstring const& filePath){
+    MediaInspectionResult result{};
+    MFLifetime mf{};
+
+    com_ptr<IMFSourceReader> reader;
+    check_hresult(MFCreateSourceReaderFromURL(filePath.c_str(), nullptr, reader.put()));
+
+    uint32_t videoCount{};
+    uint32_t audioCount{};
+    bool hasText{};
+    GUID videoSubtype{GUID_NULL};
+    GUID audioSubtype{GUID_NULL};
+    uint32_t width{};
+    uint32_t height{};
+    uint32_t fpsNum{};
+    uint32_t fpsDen{};
+    uint32_t videoBitrate{};
+    uint32_t audioBitrate{};
+
+    for(DWORD streamIndex = 0;; ++streamIndex){
+        com_ptr<IMFMediaType> type;
+        const HRESULT hr = reader->GetNativeMediaType(streamIndex, 0, type.put());
+        if(hr == MF_E_INVALIDSTREAMNUMBER){
+            break;
+        }
+        check_hresult(hr);
+
+        GUID major{GUID_NULL};
+        GUID subtype{GUID_NULL};
+        check_hresult(type->GetGUID(MF_MT_MAJOR_TYPE, &major));
+        check_hresult(type->GetGUID(MF_MT_SUBTYPE, &subtype));
+
+        if(major == MFMediaType_Video){
+            ++videoCount;
+            videoSubtype = subtype;
+            MFGetAttributeSize(type.get(), MF_MT_FRAME_SIZE, &width, &height);
+            MFGetAttributeRatio(type.get(), MF_MT_FRAME_RATE, &fpsNum, &fpsDen);
+            (void)type->GetUINT32(MF_MT_AVG_BITRATE, &videoBitrate);
+        }else if(major == MFMediaType_Audio){
+            ++audioCount;
+            audioSubtype = subtype;
+            (void)type->GetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND, &audioBitrate);
+        }else{
+            hasText = true;
+        }
+    }
+
+    if(videoCount != 1){
+        result.errorMessage = L"Expected exactly one video stream.";
+        return result;
+    }
+    if(audioCount > 1){
+        result.errorMessage = L"Multiple audio streams are not supported.";
+        return result;
+    }
+    if(hasText){
+        result.errorMessage = L"Subtitle/text streams are not supported.";
+        return result;
+    }
+    if(!IsSupportedVideoSubtype(videoSubtype)){
+        result.errorMessage = L"Video codec not supported. Only H.264 and HEVC are allowed.";
+        return result;
+    }
+
+    std::wstring lowerPath(filePath);
+    std::transform(lowerPath.begin(), lowerPath.end(), lowerPath.begin(), ::towlower);
+    if(lowerPath.size() >= 4 && lowerPath.substr(lowerPath.size() - 4) == L".mp4"){
+        result.container = L"MP4";
+    }else if(lowerPath.size() >= 4 && lowerPath.substr(lowerPath.size() - 4) == L".mov"){
+        result.container = L"MOV";
+    }else{
+        result.errorMessage = L"Container not supported. Only MP4 and MOV are allowed.";
+        return result;
+    }
+
+    if(videoSubtype == MFVideoFormat_HEVC || videoSubtype == MFVideoFormat_H265){
+        if(!HasDecoderForSubtype(videoSubtype)){
+            result.errorMessage = L"HEVC support missing (install HEVC Video Extensions)";
+            return result;
+        }
+    }else if(!HasDecoderForSubtype(videoSubtype)){
+        result.errorMessage = L"No decoder available";
+        return result;
+    }
+
+    PROPVARIANT duration{};
+    PropVariantInit(&duration);
+    if(SUCCEEDED(reader->GetPresentationAttribute(MF_SOURCE_READER_MEDIASOURCE, MF_PD_DURATION, &duration)) && duration.vt == VT_UI8){
+        const auto seconds = static_cast<double>(duration.uhVal.QuadPart) / 10'000'000.0;
+        std::wstringstream ss;
+        ss << std::fixed << std::setprecision(3) << seconds << L" s";
+        result.duration = ss.str();
+    }
+    PropVariantClear(&duration);
+
+    result.videoCodec = GuidToCodecName(videoSubtype, true);
+    result.audioCodec = audioCount == 0 ? L"none" : GuidToCodecName(audioSubtype, false);
+    result.resolution = width > 0 ? (std::to_wstring(width) + L"x" + std::to_wstring(height)) : L"-";
+    result.frameRate = (fpsNum > 0 && fpsDen > 0) ? (FormatRatio(fpsNum, fpsDen) + L" fps") : L"-";
+    result.videoBitrate = videoBitrate > 0 ? (std::to_wstring(videoBitrate / 1000) + L" kbps") : L"-";
+    result.audioBitrate = audioBitrate > 0 ? (std::to_wstring((audioBitrate * 8) / 1000) + L" kbps") : L"none";
+    result.isValid = true;
+    return result;
+}
+
 void MainWindow::Window_DragOver(IInspectable const&, DragEventArgs const& e){
     e.AcceptedOperation(Windows::ApplicationModel::DataTransfer::DataPackageOperation::Copy);
 }
@@ -452,9 +774,32 @@ Windows::Foundation::IAsyncAction MainWindow::Window_Drop(IInspectable const&, D
 }
 
 Windows::Foundation::IAsyncAction MainWindow::LoadVideoFileAsync(Windows::Storage::StorageFile const& file){
+    MediaInspectionResult inspected{};
+    try{
+        inspected = InspectMediaFile(file.Path().c_str());
+    }catch(winrt::hresult_error const& ex){
+        inspected.errorMessage = L"No decoder available";
+        if(ex.code() == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)){
+            inspected.errorMessage = L"File not found";
+        }
+    }
+
+    if(!inspected.isValid){
+        std::wstring status{L"Open rejected: "};
+        status += inspected.errorMessage;
+        StatusText().Text(status);
+        co_await ShowInfoDialogAsync(L"Unsupported media", hstring(status));
+        co_return;
+    }
+
+    const auto basicProperties{co_await file.GetBasicPropertiesAsync()};
+    inspected.fileSize = FormatFileSize(basicProperties.Size());
+    m_mediaInfo = inspected;
+
     const auto source{Windows::Media::Core::MediaSource::CreateFromStorageFile(file)};
     m_player.Source(source);
     m_loadedFile = file;
+    AddRecentVideo(file.Path());
 
     ThumbnailLayer().Children().Clear();
     TimelineCanvas().Width(640.0);
@@ -468,8 +813,6 @@ Windows::Foundation::IAsyncAction MainWindow::LoadVideoFileAsync(Windows::Storag
     status += file.Name().c_str();
     status += L" (loading story line...)";
     StatusText().Text(status);
-
-    co_return;
 }
 
 winrt::fire_and_forget MainWindow::RenderTimelineAsync(){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -859,8 +859,7 @@ Windows::Foundation::IAsyncAction MainWindow::ExitMenuItem_Click(IInspectable co
 }
 
 Windows::Foundation::IAsyncAction MainWindow::AboutMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
-    co_await ShowInfoDialogAsync(L"About llvc", L"llvc - Lossless Video Cut
-Preview and timeline exploration tool.");
+    co_await ShowInfoDialogAsync(L"About llvc", L"llvc - Lossless Video Cut\nPreview and timeline exploration tool.");
 }
 
 Windows::Foundation::IAsyncAction MainWindow::OptionsMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
@@ -969,7 +968,7 @@ void MainWindow::ResetProjectState(const bool clearLoadedVideo){
     m_lastSavedProjectSnapshot = BuildProjectSnapshot();
 }
 
-std::wstring MainWindow::BuildProjectSnapshot() const{
+std::wstring MainWindow::BuildProjectSnapshot(){
     std::wstringstream ss;
     ss << L"file_path=" << (m_loadedFile ? m_loadedFile.Path().c_str() : L"") << L"\n";
     ss << L"storyline_zoom=" << std::setprecision(15) << TimelineZoomSlider().Value() << L"\n";
@@ -982,7 +981,7 @@ std::wstring MainWindow::BuildProjectSnapshot() const{
     return ss.str();
 }
 
-bool MainWindow::IsProjectDirty() const{
+bool MainWindow::IsProjectDirty(){
     return BuildProjectSnapshot() != m_lastSavedProjectSnapshot;
 }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -316,6 +316,7 @@ MainWindow::MainWindow(){
     Closed({this, &MainWindow::OnClosed});
     RefreshRecentVideosMenu();
     RefreshRecentProjectsMenu();
+    m_lastSavedProjectSnapshot = BuildProjectSnapshot();
 }
 
 HWND MainWindow::GetWindowHandle() const{
@@ -733,12 +734,20 @@ void MainWindow::KeyFrameSnapMode_Checked(IInspectable const& sender, RoutedEven
     m_keyFrameSnapMode = unbox_value<hstring>(radio.Tag()).c_str();
 }
 
-void MainWindow::NewProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
-    ResetProjectState(false);
+Windows::Foundation::IAsyncAction MainWindow::NewProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    if(!co_await EnsureProjectSavedBeforeContinuingAsync()){
+        co_return;
+    }
+
+    ResetProjectState(true);
     StatusText().Text(L"New project created");
 }
 
 Windows::Foundation::IAsyncAction MainWindow::OpenProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    if(!co_await EnsureProjectSavedBeforeContinuingAsync()){
+        co_return;
+    }
+
     Windows::Storage::Pickers::FileOpenPicker picker{};
     picker.FileTypeFilter().Append(L".llvc");
     picker.SuggestedStartLocation(Windows::Storage::Pickers::PickerLocationId::DocumentsLibrary);
@@ -780,7 +789,11 @@ Windows::Foundation::IAsyncAction MainWindow::SaveProjectMenuItem_Click(IInspect
     co_await SaveProjectFileAsync(target);
 }
 
-void MainWindow::CloseProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+Windows::Foundation::IAsyncAction MainWindow::CloseProjectMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    if(!co_await EnsureProjectSavedBeforeContinuingAsync()){
+        co_return;
+    }
+
     ResetProjectState(true);
     StatusText().Text(L"Project closed");
 }
@@ -815,6 +828,10 @@ Windows::Foundation::IAsyncAction MainWindow::RecentProjectMenuItem_Click(IInspe
         co_return;
     }
 
+    if(!co_await EnsureProjectSavedBeforeContinuingAsync()){
+        co_return;
+    }
+
     bool openFailed{false};
     const auto path{unbox_value<hstring>(item.Tag())};
     try{
@@ -833,12 +850,17 @@ Windows::Foundation::IAsyncAction MainWindow::PropertiesMenuItem_Click(IInspecta
     co_await ShowPropertiesDialogAsync();
 }
 
-void MainWindow::ExitMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+Windows::Foundation::IAsyncAction MainWindow::ExitMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
+    if(!co_await EnsureProjectSavedBeforeContinuingAsync()){
+        co_return;
+    }
+
     Close();
 }
 
 Windows::Foundation::IAsyncAction MainWindow::AboutMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
-    co_await ShowInfoDialogAsync(L"About llvc", L"llvc - Lossless Video Cut\nPreview and timeline exploration tool.");
+    co_await ShowInfoDialogAsync(L"About llvc", L"llvc - Lossless Video Cut
+Preview and timeline exploration tool.");
 }
 
 Windows::Foundation::IAsyncAction MainWindow::OptionsMenuItem_Click(IInspectable const&, RoutedEventArgs const&){
@@ -937,11 +959,56 @@ void MainWindow::ResetProjectState(const bool clearLoadedVideo){
     m_cutIntervals.clear();
     m_keyFrameSnapMode = L"Nearest";
     NearestSnapRadio().IsChecked(true);
+    TimelineZoomSlider().Value(3);
 
     if(clearLoadedVideo){
         m_loadedFile = nullptr;
         m_player.Source(nullptr);
     }
+
+    m_lastSavedProjectSnapshot = BuildProjectSnapshot();
+}
+
+std::wstring MainWindow::BuildProjectSnapshot() const{
+    std::wstringstream ss;
+    ss << L"file_path=" << (m_loadedFile ? m_loadedFile.Path().c_str() : L"") << L"\n";
+    ss << L"storyline_zoom=" << std::setprecision(15) << TimelineZoomSlider().Value() << L"\n";
+    ss << L"keyframe_snap_mode=" << m_keyFrameSnapMode << L"\n";
+    ss << L"selected_key_frames=" << SerializeNumberList(m_selectedKeyFrames) << L"\n";
+    ss << L"cut_intervals=" << SerializeNumberPairs(m_cutIntervals) << L"\n";
+    for(auto const& line : m_projectUnknownLines){
+        ss << line << L"\n";
+    }
+    return ss.str();
+}
+
+bool MainWindow::IsProjectDirty() const{
+    return BuildProjectSnapshot() != m_lastSavedProjectSnapshot;
+}
+
+Windows::Foundation::IAsyncOperation<bool> MainWindow::EnsureProjectSavedBeforeContinuingAsync(){
+    if(!IsProjectDirty()){
+        co_return true;
+    }
+
+    Controls::ContentDialog dialog{};
+    dialog.XamlRoot(Content().XamlRoot());
+    dialog.Title(box_value(L"Unsaved changes"));
+    dialog.Content(box_value(L"Current project has unsaved changes. Save before continuing?"));
+    dialog.PrimaryButtonText(L"Save");
+    dialog.SecondaryButtonText(L"Don't save");
+    dialog.CloseButtonText(L"Cancel");
+
+    const auto choice{co_await dialog.ShowAsync()};
+    if(choice == Controls::ContentDialogResult::Primary){
+        co_await SaveProjectMenuItem_Click(nullptr, RoutedEventArgs{});
+        co_return !IsProjectDirty();
+    }
+    if(choice == Controls::ContentDialogResult::Secondary){
+        co_return true;
+    }
+
+    co_return false;
 }
 
 Windows::Foundation::IAsyncAction MainWindow::OpenProjectFileAsync(Windows::Storage::StorageFile const& file){
@@ -1016,6 +1083,7 @@ Windows::Foundation::IAsyncAction MainWindow::OpenProjectFileAsync(Windows::Stor
     }
 
     AddRecentProject(file.Path());
+    m_lastSavedProjectSnapshot = BuildProjectSnapshot();
     StatusText().Text(L"Project loaded");
 }
 
@@ -1035,6 +1103,7 @@ Windows::Foundation::IAsyncAction MainWindow::SaveProjectFileAsync(Windows::Stor
     co_await Windows::Storage::FileIO::WriteLinesAsync(file, single_threaded_vector<hstring>(std::move(lines)));
     m_projectPath = file.Path();
     AddRecentProject(file.Path());
+    m_lastSavedProjectSnapshot = BuildProjectSnapshot();
     StatusText().Text(L"Project saved");
 }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -815,11 +815,16 @@ Windows::Foundation::IAsyncAction MainWindow::RecentProjectMenuItem_Click(IInspe
         co_return;
     }
 
+    bool openFailed{false};
     const auto path{unbox_value<hstring>(item.Tag())};
     try{
         const auto file{co_await Windows::Storage::StorageFile::GetFileFromPathAsync(path)};
         co_await OpenProjectFileAsync(file);
     }catch(...){
+        openFailed = true;
+    }
+
+    if(openFailed){
         co_await ShowInfoDialogAsync(L"Open failed", L"Could not open selected recent project.");
     }
 }

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -52,6 +52,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     void TimelineCanvas_PointerCanceled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCaptureLost(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    void TimelineTickCanvas_PointerReleased(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void Window_PreviewKeyDown(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args);
     void Window_KeyDown(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args);
     void RootGrid_PointerReleased(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
@@ -130,6 +131,7 @@ private:
     void RenderTimelineTicks();
     void SeekTimelineToCanvasX(double pointerX, bool bypassSnap);
     void RenderKeyframeTicks();
+    bool ToggleSelectedKeyframeAtCanvasX(double pointerX);
     void StepByFrame(int delta);
     void StepByKeyframe(int delta);
     void EnsureTimelineCursorVisible(double cursorLeft);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -51,6 +51,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     void TimelineCanvas_PointerReleased(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCanceled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCaptureLost(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    void TimelineCanvas_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     void Window_KeyDown(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args);
     void KeyFrameSnapMode_Checked(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction NewProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -52,7 +52,9 @@ struct MainWindow: MainWindowT<MainWindow>{
     void TimelineCanvas_PointerCanceled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCaptureLost(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    void Window_PreviewKeyDown(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args);
     void Window_KeyDown(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args);
+    void RootGrid_PointerReleased(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void KeyFrameSnapMode_Checked(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction NewProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction OpenProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
@@ -131,6 +133,7 @@ private:
     void StepByFrame(int delta);
     void StepByKeyframe(int delta);
     void EnsureTimelineCursorVisible(double cursorLeft);
+    bool HandleStorylineKeyDown(winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args);
     static winrt::Windows::Foundation::TimeSpan SecondsToTimeSpan(double seconds);
     static bool IsRectVisibleOnAnyMonitor(RECT const& rect);
 };

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -22,6 +22,10 @@ struct MediaInspectionResult{
     std::wstring frameRate{};
     std::wstring videoBitrate{};
     std::wstring audioBitrate{};
+    std::wstring keyFrameSummary{};
+    std::wstring keyFrameInterval{};
+    std::wstring allSamplesIndependent{};
+    std::wstring maxKeyFrameSpacing{};
 };
 
 struct MainWindow: MainWindowT<MainWindow>{

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -45,15 +45,15 @@ struct MainWindow: MainWindowT<MainWindow>{
     void TimelineCanvas_PointerCanceled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCaptureLost(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void KeyFrameSnapMode_Checked(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
-    void NewProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction NewProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction OpenProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction SaveProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
-    void CloseProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction CloseProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction LoadVideoMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction RecentVideoMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction RecentProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction PropertiesMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
-    void ExitMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction ExitMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction AboutMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction OptionsMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     void Window_DragOver(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
@@ -79,6 +79,7 @@ private:
     std::vector<std::pair<double, double>> m_cutIntervals{};
     std::vector<std::wstring> m_projectUnknownLines{};
     winrt::hstring m_projectPath{};
+    std::wstring m_lastSavedProjectSnapshot{};
     bool m_isClosing{false};
     bool m_isTimelineDragging{false};
     bool m_timelineDragMoved{false};
@@ -103,6 +104,9 @@ private:
     winrt::Windows::Foundation::IAsyncAction OpenProjectFileAsync(winrt::Windows::Storage::StorageFile const& file);
     winrt::Windows::Foundation::IAsyncAction SaveProjectFileAsync(winrt::Windows::Storage::StorageFile const& file);
     void ResetProjectState(bool clearLoadedVideo);
+    std::wstring BuildProjectSnapshot() const;
+    bool IsProjectDirty() const;
+    winrt::Windows::Foundation::IAsyncOperation<bool> EnsureProjectSavedBeforeContinuingAsync();
     static MediaInspectionResult InspectMediaFile(std::wstring const& filePath);
     static bool IsSupportedVideoSubtype(_GUID const& subtype);
     static std::wstring GuidToCodecName(_GUID const& subtype, bool isVideo);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -43,6 +43,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     void TimelineCanvas_PointerReleased(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCanceled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCaptureLost(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    void KeyFrameSnapMode_Checked(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction LoadVideoMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction RecentVideoMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction PropertiesMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
@@ -67,6 +68,7 @@ private:
     std::vector<winrt::hstring> m_recentProjects{};
     std::uint32_t m_maxRecentVideos{5};
     std::uint32_t m_maxRecentProjects{5};
+    std::wstring m_keyFrameSnapMode{L"Nearest"};
     bool m_isClosing{false};
     bool m_isTimelineDragging{false};
     bool m_timelineDragMoved{false};

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -3,8 +3,26 @@
 #include "MainWindow.g.h"
 
 #include <cstdint>
+#include <string>
+#include <vector>
+
+struct _GUID;
 
 namespace winrt::llvc::implementation{
+
+struct MediaInspectionResult{
+    bool isValid{false};
+    std::wstring errorMessage{};
+    std::wstring container{};
+    std::wstring videoCodec{};
+    std::wstring audioCodec{};
+    std::wstring duration{};
+    std::wstring fileSize{};
+    std::wstring resolution{};
+    std::wstring frameRate{};
+    std::wstring videoBitrate{};
+    std::wstring audioBitrate{};
+};
 
 struct MainWindow: MainWindowT<MainWindow>{
     MainWindow();
@@ -21,6 +39,11 @@ struct MainWindow: MainWindowT<MainWindow>{
     void TimelineCanvas_PointerReleased(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCanceled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCaptureLost(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction LoadVideoMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction RecentVideoMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction PropertiesMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    void ExitMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction AboutMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     void Window_DragOver(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction Window_Drop(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
     void OnClosed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::WindowEventArgs const& args);
@@ -34,6 +57,8 @@ private:
     winrt::Microsoft::UI::Xaml::DispatcherTimer m_positionTimer{nullptr};
     double m_timelineDurationSeconds{0};
     std::uint64_t m_timelineRenderVersion{0};
+    MediaInspectionResult m_mediaInfo{};
+    std::vector<winrt::hstring> m_recentVideos{};
     bool m_isClosing{false};
     bool m_isTimelineDragging{false};
     bool m_timelineDragMoved{false};
@@ -45,6 +70,14 @@ private:
 private:
     void RestoreWindowPlacement();
     void SaveWindowPlacement() const;
+    winrt::Windows::Foundation::IAsyncAction PickAndLoadVideoAsync();
+    void RefreshRecentVideosMenu();
+    void AddRecentVideo(winrt::hstring const& path);
+    winrt::Windows::Foundation::IAsyncAction ShowInfoDialogAsync(winrt::hstring const& title, winrt::hstring const& message);
+    winrt::Windows::Foundation::IAsyncAction ShowPropertiesDialogAsync();
+    static MediaInspectionResult InspectMediaFile(std::wstring const& filePath);
+    static bool IsSupportedVideoSubtype(_GUID const& subtype);
+    static std::wstring GuidToCodecName(_GUID const& subtype, bool isVideo);
     winrt::Windows::Foundation::IAsyncAction LoadVideoFileAsync(winrt::Windows::Storage::StorageFile const& file);
     winrt::fire_and_forget RenderTimelineAsync();
     void UpdateTimelineCursorFromPlayback();

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 struct _GUID;
@@ -44,8 +45,13 @@ struct MainWindow: MainWindowT<MainWindow>{
     void TimelineCanvas_PointerCanceled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCaptureLost(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void KeyFrameSnapMode_Checked(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    void NewProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction OpenProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction SaveProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    void CloseProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction LoadVideoMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction RecentVideoMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction RecentProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction PropertiesMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     void ExitMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction AboutMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
@@ -69,6 +75,10 @@ private:
     std::uint32_t m_maxRecentVideos{5};
     std::uint32_t m_maxRecentProjects{5};
     std::wstring m_keyFrameSnapMode{L"Nearest"};
+    std::vector<double> m_selectedKeyFrames{};
+    std::vector<std::pair<double, double>> m_cutIntervals{};
+    std::vector<std::wstring> m_projectUnknownLines{};
+    winrt::hstring m_projectPath{};
     bool m_isClosing{false};
     bool m_isTimelineDragging{false};
     bool m_timelineDragMoved{false};
@@ -90,6 +100,9 @@ private:
     winrt::Windows::Foundation::IAsyncAction ShowInfoDialogAsync(winrt::hstring const& title, winrt::hstring const& message);
     winrt::Windows::Foundation::IAsyncAction ShowPropertiesDialogAsync();
     winrt::Windows::Foundation::IAsyncAction ShowOptionsDialogAsync();
+    winrt::Windows::Foundation::IAsyncAction OpenProjectFileAsync(winrt::Windows::Storage::StorageFile const& file);
+    winrt::Windows::Foundation::IAsyncAction SaveProjectFileAsync(winrt::Windows::Storage::StorageFile const& file);
+    void ResetProjectState(bool clearLoadedVideo);
     static MediaInspectionResult InspectMediaFile(std::wstring const& filePath);
     static bool IsSupportedVideoSubtype(_GUID const& subtype);
     static std::wstring GuidToCodecName(_GUID const& subtype, bool isVideo);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -11,6 +11,13 @@ struct _GUID;
 
 namespace winrt::llvc::implementation{
 
+struct IndexedFrameSample{
+    std::int64_t time100ns{};
+    std::int64_t duration100ns{};
+    bool cleanPoint{};
+    std::uint32_t sampleIndex{};
+};
+
 struct MediaInspectionResult{
     bool isValid{false};
     std::wstring errorMessage{};
@@ -44,6 +51,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     void TimelineCanvas_PointerReleased(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCanceled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
     void TimelineCanvas_PointerCaptureLost(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& args);
+    void Window_KeyDown(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args);
     void KeyFrameSnapMode_Checked(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction NewProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction OpenProjectMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
@@ -76,6 +84,7 @@ private:
     std::uint32_t m_maxRecentProjects{5};
     std::wstring m_keyFrameSnapMode{L"Nearest"};
     std::vector<double> m_selectedKeyFrames{};
+    std::vector<IndexedFrameSample> m_frameIndex{};
     std::vector<std::pair<double, double>> m_cutIntervals{};
     std::vector<std::wstring> m_projectUnknownLines{};
     winrt::hstring m_projectPath{};
@@ -109,13 +118,17 @@ private:
     winrt::Windows::Foundation::IAsyncOperation<bool> EnsureProjectSavedBeforeContinuingAsync();
     static MediaInspectionResult InspectMediaFile(std::wstring const& filePath);
     static bool IsSupportedVideoSubtype(_GUID const& subtype);
+    static std::vector<IndexedFrameSample> BuildKeyframeIndexForFile(std::wstring const& filePath);
     static std::wstring GuidToCodecName(_GUID const& subtype, bool isVideo);
     winrt::Windows::Foundation::IAsyncAction LoadVideoFileAsync(winrt::Windows::Storage::StorageFile const& file);
     winrt::fire_and_forget RenderTimelineAsync();
     void UpdateTimelineCursorFromPlayback();
     void SyncTimelineHorizontalScrollBar();
     void RenderTimelineTicks();
-    void SeekTimelineToCanvasX(double pointerX);
+    void SeekTimelineToCanvasX(double pointerX, bool bypassSnap);
+    void RenderKeyframeTicks();
+    void StepByFrame(int delta);
+    void StepByKeyframe(int delta);
     void EnsureTimelineCursorVisible(double cursorLeft);
     static winrt::Windows::Foundation::TimeSpan SecondsToTimeSpan(double seconds);
     static bool IsRectVisibleOnAnyMonitor(RECT const& rect);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -133,6 +133,7 @@ private:
     void StepByFrame(int delta);
     void StepByKeyframe(int delta);
     void EnsureTimelineCursorVisible(double cursorLeft);
+    void TryFocusTimelineCanvas(winrt::Microsoft::UI::Xaml::FocusState const focusState);
     bool HandleStorylineKeyDown(winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& args);
     static winrt::Windows::Foundation::TimeSpan SecondsToTimeSpan(double seconds);
     static bool IsRectVisibleOnAnyMonitor(RECT const& rect);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -104,8 +104,8 @@ private:
     winrt::Windows::Foundation::IAsyncAction OpenProjectFileAsync(winrt::Windows::Storage::StorageFile const& file);
     winrt::Windows::Foundation::IAsyncAction SaveProjectFileAsync(winrt::Windows::Storage::StorageFile const& file);
     void ResetProjectState(bool clearLoadedVideo);
-    std::wstring BuildProjectSnapshot() const;
-    bool IsProjectDirty() const;
+    std::wstring BuildProjectSnapshot();
+    bool IsProjectDirty();
     winrt::Windows::Foundation::IAsyncOperation<bool> EnsureProjectSavedBeforeContinuingAsync();
     static MediaInspectionResult InspectMediaFile(std::wstring const& filePath);
     static bool IsSupportedVideoSubtype(_GUID const& subtype);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -48,6 +48,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     winrt::Windows::Foundation::IAsyncAction PropertiesMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     void ExitMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction AboutMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    winrt::Windows::Foundation::IAsyncAction OptionsMenuItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
     void Window_DragOver(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
     winrt::Windows::Foundation::IAsyncAction Window_Drop(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::DragEventArgs const& args);
     void OnClosed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::WindowEventArgs const& args);
@@ -63,6 +64,9 @@ private:
     std::uint64_t m_timelineRenderVersion{0};
     MediaInspectionResult m_mediaInfo{};
     std::vector<winrt::hstring> m_recentVideos{};
+    std::vector<winrt::hstring> m_recentProjects{};
+    std::uint32_t m_maxRecentVideos{5};
+    std::uint32_t m_maxRecentProjects{5};
     bool m_isClosing{false};
     bool m_isTimelineDragging{false};
     bool m_timelineDragMoved{false};
@@ -75,10 +79,15 @@ private:
     void RestoreWindowPlacement();
     void SaveWindowPlacement() const;
     winrt::Windows::Foundation::IAsyncAction PickAndLoadVideoAsync();
+    void LoadAppSettings();
+    void SaveAppSettings() const;
     void RefreshRecentVideosMenu();
+    void RefreshRecentProjectsMenu();
     void AddRecentVideo(winrt::hstring const& path);
+    void AddRecentProject(winrt::hstring const& path);
     winrt::Windows::Foundation::IAsyncAction ShowInfoDialogAsync(winrt::hstring const& title, winrt::hstring const& message);
     winrt::Windows::Foundation::IAsyncAction ShowPropertiesDialogAsync();
+    winrt::Windows::Foundation::IAsyncAction ShowOptionsDialogAsync();
     static MediaInspectionResult InspectMediaFile(std::wstring const& filePath);
     static bool IsSupportedVideoSubtype(_GUID const& subtype);
     static std::wstring GuidToCodecName(_GUID const& subtype, bool isVideo);


### PR DESCRIPTION
### Motivation
- Provide the requested top-level menus and make the selected actions functional while gating loaded media to a strict, deterministic supported list.
- Surface useful file metadata in a `Properties` dialog so users can inspect container, codecs, duration, size, resolution, FPS and bitrates before previewing.

### Description
- Added a `MenuBar` to the main window and wired the requested actions `Load video`, `Recent videos`, `Properties`, `Exit`, and `About`, leaving other menu entries present but disabled (UI in `Win/llvc/MainWindow.xaml`).
- Implemented menu handlers, recent-video tracking and picker integration via `PickAndLoadVideoAsync`, `RefreshRecentVideosMenu`, and `AddRecentVideo` (changes in `Win/llvc/MainWindow.xaml.h` and `Win/llvc/MainWindow.xaml.cpp`).
- Added deterministic Media Foundation introspection (`InspectMediaFile`) and a `MediaInspectionResult` struct to enumerate streams and extract metadata, requiring exactly one video stream, at most one audio stream, rejecting text/subtitle streams, restricting video codecs to H.264/HEVC, restricting container to MP4/MOV, and performing MFT-based decoder availability checks (specific message for missing HEVC support).
- Hooked validation into `LoadVideoFileAsync` so unsupported files are rejected with a clear status and an info dialog, and populated the `Properties` dialog using the collected metadata.

### Testing
- Executed repository checks `git diff --check` with no problems reported.
- Verified working-tree modifications with `git status --short` to confirm the set of changed files.
- No automated build or runtime tests were executed because the change targets a native WinUI desktop app and requires the Windows Media Foundation runtime and platform-specific environment to exercise end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69962031f2748333a47f86fc233cd49c)