### PR TITLE
Add collapsible source video details panel to preview

### DIFF
--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -46,32 +46,39 @@
             </controls:MenuBarItem>
         </controls:MenuBar>
 
-        <Grid Grid.Row="1">
-            <Border BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="8">
+        <Grid Grid.Row="1" ColumnSpacing="6">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <Grid Grid.Column="0" VerticalAlignment="Stretch">
+                <Button x:Name="VideoDetailsOpenMarker" Width="26" Height="64" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="0"
+                        Content="❯" Click="videoDetailsOpenMarker_Click" ToolTipService.ToolTip="Show source video details"/>
+
+                <Border x:Name="VideoDetailsPanel" Width="340" HorizontalAlignment="Left" VerticalAlignment="Stretch" Padding="10" CornerRadius="4"
+                        BorderBrush="#707070" BorderThickness="1" Background="#E6101010" Visibility="Collapsed">
+                    <Grid ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <ScrollViewer VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel Spacing="6">
+                                <TextBlock Text="Source video details" FontWeight="SemiBold"/>
+                                <TextBlock x:Name="VideoDetailsText" Text="No video is currently loaded." TextWrapping="Wrap"/>
+                            </StackPanel>
+                        </ScrollViewer>
+
+                        <Button Grid.Column="1" x:Name="VideoDetailsCollapseMarker" Width="24" HorizontalAlignment="Right" VerticalAlignment="Stretch" Padding="0"
+                                Content="❮" Click="videoDetailsCollapseMarker_Click" ToolTipService.ToolTip="Collapse details panel"/>
+                    </Grid>
+                </Border>
+            </Grid>
+
+            <Border Grid.Column="1" BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="8">
                 <controls:MediaPlayerElement x:Name="PreviewPlayer" AreTransportControlsEnabled="False"/>
-            </Border>
-
-            <Button x:Name="VideoDetailsOpenMarker" Width="26" Height="64" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="4,0,0,0" Padding="0"
-                    Content="❯" Click="videoDetailsOpenMarker_Click" ToolTipService.ToolTip="Show source video details"/>
-
-            <Border x:Name="VideoDetailsPanel" Width="340" HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="4" Padding="10" CornerRadius="4"
-                    BorderBrush="#707070" BorderThickness="1" Background="#E6101010" Visibility="Collapsed">
-                <Grid ColumnSpacing="8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-
-                    <ScrollViewer VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled">
-                        <StackPanel Spacing="6">
-                            <TextBlock Text="Source video details" FontWeight="SemiBold"/>
-                            <TextBlock x:Name="VideoDetailsText" Text="No video is currently loaded." TextWrapping="Wrap"/>
-                        </StackPanel>
-                    </ScrollViewer>
-
-                    <Button Grid.Column="1" x:Name="VideoDetailsCollapseMarker" Width="24" HorizontalAlignment="Right" VerticalAlignment="Stretch" Padding="0"
-                            Content="❮" Click="videoDetailsCollapseMarker_Click" ToolTipService.ToolTip="Collapse details panel"/>
-                </Grid>
             </Border>
         </Grid>
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -46,9 +46,34 @@
             </controls:MenuBarItem>
         </controls:MenuBar>
 
-        <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="8">
-            <controls:MediaPlayerElement x:Name="PreviewPlayer" AreTransportControlsEnabled="False"/>
-        </Border>
+        <Grid Grid.Row="1">
+            <Border BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="8">
+                <controls:MediaPlayerElement x:Name="PreviewPlayer" AreTransportControlsEnabled="False"/>
+            </Border>
+
+            <Button x:Name="VideoDetailsOpenMarker" Width="26" Height="64" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="4,0,0,0" Padding="0"
+                    Content="❯" Click="videoDetailsOpenMarker_Click" ToolTipService.ToolTip="Show source video details"/>
+
+            <Border x:Name="VideoDetailsPanel" Width="340" HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="4" Padding="10" CornerRadius="4"
+                    BorderBrush="#707070" BorderThickness="1" Background="#E6101010" Visibility="Collapsed">
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <ScrollViewer VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled">
+                        <StackPanel Spacing="6">
+                            <TextBlock Text="Source video details" FontWeight="SemiBold"/>
+                            <TextBlock x:Name="VideoDetailsText" Text="No video is currently loaded." TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </ScrollViewer>
+
+                    <Button Grid.Column="1" x:Name="VideoDetailsCollapseMarker" Width="24" HorizontalAlignment="Right" VerticalAlignment="Stretch" Padding="0"
+                            Content="❮" Click="videoDetailsCollapseMarker_Click" ToolTipService.ToolTip="Collapse details panel"/>
+                </Grid>
+            </Border>
+        </Grid>
 
         <Grid Grid.Row="2" RowSpacing="6">
             <Grid.RowDefinitions>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -56,20 +56,15 @@
 
             <Border x:Name="VideoDetailsPanel" Width="340" HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="4" Padding="10" CornerRadius="4"
                     BorderBrush="#707070" BorderThickness="1" Background="#E6101010" Visibility="Collapsed">
-                <Grid ColumnSpacing="8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-
-                    <ScrollViewer VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled">
+                <Grid>
+                    <ScrollViewer Margin="0,0,30,0" VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled">
                         <StackPanel Spacing="6">
                             <TextBlock Text="Source video details" FontWeight="SemiBold"/>
                             <TextBlock x:Name="VideoDetailsText" Text="No video is currently loaded." TextWrapping="Wrap"/>
                         </StackPanel>
                     </ScrollViewer>
 
-                    <Button Grid.Column="1" x:Name="VideoDetailsCollapseMarker" Width="24" HorizontalAlignment="Right" VerticalAlignment="Stretch" Padding="0"
+                    <Button x:Name="VideoDetailsCollapseMarker" Width="24" HorizontalAlignment="Right" VerticalAlignment="Stretch" Padding="0"
                             Content="❮" Click="videoDetailsCollapseMarker_Click" ToolTipService.ToolTip="Collapse details panel"/>
                 </Grid>
             </Border>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -46,39 +46,32 @@
             </controls:MenuBarItem>
         </controls:MenuBar>
 
-        <Grid Grid.Row="1" ColumnSpacing="6">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-
-            <Grid Grid.Column="0" VerticalAlignment="Stretch">
-                <Button x:Name="VideoDetailsOpenMarker" Width="26" Height="64" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="0"
-                        Content="❯" Click="videoDetailsOpenMarker_Click" ToolTipService.ToolTip="Show source video details"/>
-
-                <Border x:Name="VideoDetailsPanel" Width="340" HorizontalAlignment="Left" VerticalAlignment="Stretch" Padding="10" CornerRadius="4"
-                        BorderBrush="#707070" BorderThickness="1" Background="#E6101010" Visibility="Collapsed">
-                    <Grid ColumnSpacing="8">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-
-                        <ScrollViewer VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled">
-                            <StackPanel Spacing="6">
-                                <TextBlock Text="Source video details" FontWeight="SemiBold"/>
-                                <TextBlock x:Name="VideoDetailsText" Text="No video is currently loaded." TextWrapping="Wrap"/>
-                            </StackPanel>
-                        </ScrollViewer>
-
-                        <Button Grid.Column="1" x:Name="VideoDetailsCollapseMarker" Width="24" HorizontalAlignment="Right" VerticalAlignment="Stretch" Padding="0"
-                                Content="❮" Click="videoDetailsCollapseMarker_Click" ToolTipService.ToolTip="Collapse details panel"/>
-                    </Grid>
-                </Border>
-            </Grid>
-
-            <Border Grid.Column="1" BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="8">
+        <Grid Grid.Row="1">
+            <Border BorderBrush="Gray" BorderThickness="1" CornerRadius="4" Padding="8">
                 <controls:MediaPlayerElement x:Name="PreviewPlayer" AreTransportControlsEnabled="False"/>
+            </Border>
+
+            <Button x:Name="VideoDetailsOpenMarker" Width="26" Height="64" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="4,0,0,0" Padding="0"
+                    Content="❯" Click="videoDetailsOpenMarker_Click" ToolTipService.ToolTip="Show source video details"/>
+
+            <Border x:Name="VideoDetailsPanel" Width="340" HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="4" Padding="10" CornerRadius="4"
+                    BorderBrush="#707070" BorderThickness="1" Background="#E6101010" Visibility="Collapsed">
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <ScrollViewer VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled">
+                        <StackPanel Spacing="6">
+                            <TextBlock Text="Source video details" FontWeight="SemiBold"/>
+                            <TextBlock x:Name="VideoDetailsText" Text="No video is currently loaded." TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </ScrollViewer>
+
+                    <Button Grid.Column="1" x:Name="VideoDetailsCollapseMarker" Width="24" HorizontalAlignment="Right" VerticalAlignment="Stretch" Padding="0"
+                            Content="❮" Click="videoDetailsCollapseMarker_Click" ToolTipService.ToolTip="Collapse details panel"/>
+                </Grid>
             </Border>
         </Grid>
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -76,23 +76,21 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <Grid VerticalAlignment="Center">
-                <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
-                    <TextBlock Text="Zoom" VerticalAlignment="Center"/>
-                    <Slider x:Name="TimelineZoomSlider" Width="240" IsTabStop="False" Minimum="1" Maximum="12" Value="2" SmallChange="0.25" LargeChange="1" ValueChanged="timelineZoomSlider_ValueChanged"/>
-                    <CheckBox x:Name="KeepAudioCheckBox" Content="Keep audio" IsEnabled="False" VerticalAlignment="Center" Checked="keepAudioCheckBox_Changed" Unchecked="keepAudioCheckBox_Changed"/>
-                    <TextBlock Text="Audio cross-fade:" VerticalAlignment="Center"/>
-                    <ComboBox x:Name="AudioCrossfadeComboBox" Width="120" IsEnabled="False" SelectionChanged="audioCrossfadeComboBox_SelectionChanged">
-                        <ComboBoxItem Content="0 ms" Tag="0"/>
-                        <ComboBoxItem Content="50 ms" Tag="50"/>
-                        <ComboBoxItem Content="100 ms" Tag="100"/>
-                        <ComboBoxItem Content="250 ms" Tag="250"/>
-                        <ComboBoxItem Content="500 ms" Tag="500"/>
-                        <ComboBoxItem Content="750 ms" Tag="750"/>
-                        <ComboBoxItem Content="1 s" Tag="1000"/>
-                    </ComboBox>
-                </StackPanel>
-            </Grid>
+            <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                <TextBlock Text="Zoom" VerticalAlignment="Center"/>
+                <Slider x:Name="TimelineZoomSlider" Width="240" IsTabStop="False" Minimum="1" Maximum="12" Value="2" SmallChange="0.25" LargeChange="1" ValueChanged="timelineZoomSlider_ValueChanged"/>
+                <CheckBox x:Name="KeepAudioCheckBox" Content="Keep audio" IsEnabled="False" VerticalAlignment="Center" Checked="keepAudioCheckBox_Changed" Unchecked="keepAudioCheckBox_Changed"/>
+                <TextBlock Text="Audio cross-fade:" VerticalAlignment="Center"/>
+                <ComboBox x:Name="AudioCrossfadeComboBox" Width="120" IsEnabled="False" SelectionChanged="audioCrossfadeComboBox_SelectionChanged">
+                    <ComboBoxItem Content="0 ms" Tag="0"/>
+                    <ComboBoxItem Content="50 ms" Tag="50"/>
+                    <ComboBoxItem Content="100 ms" Tag="100"/>
+                    <ComboBoxItem Content="250 ms" Tag="250"/>
+                    <ComboBoxItem Content="500 ms" Tag="500"/>
+                    <ComboBoxItem Content="750 ms" Tag="750"/>
+                    <ComboBoxItem Content="1 s" Tag="1000"/>
+                </ComboBox>
+            </StackPanel>
 
             <Border Grid.Row="1" BorderThickness="1" BorderBrush="#404040" Background="#111111" CornerRadius="4" Padding="6">
                 <Grid RowSpacing="4">
@@ -102,7 +100,7 @@
                     </Grid.RowDefinitions>
 
                     <ScrollViewer x:Name="TimelineScrollViewer" HorizontalScrollBarVisibility="Hidden" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" VerticalScrollBarVisibility="Disabled" ViewChanged="timelineScrollViewer_ViewChanged" SizeChanged="timelineScrollViewer_SizeChanged">
-                        <StackPanel Orientation="Vertical" Spacing="4">
+                        <StackPanel Spacing="4">
                             <Canvas x:Name="TimelineTickCanvas" Height="24" Background="#222222" PointerReleased="timelineTickCanvas_PointerReleased"/>
                             <Canvas x:Name="TimelineCanvas" Height="86" IsTabStop="True" Loaded="timelineCanvas_Loaded" PointerPressed="timelineCanvas_PointerPressed" PointerMoved="timelineCanvas_PointerMoved" PointerReleased="timelineCanvas_PointerReleased" PointerCanceled="timelineCanvas_PointerCanceled" PointerCaptureLost="timelineCanvas_PointerCaptureLost" Background="#111111">
                                 <Canvas x:Name="ThumbnailLayer" Height="86"/>
@@ -119,9 +117,7 @@
             </Border>
         </Grid>
 
-        <StackPanel Grid.Row="3" Spacing="4">
-            <TextBlock x:Name="StatusText" Text="Load or drag-and-drop an .mp4/.mov file to preview."/>
-        </StackPanel>
+        <TextBlock Grid.Row="3" x:Name="StatusText" Text="Load or drag-and-drop an .mp4/.mov file to preview."/>
 
         <StackPanel Grid.Row="4" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
             <Button x:Name="StartButton" Content="Start" IsTabStop="False" Click="startButton_Click"/>

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -437,6 +437,8 @@ MainWindow::MainWindow(){
 
     syncAudioCrossfadeComboSelection();
     updateAudioUiAndPlaybackState();
+    refreshVideoDetailsPanel();
+    setVideoDetailsPanelExpanded(false);
 
     restoreWindowPlacement();
     loadAppSettings();
@@ -1157,7 +1159,32 @@ void MainWindow::rootGrid_PointerReleased(const Control&, const PREArgs& args){
     if(isInMenuSubtree(source) || isInDialogSubtree(source)){
         return;
     }
+
+    if(VideoDetailsPanel().Visibility() == Visibility::Visible){
+        auto current{source};
+        auto clickedInsideDetailsPanel{false};
+        while(current){
+            if(current == VideoDetailsPanel()){
+                clickedInsideDetailsPanel = true;
+                break;
+            }
+            current = Media::VisualTreeHelper::GetParent(current);
+        }
+
+        if(!clickedInsideDetailsPanel){
+            setVideoDetailsPanelExpanded(false);
+        }
+    }
+
     tryFocusTimelineCanvas(FocusState::Programmatic);
+}
+
+void MainWindow::videoDetailsOpenMarker_Click(const Control&, const REArgs&){
+    setVideoDetailsPanelExpanded(true);
+}
+
+void MainWindow::videoDetailsCollapseMarker_Click(const Control&, const REArgs&){
+    setVideoDetailsPanelExpanded(false);
 }
 
 TS MainWindow::secondsToTimeSpan(double seconds){
@@ -1404,6 +1431,8 @@ void MainWindow::resetProjectState(){
     m_mediaInfo = {};
     m_timelineDurationSeconds = 0;
     TimelineZoomSlider().Value(m_prj.zoom());
+    refreshVideoDetailsPanel();
+    setVideoDetailsPanelExpanded(false);
     syncAudioCrossfadeComboSelection();
     updateAudioUiAndPlaybackState();
 
@@ -1513,6 +1542,14 @@ AAction MainWindow::showPropertiesDialogAsync(){
         co_return;
     }
 
+    co_await showInfoDialogAsync(L"Properties", hstring(buildSourcePropertiesText()));
+}
+
+wstring MainWindow::buildSourcePropertiesText() const{
+    if(!m_prj.videoFile() || !m_mediaInfo.isValid){
+        return L"No video is currently loaded.";
+    }
+
     wstring content;
     content += L"File: "; content += m_prj.videoFile().Path().c_str(); content += L"\n";
     content += L"Container: "; content += m_mediaInfo.container; content += L"\n";
@@ -1528,8 +1565,16 @@ AAction MainWindow::showPropertiesDialogAsync(){
     content += L"Max random access spacing: "; content += m_mediaInfo.maxKeyFrameSpacing; content += L"\n";
     content += L"Audio codec: "; content += m_mediaInfo.audioCodec; content += L"\n";
     content += L"Audio bitrate: "; content += m_mediaInfo.audioBitrate;
+    return content;
+}
 
-    co_await showInfoDialogAsync(L"Properties", hstring(content));
+void MainWindow::setVideoDetailsPanelExpanded(bool expanded){
+    VideoDetailsPanel().Visibility(expanded ? Visibility::Visible : Visibility::Collapsed);
+    VideoDetailsOpenMarker().Visibility(expanded ? Visibility::Collapsed : Visibility::Visible);
+}
+
+void MainWindow::refreshVideoDetailsPanel(){
+    VideoDetailsText().Text(buildSourcePropertiesText());
 }
 
 AAction MainWindow::showOptionsDialogAsync(){
@@ -1808,6 +1853,7 @@ AAction MainWindow::loadVideoFileAsync(const SFile& file){
     const auto basicProperties{co_await file.GetBasicPropertiesAsync()};
     inspected.fileSize = formatFileSize(basicProperties.Size());
     m_mediaInfo = inspected;
+    refreshVideoDetailsPanel();
 
     wstring status{L"Loaded: "};
     status += file.Name().c_str();

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1853,7 +1853,6 @@ AAction MainWindow::loadVideoFileAsync(const SFile& file){
     const auto basicProperties{co_await file.GetBasicPropertiesAsync()};
     inspected.fileSize = formatFileSize(basicProperties.Size());
     m_mediaInfo = inspected;
-    refreshVideoDetailsPanel();
 
     wstring status{L"Loaded: "};
     status += file.Name().c_str();
@@ -1864,6 +1863,7 @@ AAction MainWindow::loadVideoFileAsync(const SFile& file){
     m_player.Source(source);
     m_player.IsMuted(false);
     m_prj.videoFile(file);
+    refreshVideoDetailsPanel();
     addRecentVideo(file.Path());
 
     ThumbnailLayer().Children().Clear();

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -81,6 +81,8 @@ struct MainWindow: MainWindowT<MainWindow>{
     void window_PreviewKeyDown(const Control& sender, const KRArgs& args);
     void window_KeyDown(const Control& sender, const KRArgs& args);
     void rootGrid_PointerReleased(const Control& sender, const PREArgs& args);
+    void videoDetailsOpenMarker_Click(const Control& sender, const REArgs& args);
+    void videoDetailsCollapseMarker_Click(const Control& sender, const REArgs& args);
     AAction newProjectMenuItem_Click(const Control& sender, const REArgs& args);
     AAction openProjectMenuItem_Click(const Control& sender, const REArgs& args);
     AAction saveProjectMenuItem_Click(const Control& sender, const REArgs& args);
@@ -159,6 +161,9 @@ private:
     void tryFocusTimelineCanvas(const FState focusState);
     bool handleStorylineKeyDown(const KRArgs& args);
     void updateAudioUiAndPlaybackState();
+    void setVideoDetailsPanelExpanded(bool expanded);
+    void refreshVideoDetailsPanel();
+    wstring buildSourcePropertiesText() const;
     void applyAudioSettingsToPlayer();
     void syncAudioCrossfadeComboSelection();
     bool sourceHasAudio() const;


### PR DESCRIPTION
### Motivation
- Provide a quick-access fly-out over the video preview to show the source video's properties (same info as File→Properties) without opening a dialog. 
- Allow the user to open/close the panel via a left-edge marker and an in-panel collapse marker, with click-away to close for a natural UX. 
- Make the details content vertically scrollable so the panel works on small window geometries.

### Description
- Added UI markup in `Win/llvc/MainWindow.xaml` to overlay a left-edge open marker button (`VideoDetailsOpenMarker`) and a collapsible `VideoDetailsPanel` containing a `ScrollViewer` and `VideoDetailsText` TextBlock. 
- Declared new handlers and helpers in `Win/llvc/MainWindow.xaml.h`: `videoDetailsOpenMarker_Click`, `videoDetailsCollapseMarker_Click`, `setVideoDetailsPanelExpanded`, `refreshVideoDetailsPanel`, and `buildSourcePropertiesText`. 
- Implemented behavior in `Win/llvc/MainWindow.xaml.cpp` including the open/collapse handlers, click-away collapse logic inside `rootGrid_PointerReleased`, and helper implementations; the panel is refreshed on startup, on project reset, and after `loadVideoFileAsync`. 
- Refactored property text building into `buildSourcePropertiesText()` and reused it for the File→Properties dialog and the new panel to keep content consistent.
- Files changed: `Win/llvc/MainWindow.xaml`, `Win/llvc/MainWindow.xaml.h`, `Win/llvc/MainWindow.xaml.cpp`.

### Testing
- Ran repository checks (`git status --short`) and committed the changes successfully. 
- Verified code edits locally by grepping and inspecting the modified files to ensure handlers and helpers are wired up. 
- Attempted to run a build validation (`msbuild`) but no `msbuild` was available in this environment so a full WinUI build/test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e226daccc8333bcdf612404e2db94)