### PR TITLE
llvc: preserve source metadata and add export provenance tag

### DIFF
--- a/Win/llvc/Export.ixx
+++ b/Win/llvc/Export.ixx
@@ -17,7 +17,13 @@
 #include <mfobjects.h>
 #include <mfreadwrite.h>
 
+#include <propkey.h>
+#include <propsys.h>
+#include <propvarutil.h>
+
 #include <shobjidl_core.h>
+
+#include <wil/resource.h>
 
 export module llvc.Export;
 
@@ -51,6 +57,7 @@ void appendCrossfadedAudioSegment(vector<float>& mixedAudio, const vector<float>
 vector<float> buildMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs);
 void writePcmAudioToWriter(const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, const vector<float>& mixedAudio, uint32_t audioChannels, uint32_t audioSampleRate);
 VideoWriteStats writeVideoSamplesForExport(const com_ptr<IMFSourceReader>& reader, DWORD videoStreamIndex, const com_ptr<IMFSinkWriter>& writer, DWORD writerVideoStreamIndex, const vector<pair<int64_t, int64_t>>& effectiveCutRanges100ns, GUID videoSubtype, uint32_t nalLengthFieldSize, int64_t sourceDuration100ns, const function<void(double)>& progressCallback);
+void applyExportFileMetadata(const std::wstring& sourcePath, const std::wstring& outputPath, const std::wstring& exportComment);
 
 }
 
@@ -588,6 +595,41 @@ VideoWriteStats writeVideoSamplesForExport(const com_ptr<IMFSourceReader>& reade
         progressCallback(100.0);
     }
     return stats;
+}
+
+void applyExportFileMetadata(const std::wstring& sourcePath, const std::wstring& outputPath, const std::wstring& exportComment){
+    wil::unique_hfile sourceHandle{::CreateFileW(sourcePath.c_str(), FILE_READ_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
+    if(sourceHandle){
+        FILETIME creationTime{};
+        FILETIME lastAccessTime{};
+        FILETIME lastWriteTime{};
+        if(::GetFileTime(sourceHandle.get(), &creationTime, &lastAccessTime, &lastWriteTime)){
+            wil::unique_hfile outputHandle{::CreateFileW(outputPath.c_str(), FILE_WRITE_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
+            if(outputHandle){
+                (void)::SetFileTime(outputHandle.get(), &creationTime, &lastAccessTime, &lastWriteTime);
+            }
+        }
+    }
+
+    com_ptr<IPropertyStore> propertyStore;
+    const auto propertyStoreHr{SHGetPropertyStoreFromParsingName(outputPath.c_str(), nullptr, GPS_READWRITE, IID_PPV_ARGS(propertyStore.put()))};
+    if(SUCCEEDED(propertyStoreHr) && propertyStore){
+        PROPVARIANT encodedByValue{};
+        if(SUCCEEDED(InitPropVariantFromString(L"llvc", &encodedByValue))){
+            (void)propertyStore->SetValue(PKEY_Media_EncodedBy, encodedByValue);
+            PropVariantClear(&encodedByValue);
+        }
+
+        if(!exportComment.empty()){
+            PROPVARIANT commentValue{};
+            if(SUCCEEDED(InitPropVariantFromString(exportComment.c_str(), &commentValue))){
+                (void)propertyStore->SetValue(PKEY_Comment, commentValue);
+                PropVariantClear(&commentValue);
+            }
+        }
+
+        (void)propertyStore->Commit();
+    }
 }
 
 }

--- a/Win/llvc/MainWindow.Export.cpp
+++ b/Win/llvc/MainWindow.Export.cpp
@@ -6,6 +6,8 @@
 #include <limits>
 
 #include <algorithm>
+#include <chrono>
+#include <ctime>
 
 #include <mfapi.h>
 #include <mferror.h>
@@ -40,6 +42,22 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
     const auto outputDuration100ns{m_prj.outputDuration100ns(m_timelineDurationSeconds)};
 
     const filesystem::path sourceFsPath{sourcePath};
+
+    auto makeExportComment = [&](const filesystem::path& sourcePathForComment) -> wstring {
+        const auto now{chrono::system_clock::now()};
+        const auto nowTimeT{chrono::system_clock::to_time_t(now)};
+        tm localTime{};
+        if(localtime_s(&localTime, &nowTimeT) != 0){
+            return L"created by llvc from " + sourcePathForComment.filename().wstring();
+        }
+
+        wchar_t timestamp[64]{};
+        if(wcsftime(timestamp, size(timestamp), L"%Y-%m-%d %H:%M:%S", &localTime) == 0){
+            return L"created by llvc from " + sourcePathForComment.filename().wstring();
+        }
+
+        return L"created by llvc from " + sourcePathForComment.filename().wstring() + L" on " + timestamp;
+    };
     const auto sourceExt{sourceFsPath.extension().wstring()};
     const auto defaultExt{_wcsicmp(sourceExt.c_str(), L".mov") == 0 ? L".mov" : L".mp4"};
 
@@ -58,6 +76,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
 
     winrt::hstring exportErrorMessage{};
     auto exportSucceeded{false};
+    const auto exportComment{makeExportComment(sourceFsPath)};
 
     winrt::apartment_context uiThread;
     co_await winrt::resume_background();
@@ -252,6 +271,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
         }
 
         check_hresult(writer->Finalize());
+        applyExportFileMetadata(sourcePath, outputPath, exportComment);
         exportSucceeded = true;
     }catch(const hresult_error& ex){
         exportErrorMessage = ex.message();

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -27,6 +27,9 @@
 #include <mfreadwrite.h>
 
 #include <microsoft.ui.xaml.window.h>
+#include <propkey.h>
+#include <propsys.h>
+#include <propvarutil.h>
 #include <shobjidl_core.h>
 #include <winrt/Windows.Storage.FileProperties.h>
 #include <winrt/Microsoft.UI.Input.h>
@@ -80,6 +83,33 @@ using IOpBool = MainWindow::IOpBool;
 using TS = MainWindow::TS;
 
 constexpr auto W_POS_L{L"WindowLeft"};
+
+namespace{
+
+std::wstring readShellStringProperty(const std::wstring& filePath, const PROPERTYKEY& key){
+    winrt::com_ptr<IPropertyStore> propertyStore;
+    const auto hr{SHGetPropertyStoreFromParsingName(filePath.c_str(), nullptr, GPS_BESTEFFORT, IID_PPV_ARGS(propertyStore.put()))};
+    if(FAILED(hr) || !propertyStore){
+        return {};
+    }
+
+    PROPVARIANT value{};
+    PropVariantInit(&value);
+
+    std::wstring text;
+    if(SUCCEEDED(propertyStore->GetValue(key, &value))){
+        PWSTR converted{};
+        if(SUCCEEDED(PropVariantToStringAlloc(value, &converted)) && converted){
+            text = converted;
+            ::CoTaskMemFree(converted);
+        }
+    }
+
+    PropVariantClear(&value);
+    return text;
+}
+
+}
 constexpr auto W_POS_T{L"WindowTop"};
 constexpr auto W_POS_W{L"WindowWidth"};
 constexpr auto W_POS_H{L"WindowHeight"};
@@ -1264,6 +1294,8 @@ wstring MainWindow::buildSourcePropertiesText() const{
     content += L"Size: "; content += m_mediaInfo.fileSize; content += L"\n";
     content += L"Created: "; content += m_mediaInfo.sourceCreated; content += L"\n";
     content += L"Modified: "; content += m_mediaInfo.sourceModified; content += L"\n";
+    content += L"Encoded by: "; content += (m_mediaInfo.sourceEncodedBy.empty() ? L"-" : m_mediaInfo.sourceEncodedBy); content += L"\n";
+    content += L"Comment: "; content += (m_mediaInfo.sourceComment.empty() ? L"-" : m_mediaInfo.sourceComment); content += L"\n";
     content += L"Video codec: "; content += m_mediaInfo.videoCodec; content += L"\n";
     content += L"Resolution: "; content += m_mediaInfo.resolution; content += L"\n";
     content += L"FPS: "; content += formatRatio(m_mediaInfo.frameRate.num, m_mediaInfo.frameRate.den, L" fps"); content += L"\n";
@@ -1560,6 +1592,9 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
     if(videoStreamIndex != invalidStreamIndex){
         analyzeKeyFrameCadence(reader.get(), videoStreamIndex, fpsNum, fpsDen, result);
     }
+
+    result.sourceEncodedBy = readShellStringProperty(filePath, PKEY_Media_EncodedBy);
+    result.sourceComment = readShellStringProperty(filePath, PKEY_Comment);
     result.isValid = true;
     return result;
 }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -5,8 +5,10 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstring>
+#include <ctime>
 #include <cwctype>
 #include <cwchar>
 #include <filesystem>
@@ -1260,6 +1262,8 @@ wstring MainWindow::buildSourcePropertiesText() const{
     content += L"Container: "; content += m_mediaInfo.container; content += L"\n";
     content += L"Duration: "; content += m_mediaInfo.duration; content += L"\n";
     content += L"Size: "; content += m_mediaInfo.fileSize; content += L"\n";
+    content += L"Created: "; content += m_mediaInfo.sourceCreated; content += L"\n";
+    content += L"Modified: "; content += m_mediaInfo.sourceModified; content += L"\n";
     content += L"Video codec: "; content += m_mediaInfo.videoCodec; content += L"\n";
     content += L"Resolution: "; content += m_mediaInfo.resolution; content += L"\n";
     content += L"FPS: "; content += formatRatio(m_mediaInfo.frameRate.num, m_mediaInfo.frameRate.den, L" fps"); content += L"\n";
@@ -1289,6 +1293,22 @@ wstring MainWindow::formatTimelineDurationText(int64_t duration100ns){
     const auto seconds{(totalMs / 1'000) % 60};
     const auto millis{totalMs % 1'000};
     return std::format(L"{:02}:{:02}.{:03}", minutes, seconds, millis);
+}
+
+
+wstring MainWindow::formatDateTimeText(const winrt::Windows::Foundation::DateTime& value){
+    const auto asTimeT{winrt::clock::to_time_t(value)};
+    tm localTime{};
+    if(localtime_s(&localTime, &asTimeT) != 0){
+        return L"-";
+    }
+
+    wchar_t timestamp[64]{};
+    if(wcsftime(timestamp, size(timestamp), L"%Y-%m-%d %H:%M:%S", &localTime) == 0){
+        return L"-";
+    }
+
+    return timestamp;
 }
 
 void MainWindow::setStatusMessage(const wstring& message){
@@ -1608,6 +1628,8 @@ AAction MainWindow::loadVideoFileAsync(const SFile& file){
 
     const auto basicProperties{co_await file.GetBasicPropertiesAsync()};
     inspected.fileSize = formatFileSize(basicProperties.Size());
+    inspected.sourceCreated = formatDateTimeText(file.DateCreated());
+    inspected.sourceModified = formatDateTimeText(basicProperties.DateModified());
     m_mediaInfo = inspected;
 
     wstring status{L"Loaded: "};

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -31,6 +31,8 @@ struct MediaInspectionResult{
     wstring audioCodec{};
     wstring duration{};
     wstring fileSize{};
+    wstring sourceCreated{};
+    wstring sourceModified{};
     wstring resolution{};
     Ratio frameRate{};
     wstring videoBitrate{};
@@ -175,6 +177,7 @@ private:
     void setOperationInProgress(bool active, bool indeterminate = false);
     void setOperationProgress(double percent);
     static wstring formatTimelineDurationText(int64_t duration100ns);
+    static wstring formatDateTimeText(const winrt::Windows::Foundation::DateTime& value);
     bool sourceHasAudio() const;
     static TS secondsToTimeSpan(double seconds);
     static bool isRectVisibleOnAnyMonitor(const RECT& rect);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -33,6 +33,8 @@ struct MediaInspectionResult{
     wstring fileSize{};
     wstring sourceCreated{};
     wstring sourceModified{};
+    wstring sourceEncodedBy{};
+    wstring sourceComment{};
     wstring resolution{};
     Ratio frameRate{};
     wstring videoBitrate{};


### PR DESCRIPTION
### Motivation

- Preserve source file timestamps and tag exported files with provenance so exports retain original creation/modification metadata and an author/comment stamp.
- Provide a human-readable provenance note like `created by llvc from <original filename> on <date/time>` in the output file properties.

### Description

- Add `applyExportFileMetadata(const std::wstring& sourcePath, const std::wstring& outputPath, const std::wstring& exportComment)` in `Win/llvc/Export.ixx` that copies source file times (creation/access/modified) to the exported file and writes `PKEY_Media_EncodedBy = llvc` and `PKEY_Comment = <exportComment>` to the output's property store as a best-effort operation.
- Export the new helper by adding its declaration to the `llvc.Export` module and include the required headers (`<propkey.h>`, `<propsys.h>`, `<propvarutil.h>`, and `<wil/resource.h>`).
- Generate a timestamped provenance string in the export flow by adding a `makeExportComment` lambda to `Win/llvc/MainWindow.Export.cpp` that produces `created by llvc from <filename> on <YYYY-MM-DD HH:MM:SS>` and pass it through the export flow as `exportComment`.
- Invoke `applyExportFileMetadata` immediately after `writer->Finalize()` in the successful export path so metadata is applied once the sink writer finishes.

### Testing

- Ran `git diff --check` to verify there are no whitespace/patch issues and the diff is clean (succeeded).
- Changes were committed to the branch as `llvc: preserve source metadata on export and tag output`; no build or runtime tests were executed in this rollout (metadata write is implemented as best-effort so export still succeeds if property store operations fail).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec239d2dc83338a80c188b9ca1de7)