### PR TITLE
llvc: close menu on Tab/Escape focus exit

### DIFF
--- a/Win/llvc/MainWindow.Helpers.cpp
+++ b/Win/llvc/MainWindow.Helpers.cpp
@@ -97,7 +97,7 @@ vector<hstring> splitRecentItems(const wstring& source){
 bool isInMenuSubtree(const DependencyObject& object){
     auto current{object};
     while(current){
-        if(current.try_as<Controls::MenuBar>() || current.try_as<Controls::MenuFlyoutItem>() || current.try_as<Controls::MenuFlyoutSubItem>() || current.try_as<Controls::MenuFlyoutPresenter>()){
+        if(current.try_as<Controls::MenuBar>() || current.try_as<Controls::MenuBarItem>() || current.try_as<Controls::MenuFlyoutItem>() || current.try_as<Controls::MenuFlyoutSubItem>() || current.try_as<Controls::MenuFlyoutPresenter>()){
             return true;
         }
         current = Media::VisualTreeHelper::GetParent(current);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1068,19 +1068,6 @@ void MainWindow::tryFocusTimelineCanvas(FState focusState){
     }
 }
 
-void MainWindow::closeMainMenu(){
-    const auto menuBar{MainMenuBar()};
-    if(!menuBar){
-        return;
-    }
-
-    for(const auto& item: menuBar.Items()){
-        if(const auto menuItem{item.try_as<Controls::MenuBarItem>()}){
-            menuItem.IsSelected(false);
-        }
-    }
-}
-
 bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
     const auto focused{Input::FocusManager::GetFocusedElement(Content().XamlRoot()).try_as<DependencyObject>()};
     const auto focusOnMenu{focused && isInMenuSubtree(focused)};
@@ -1088,8 +1075,15 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
 
     if(!focusInDialog && (args.Key() == VirtualKey::Tab || args.Key() == VirtualKey::Escape)){
         if(focusOnMenu){
-            closeMainMenu();
+            const auto weakThis{get_weak()};
+            DispatcherQueue().TryEnqueue([weakThis]{
+                if(const auto self{weakThis.get()}){
+                    self->tryFocusTimelineCanvas(FocusState::Programmatic);
+                }
+            });
+            return false;
         }
+
         tryFocusTimelineCanvas(FocusState::Programmatic);
         args.Handled(true);
         return true;

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1269,6 +1269,8 @@ AAction MainWindow::recentVideoMenuItem_Click(const Control& sender, const REArg
     if(openFailed){
         co_await showInfoDialogAsync(L"Open failed", L"Could not open selected recent video.");
     }
+
+    tryFocusTimelineCanvas(FocusState::Programmatic);
 }
 
 AAction MainWindow::recentProjectMenuItem_Click(const Control& sender, const REArgs&){
@@ -1293,6 +1295,8 @@ AAction MainWindow::recentProjectMenuItem_Click(const Control& sender, const REA
     if(openFailed){
         co_await showInfoDialogAsync(L"Open failed", L"Could not open selected recent project.");
     }
+
+    tryFocusTimelineCanvas(FocusState::Programmatic);
 }
 
 AAction MainWindow::propertiesMenuItem_Click(const Control&, const REArgs&){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1068,12 +1068,28 @@ void MainWindow::tryFocusTimelineCanvas(FState focusState){
     }
 }
 
+void MainWindow::closeMainMenu(){
+    const auto menuBar{MainMenuBar()};
+    if(!menuBar){
+        return;
+    }
+
+    for(const auto& item: menuBar.Items()){
+        if(const auto menuItem{item.try_as<Controls::MenuBarItem>()}){
+            menuItem.IsSelected(false);
+        }
+    }
+}
+
 bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
     const auto focused{Input::FocusManager::GetFocusedElement(Content().XamlRoot()).try_as<DependencyObject>()};
     const auto focusOnMenu{focused && isInMenuSubtree(focused)};
     const auto focusInDialog{focused && isInDialogSubtree(focused)};
 
     if(!focusInDialog && (args.Key() == VirtualKey::Tab || args.Key() == VirtualKey::Escape)){
+        if(focusOnMenu){
+            closeMainMenu();
+        }
         tryFocusTimelineCanvas(FocusState::Programmatic);
         args.Handled(true);
         return true;

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -156,6 +156,7 @@ private:
     bool trySkipCurrentCutDuringPlayback();
     void stepByFrame(int delta);
     void ensureTimelineCursorVisible(double cursorLeft);
+    void closeMainMenu();
     void tryFocusTimelineCanvas(const FState focusState);
     bool handleStorylineKeyDown(const KRArgs& args);
     void updateAudioUiAndPlaybackState();

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -156,7 +156,6 @@ private:
     bool trySkipCurrentCutDuringPlayback();
     void stepByFrame(int delta);
     void ensureTimelineCursorVisible(double cursorLeft);
-    void closeMainMenu();
     void tryFocusTimelineCanvas(const FState focusState);
     bool handleStorylineKeyDown(const KRArgs& args);
     void updateAudioUiAndPlaybackState();


### PR DESCRIPTION
### Motivation
- Ensure the main menu closes when users press `Tab` or `Escape` to leave the menu so focus correctly returns to the timeline.

### Description
- Treat `Controls::MenuBarItem` as part of the menu subtree by updating `isInMenuSubtree` in `Win/llvc/MainWindow.Helpers.cpp`.
- Add `closeMainMenu()` in `Win/llvc/MainWindow.xaml.cpp` which deselects open `MenuBarItem` entries and call it when `Tab`/`Escape` are handled while focus is on the menu.
- Declare `closeMainMenu()` in `Win/llvc/MainWindow.xaml.h` to expose the new helper in the class interface.

### Testing
- Ran `git diff --check` which produced no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e1ec624b4833386b0aa3b8766518d)