### PR TITLE
Add strict AVI (H.264-only) input gating with MP4-only passthrough export in llvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ If you find something useful and want to suggest improvements, feel free to open
 
 - The **ATT addon community** for their work on collection tracking.  
 - Open-source contributors everywhere — standing on your shoulders makes side projects way more fun.
+
+## llvc (WinUI) manual test checklist
+
+- H264-in-AVI opens successfully, keyframe/index inspection succeeds, and MP4 export plays without visible video artifacts.
+- CRAM/MJPG/Xvid/DivX (or other non-H264) AVI files are rejected with a codec-specific AVI v1 message.
+- AVI files lacking robust timestamps or reliable sync/keyframe flags are rejected with guidance to convert to MP4 first.

--- a/Win/llvc/Export.ixx
+++ b/Win/llvc/Export.ixx
@@ -52,7 +52,7 @@ com_ptr<IMFMediaType> createPcmFloatAudioType(uint32_t sampleRate, uint32_t chan
 com_ptr<IMFMediaType> createAacOutputType(uint32_t sampleRate, uint32_t channels);
 vector<float> decodeAudioRangeToFloat(const com_ptr<IMFSourceReader>& reader, DWORD audioStreamIndex, int64_t rangeStart100ns, int64_t rangeEnd100ns, uint32_t channels, uint32_t sampleRate);
 
-wstring pickExportOutputPath(const std::filesystem::path& sourceFsPath, const wchar_t* defaultExt, int64_t outputDuration100ns, HWND ownerWindow);
+wstring pickExportOutputPath(const std::filesystem::path& sourceFsPath, const wchar_t* defaultExt, int64_t outputDuration100ns, HWND ownerWindow, bool mp4Only);
 void appendCrossfadedAudioSegment(vector<float>& mixedAudio, const vector<float>& segmentAudio, uint32_t audioChannels, size_t fadeFrames);
 vector<float> buildMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs);
 void writePcmAudioToWriter(const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, const vector<float>& mixedAudio, uint32_t audioChannels, uint32_t audioSampleRate);
@@ -354,7 +354,7 @@ vector<float> decodeAudioRangeToFloat(const com_ptr<IMFSourceReader>& reader, DW
     return out;
 }
 
-wstring pickExportOutputPath(const std::filesystem::path& sourceFsPath, const wchar_t* defaultExt, int64_t outputDuration100ns, HWND ownerWindow){
+wstring pickExportOutputPath(const std::filesystem::path& sourceFsPath, const wchar_t* defaultExt, int64_t outputDuration100ns, HWND ownerWindow, bool mp4Only){
     com_ptr<IFileSaveDialog> saveDialog;
     check_hresult(::CoCreateInstance(CLSID_FileSaveDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(saveDialog.put())));
 
@@ -362,15 +362,24 @@ wstring pickExportOutputPath(const std::filesystem::path& sourceFsPath, const wc
     check_hresult(saveDialog->GetOptions(&options));
     check_hresult(saveDialog->SetOptions(options | FOS_FORCEFILESYSTEM | FOS_OVERWRITEPROMPT));
 
-    const COMDLG_FILTERSPEC fileTypes[]{
-        {L"MP4 video", L"*.mp4"},
-        {L"MOV video", L"*.mov"},
-    };
-    check_hresult(saveDialog->SetFileTypes(static_cast<UINT>(size(fileTypes)), fileTypes));
+    if(mp4Only){
+        const COMDLG_FILTERSPEC fileTypes[]{
+            {L"MP4 video", L"*.mp4"},
+        };
+        check_hresult(saveDialog->SetFileTypes(static_cast<UINT>(size(fileTypes)), fileTypes));
+        check_hresult(saveDialog->SetFileTypeIndex(1));
+        check_hresult(saveDialog->SetDefaultExtension(L"mp4"));
+    }else{
+        const COMDLG_FILTERSPEC fileTypes[]{
+            {L"MP4 video", L"*.mp4"},
+            {L"MOV video", L"*.mov"},
+        };
+        check_hresult(saveDialog->SetFileTypes(static_cast<UINT>(size(fileTypes)), fileTypes));
 
-    const auto isMovDefault{_wcsicmp(defaultExt, L".mov") == 0};
-    check_hresult(saveDialog->SetFileTypeIndex(isMovDefault ? 2U : 1U));
-    check_hresult(saveDialog->SetDefaultExtension(isMovDefault ? L"mov" : L"mp4"));
+        const auto isMovDefault{_wcsicmp(defaultExt, L".mov") == 0};
+        check_hresult(saveDialog->SetFileTypeIndex(isMovDefault ? 2U : 1U));
+        check_hresult(saveDialog->SetDefaultExtension(isMovDefault ? L"mov" : L"mp4"));
+    }
 
     const auto suggestedName{sourceFsPath.stem().wstring() + L" - " + formatDurationFileTag(outputDuration100ns)};
     check_hresult(saveDialog->SetFileName(suggestedName.c_str()));

--- a/Win/llvc/MainWindow.Export.cpp
+++ b/Win/llvc/MainWindow.Export.cpp
@@ -154,13 +154,15 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
             if(videoSubtype != MFVideoFormat_H264){
                 throw hresult_error(MF_E_INVALIDMEDIATYPE, L"AVI is supported only for H.264 video in v1.");
             }
-            UINT8* sequenceHeader{};
             UINT32 sequenceHeaderSize{};
-            const auto seqHr{sourceVideoType->GetAllocatedBlob(MF_MT_MPEG_SEQUENCE_HEADER, &sequenceHeader, &sequenceHeaderSize)};
-            if(SUCCEEDED(seqHr) && sequenceHeader){
-                CoTaskMemFree(sequenceHeader);
-            }
-            if(FAILED(seqHr) || sequenceHeaderSize == 0){
+            const auto seqSizeHr{sourceVideoType->GetBlobSize(MF_MT_MPEG_SEQUENCE_HEADER, &sequenceHeaderSize)};
+            std::vector<uint8_t> sequenceHeader(sequenceHeaderSize);
+            UINT32 bytesWritten{};
+            const auto seqReadHr{
+                SUCCEEDED(seqSizeHr) && sequenceHeaderSize > 0
+                    ? sourceVideoType->GetBlob(MF_MT_MPEG_SEQUENCE_HEADER, sequenceHeader.data(), sequenceHeaderSize, &bytesWritten)
+                    : E_FAIL};
+            if(FAILED(seqReadHr) || bytesWritten == 0){
                 throw hresult_error(MF_E_INVALIDMEDIATYPE, L"This AVI cannot be stream-copied to MP4 on this system (missing H.264 mux support).");
             }
         }

--- a/Win/llvc/MainWindow.Export.cpp
+++ b/Win/llvc/MainWindow.Export.cpp
@@ -29,6 +29,11 @@ using Control = MainWindow::Control;
 using REArgs = MainWindow::REArgs;
 using AAction = MainWindow::AAction;
 
+bool isAviSourcePath(const std::wstring& path){
+    return path.size() >= 4 && _wcsicmp(path.substr(path.size() - 4).c_str(), L".avi") == 0;
+}
+
+
 AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
     if(!m_prj.videoFile()){
         co_await showInfoDialogAsync(L"Export video", L"Load a video before exporting.");
@@ -59,9 +64,10 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
         return L"created by llvc from " + sourcePathForComment.filename().wstring() + L" on " + timestamp;
     };
     const auto sourceExt{sourceFsPath.extension().wstring()};
-    const auto defaultExt{_wcsicmp(sourceExt.c_str(), L".mov") == 0 ? L".mov" : L".mp4"};
+    const auto sourceIsAvi{isAviSourcePath(sourcePath)};
+    const auto defaultExt{sourceIsAvi ? L".mp4" : (_wcsicmp(sourceExt.c_str(), L".mov") == 0 ? L".mov" : L".mp4")};
 
-    const auto outputPath{pickExportOutputPath(sourceFsPath, defaultExt, outputDuration100ns, getWindowHandle())};
+    const auto outputPath{pickExportOutputPath(sourceFsPath, defaultExt, outputDuration100ns, getWindowHandle(), sourceIsAvi)};
     if(outputPath.empty()){
         co_return;
     }
@@ -115,6 +121,26 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
         check_hresult(reader->SetStreamSelection(videoStreamIndex, TRUE));
 
         auto sourceVideoType{chooseBestNativeVideoMediaType(reader, videoStreamIndex)};
+        if(sourceIsAvi){
+            sourceVideoType = nullptr;
+            for(DWORD mediaTypeIndex{};; ++mediaTypeIndex){
+                com_ptr<IMFMediaType> type;
+                const auto hr{reader->GetNativeMediaType(videoStreamIndex, mediaTypeIndex, type.put())};
+                if(hr == MF_E_NO_MORE_TYPES){
+                    break;
+                }
+                check_hresult(hr);
+
+                GUID major{GUID_NULL};
+                GUID subtype{GUID_NULL};
+                check_hresult(type->GetGUID(MF_MT_MAJOR_TYPE, &major));
+                check_hresult(type->GetGUID(MF_MT_SUBTYPE, &subtype));
+                if(major == MFMediaType_Video && subtype == MFVideoFormat_H264){
+                    sourceVideoType = type;
+                    break;
+                }
+            }
+        }
         if(!sourceVideoType){
             throw hresult_error(MF_E_INVALIDMEDIATYPE, L"No native video media type found");
         }
@@ -123,6 +149,21 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
         GUID videoSubtype{GUID_NULL};
         check_hresult(sourceVideoType->GetGUID(MF_MT_SUBTYPE, &videoSubtype));
         const auto nalLengthFieldSize{getNalLengthFieldSize(sourceVideoType, videoSubtype)};
+
+        if(sourceIsAvi){
+            if(videoSubtype != MFVideoFormat_H264){
+                throw hresult_error(MF_E_INVALIDMEDIATYPE, L"AVI is supported only for H.264 video in v1.");
+            }
+            UINT8* sequenceHeader{};
+            UINT32 sequenceHeaderSize{};
+            const auto seqHr{sourceVideoType->GetAllocatedBlob(MF_MT_MPEG_SEQUENCE_HEADER, &sequenceHeader, &sequenceHeaderSize)};
+            if(SUCCEEDED(seqHr) && sequenceHeader){
+                CoTaskMemFree(sequenceHeader);
+            }
+            if(FAILED(seqHr) || sequenceHeaderSize == 0){
+                throw hresult_error(MF_E_INVALIDMEDIATYPE, L"This AVI cannot be stream-copied to MP4 on this system (missing H.264 mux support).");
+            }
+        }
 
         vector<int64_t> rapTimes100ns;
         rapTimes100ns.reserve(2048);
@@ -171,7 +212,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
         DWORD audioStreamIndex{};
         constexpr auto invalidAudioStream{numeric_limits<DWORD>::max()};
 
-        if(m_prj.keepAudio() && sourceHasAudio()){
+        if(!sourceIsAvi && m_prj.keepAudio() && sourceHasAudio()){
             com_ptr<IMFSourceReader> audioProbeReader;
             check_hresult(MFCreateSourceReaderFromURL(sourcePath.c_str(), nullptr, audioProbeReader.put()));
 
@@ -234,7 +275,13 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
             return hr;
         };
 
-        check_hresult(configureWriter());
+        const auto writerConfigHr{configureWriter()};
+        if(FAILED(writerConfigHr)){
+            if(sourceIsAvi){
+                throw hresult_error(writerConfigHr, L"This AVI cannot be stream-copied to MP4 on this system (missing H.264 mux support).");
+            }
+            check_hresult(writerConfigHr);
+        }
 
         check_hresult(writer->BeginWriting());
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -137,7 +137,7 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <TextBlock x:Name="StatusText" Grid.Row="0" Text="Load or drag-and-drop an .mp4/.mov file to preview." TextTrimming="CharacterEllipsis"/>
+                    <TextBlock x:Name="StatusText" Grid.Row="0" Text="Load or drag-and-drop an .mp4/.mov/.avi (H.264 only) file to preview." TextTrimming="CharacterEllipsis"/>
                     <TextBlock x:Name="ErrorText" Grid.Row="1" Foreground="#FFFF8585" Text="" TextTrimming="CharacterEllipsis" Visibility="Collapsed"/>
                 </Grid>
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -139,7 +139,7 @@ wstring BuildUnsupportedAviReason(const wstring& detail){
     return detail;
 }
 
-bool IsAviH264StreamCopyCandidate(IMFSourceReader* reader, DWORD videoStreamIndex, com_ptr<IMFMediaType>& selectedVideoType, wstring& failureReason){
+bool IsAviH264StreamCopyCandidate(const com_ptr<IMFSourceReader>& reader, DWORD videoStreamIndex, com_ptr<IMFMediaType>& selectedVideoType, wstring& failureReason){
     if(!reader){
         failureReason = BuildUnsupportedAviReason(L"AVI is supported only for H.264 video in v1. This file uses unknown codec.");
         return false;
@@ -189,7 +189,7 @@ bool IsAviH264StreamCopyCandidate(IMFSourceReader* reader, DWORD videoStreamInde
     return true;
 }
 
-bool validateAviSampleTimesAndSyncFlags(IMFSourceReader* reader, DWORD videoStreamIndex, const com_ptr<IMFMediaType>& videoType, wstring& failureReason){
+bool validateAviSampleTimesAndSyncFlags(const com_ptr<IMFSourceReader>& reader, DWORD videoStreamIndex, const com_ptr<IMFMediaType>& videoType, wstring& failureReason){
     if(!reader){
         failureReason = BuildUnsupportedAviReason(L"AVI file lacks usable timestamps for robust cutting; convert to MP4 first.");
         return false;
@@ -1720,7 +1720,7 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
             result.errorMessage = BuildUnsupportedAviReason(L"Expected exactly one video stream.");
             return result;
         }
-        if(!IsAviH264StreamCopyCandidate(reader.get(), videoStreamIndex, aviNativeH264Type, result.errorMessage)){
+        if(!IsAviH264StreamCopyCandidate(reader, videoStreamIndex, aviNativeH264Type, result.errorMessage)){
             return result;
         }
 
@@ -1735,7 +1735,7 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
             return result;
         }
 
-        if(!validateAviSampleTimesAndSyncFlags(reader.get(), videoStreamIndex, aviNativeH264Type, result.errorMessage)){
+        if(!validateAviSampleTimesAndSyncFlags(reader, videoStreamIndex, aviNativeH264Type, result.errorMessage)){
             return result;
         }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -103,7 +103,36 @@ wstring guidToVideoCodecName(const GUID& subtype){
     if(subtype == MFVideoFormat_HEVC || subtype == MFVideoFormat_H265){
         return L"HEVC";
     }
-    return formatGuid(subtype);
+
+    const auto hasMfSubtypeBase{
+        subtype.Data2 == 0x0000
+        && subtype.Data3 == 0x0010
+        && subtype.Data4[0] == 0x80
+        && subtype.Data4[1] == 0x00
+        && subtype.Data4[2] == 0x00
+        && subtype.Data4[3] == 0xAA
+        && subtype.Data4[4] == 0x00
+        && subtype.Data4[5] == 0x38
+        && subtype.Data4[6] == 0x9B
+        && subtype.Data4[7] == 0x71};
+    if(hasMfSubtypeBase){
+        const DWORD fcc{subtype.Data1};
+        wchar_t fourcc[5]{};
+        for(int i{}; i < 4; ++i){
+            const auto c{static_cast<wchar_t>((fcc >> (i * 8)) & 0xFF)};
+            if(c < 0x20 || c > 0x7E){
+                fourcc[0] = L'\0';
+                break;
+            }
+            fourcc[i] = static_cast<wchar_t>(towupper(c));
+        }
+
+        if(fourcc[0] != L'\0'){
+            return fourcc;
+        }
+    }
+
+    return L"unknown codec";
 }
 
 wstring BuildUnsupportedAviReason(const wstring& detail){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -86,6 +86,165 @@ constexpr auto W_POS_L{L"WindowLeft"};
 
 namespace{
 
+constexpr int64_t HNS_PER_SECOND{10'000'000LL};
+
+bool isAviPath(const wstring& filePath){
+    if(filePath.size() < 4){
+        return false;
+    }
+    const auto ext{filePath.substr(filePath.size() - 4)};
+    return _wcsicmp(ext.c_str(), L".avi") == 0;
+}
+
+wstring guidToVideoCodecName(const GUID& subtype){
+    if(subtype == MFVideoFormat_H264){
+        return L"H.264";
+    }
+    if(subtype == MFVideoFormat_HEVC || subtype == MFVideoFormat_H265){
+        return L"HEVC";
+    }
+    return formatGuid(subtype);
+}
+
+wstring BuildUnsupportedAviReason(const wstring& detail){
+    return detail;
+}
+
+bool IsAviH264StreamCopyCandidate(IMFSourceReader* reader, DWORD videoStreamIndex, com_ptr<IMFMediaType>& selectedVideoType, wstring& failureReason){
+    if(!reader){
+        failureReason = BuildUnsupportedAviReason(L"AVI is supported only for H.264 video in v1. This file uses unknown codec.");
+        return false;
+    }
+
+    com_ptr<IMFMediaType> firstVideoType;
+    GUID firstVideoSubtype{GUID_NULL};
+    auto hasH264NativeType{false};
+    for(DWORD mediaTypeIndex{};; ++mediaTypeIndex){
+        com_ptr<IMFMediaType> type;
+        const auto hr{reader->GetNativeMediaType(videoStreamIndex, mediaTypeIndex, type.put())};
+        if(hr == MF_E_NO_MORE_TYPES){
+            break;
+        }
+        if(FAILED(hr)){
+            failureReason = BuildUnsupportedAviReason(L"AVI is supported only for H.264 video in v1. This file could not be inspected.");
+            return false;
+        }
+
+        GUID major{GUID_NULL};
+        GUID subtype{GUID_NULL};
+        if(FAILED(type->GetGUID(MF_MT_MAJOR_TYPE, &major)) || major != MFMediaType_Video){
+            continue;
+        }
+        if(FAILED(type->GetGUID(MF_MT_SUBTYPE, &subtype))){
+            continue;
+        }
+
+        if(!firstVideoType){
+            firstVideoType = type;
+            firstVideoSubtype = subtype;
+        }
+
+        if(subtype == MFVideoFormat_H264){
+            hasH264NativeType = true;
+            selectedVideoType = type;
+            break;
+        }
+    }
+
+    if(!hasH264NativeType){
+        const auto codec{firstVideoType ? guidToVideoCodecName(firstVideoSubtype) : wstring(L"unknown codec")};
+        failureReason = BuildUnsupportedAviReason(L"AVI is supported only for H.264 video in v1. This file uses " + codec + L".");
+        return false;
+    }
+
+    return true;
+}
+
+bool validateAviSampleTimesAndSyncFlags(IMFSourceReader* reader, DWORD videoStreamIndex, const com_ptr<IMFMediaType>& videoType, wstring& failureReason){
+    if(!reader){
+        failureReason = BuildUnsupportedAviReason(L"AVI file lacks usable timestamps for robust cutting; convert to MP4 first.");
+        return false;
+    }
+
+    uint32_t fpsNum{};
+    uint32_t fpsDen{};
+    const auto hasFrameRate{videoType && SUCCEEDED(MFGetAttributeRatio(videoType.get(), MF_MT_FRAME_RATE, &fpsNum, &fpsDen)) && fpsNum > 0 && fpsDen > 0};
+    const auto saneFrameRate{hasFrameRate && fpsNum <= 240 * fpsDen};
+    const auto fallbackDuration100ns{saneFrameRate ? static_cast<int64_t>((HNS_PER_SECOND * static_cast<int64_t>(fpsDen) + (fpsNum / 2)) / fpsNum) : 0LL};
+
+    constexpr auto maxForwardJump100ns{10LL * HNS_PER_SECOND};
+    int64_t previousTime100ns{-1};
+    int64_t syntheticTime100ns{};
+    bool hasAnySample{};
+    bool hasAnyCleanPoint{};
+
+    PROPVARIANT startPos{};
+    startPos.vt = VT_I8;
+    startPos.hVal.QuadPart = 0;
+    check_hresult(reader->SetCurrentPosition(GUID_NULL, startPos));
+    PropVariantClear(&startPos);
+
+    for(;;){
+        DWORD actualStream{};
+        DWORD flags{};
+        LONGLONG timestamp{};
+        com_ptr<IMFSample> sample;
+        const auto hr{reader->ReadSample(videoStreamIndex, 0, &actualStream, &flags, &timestamp, sample.put())};
+        if(FAILED(hr)){
+            failureReason = BuildUnsupportedAviReason(L"AVI file lacks usable timestamps for robust cutting; convert to MP4 first.");
+            return false;
+        }
+        if(flags & MF_SOURCE_READERF_ENDOFSTREAM){
+            break;
+        }
+        if(!sample){
+            continue;
+        }
+
+        hasAnySample = true;
+        int64_t sampleTime100ns{};
+        if(FAILED(sample->GetSampleTime(&sampleTime100ns))){
+            if(!saneFrameRate || fallbackDuration100ns <= 0){
+                failureReason = BuildUnsupportedAviReason(L"AVI file lacks usable timestamps for robust cutting; convert to MP4 first.");
+                return false;
+            }
+            sampleTime100ns = syntheticTime100ns;
+            syntheticTime100ns += fallbackDuration100ns;
+        }else if(sampleTime100ns < 0){
+            failureReason = BuildUnsupportedAviReason(L"AVI file lacks usable timestamps for robust cutting; convert to MP4 first.");
+            return false;
+        }
+
+        if(previousTime100ns >= 0){
+            if(sampleTime100ns < previousTime100ns){
+                failureReason = BuildUnsupportedAviReason(L"AVI file lacks usable timestamps for robust cutting; convert to MP4 first.");
+                return false;
+            }
+            if(sampleTime100ns - previousTime100ns > maxForwardJump100ns){
+                failureReason = BuildUnsupportedAviReason(L"AVI file lacks usable timestamps for robust cutting; convert to MP4 first.");
+                return false;
+            }
+        }
+
+        previousTime100ns = sampleTime100ns;
+        UINT32 cleanPoint{};
+        if(SUCCEEDED(sample->GetUINT32(MFSampleExtension_CleanPoint, &cleanPoint)) && cleanPoint != 0){
+            hasAnyCleanPoint = true;
+        }
+    }
+
+    if(!hasAnySample || !hasAnyCleanPoint){
+        failureReason = BuildUnsupportedAviReason(L"AVI keyframe markers are not reliable for robust cutting; convert to MP4 first.");
+        return false;
+    }
+
+    startPos.vt = VT_I8;
+    startPos.hVal.QuadPart = 0;
+    check_hresult(reader->SetCurrentPosition(GUID_NULL, startPos));
+    PropVariantClear(&startPos);
+    return true;
+}
+
 std::wstring readShellStringProperty(const std::wstring& filePath, const PROPERTYKEY& key){
     winrt::com_ptr<IPropertyStore> propertyStore;
     const auto hr{SHGetPropertyStoreFromParsingName(filePath.c_str(), nullptr, GPS_BESTEFFORT, IID_PPV_ARGS(propertyStore.put()))};
@@ -1080,6 +1239,7 @@ AAction MainWindow::pickAndLoadVideoAsync(){
     picker.SuggestedStartLocation(PickerLocationId::VideosLibrary);
     picker.FileTypeFilter().Append(L".mp4");
     picker.FileTypeFilter().Append(L".mov");
+    picker.FileTypeFilter().Append(L".avi");
 
     const auto hwnd{getWindowHandle()};
     auto initWithWindow{picker.as<IInitializeWithWindow>()};
@@ -1173,7 +1333,7 @@ void MainWindow::resetProjectState(){
     Controls::Canvas::SetLeft(TimelineCursor(), 0);
     syncTimelineHorizontalScrollBar();
 
-    setStatusMessage(L"Load or drag-and-drop an .mp4/.mov file to preview.");
+    setStatusMessage(L"Load or drag-and-drop an .mp4/.mov/.avi (H.264 only) file to preview.");
     clearErrorMessage();
     refreshStatusInfoSection();
     updateWindowTitle();
@@ -1306,6 +1466,9 @@ wstring MainWindow::buildSourcePropertiesText() const{
     content += L"Max random access spacing: "; content += m_mediaInfo.maxKeyFrameSpacing; content += L"\n";
     content += L"Audio codec: "; content += m_mediaInfo.audioCodec; content += L"\n";
     content += L"Audio bitrate: "; content += m_mediaInfo.audioBitrate;
+    if(m_mediaInfo.audioDisabledForThisSource && !m_mediaInfo.audioDisabledReason.empty()){
+        content += L"\nAudio note: "; content += m_mediaInfo.audioDisabledReason;
+    }
     return content;
 }
 
@@ -1485,6 +1648,7 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
     auto videoStreamIndex{invalidStreamIndex};
     uint32_t allSamplesIndependent{};
     uint32_t maxKeyFrameSpacing{};
+    const auto sourceIsAvi{isAviPath(filePath)};
 
     for(DWORD streamIndex{0};; ++streamIndex){
         com_ptr<IMFMediaType> type;
@@ -1521,8 +1685,43 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
         }
     }
 
+    com_ptr<IMFMediaType> aviNativeH264Type;
+    if(sourceIsAvi){
+        if(videoCount != 1){
+            result.errorMessage = BuildUnsupportedAviReason(L"Expected exactly one video stream.");
+            return result;
+        }
+        if(!IsAviH264StreamCopyCandidate(reader.get(), videoStreamIndex, aviNativeH264Type, result.errorMessage)){
+            return result;
+        }
+
+        GUID aviSubtype{GUID_NULL};
+        check_hresult(aviNativeH264Type->GetGUID(MF_MT_SUBTYPE, &aviSubtype));
+        if(aviSubtype != MFVideoFormat_H264){
+            if(aviSubtype == MFVideoFormat_HEVC || aviSubtype == MFVideoFormat_H265){
+                result.errorMessage = BuildUnsupportedAviReason(L"AVI is supported only for H.264 video in v1. This file uses HEVC.");
+            }else{
+                result.errorMessage = BuildUnsupportedAviReason(L"AVI is supported only for H.264 video in v1. This file uses " + guidToVideoCodecName(aviSubtype) + L".");
+            }
+            return result;
+        }
+
+        if(!validateAviSampleTimesAndSyncFlags(reader.get(), videoStreamIndex, aviNativeH264Type, result.errorMessage)){
+            return result;
+        }
+
+        check_hresult(reader->SetCurrentMediaType(videoStreamIndex, nullptr, aviNativeH264Type.get()));
+        videoSubtype = MFVideoFormat_H264;
+        MFGetAttributeSize(aviNativeH264Type.get(), MF_MT_FRAME_SIZE, &width, &height);
+        MFGetAttributeRatio(aviNativeH264Type.get(), MF_MT_FRAME_RATE, &fpsNum, &fpsDen);
+        (void)aviNativeH264Type->GetUINT32(MF_MT_AVG_BITRATE, &videoBitrate);
+    }
+
     if(videoStreamIndex != invalidStreamIndex){
         if(auto bestVideoType{chooseBestNativeVideoMediaType(reader, videoStreamIndex)}){
+            if(sourceIsAvi){
+                bestVideoType = aviNativeH264Type;
+            }
             (void)reader->SetCurrentMediaType(videoStreamIndex, nullptr, bestVideoType.get());
 
             MFGetAttributeSize(bestVideoType.get(), MF_MT_FRAME_SIZE, &width, &height);
@@ -1560,8 +1759,10 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
         result.container = L"MP4";
     }else if(lowerPath.size() >= 4 && lowerPath.substr(lowerPath.size() - 4) == L".mov"){
         result.container = L"MOV";
+    }else if(lowerPath.size() >= 4 && lowerPath.substr(lowerPath.size() - 4) == L".avi"){
+        result.container = L"AVI";
     }else{
-        result.errorMessage = L"Container not supported. Only MP4 and MOV are allowed.";
+        result.errorMessage = L"Container not supported. Only MP4, MOV, and AVI (H.264 only) are allowed.";
         return result;
     }
 
@@ -1590,7 +1791,17 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
     result.videoBitrate = videoBitrate > 0 ? (to_wstring(videoBitrate / 1000) + L" kbps") : L"-";
     result.audioBitrate = audioBitrate > 0 ? (to_wstring((audioBitrate * 8) / 1000) + L" kbps") : L"none";
     if(videoStreamIndex != invalidStreamIndex){
+        PROPVARIANT startPos{};
+        startPos.vt = VT_I8;
+        startPos.hVal.QuadPart = 0;
+        check_hresult(reader->SetCurrentPosition(GUID_NULL, startPos));
+        PropVariantClear(&startPos);
         analyzeKeyFrameCadence(reader.get(), videoStreamIndex, fpsNum, fpsDen, result);
+    }
+
+    if(sourceIsAvi && audioCount > 0){
+        result.audioDisabledForThisSource = true;
+        result.audioDisabledReason = L"AVI audio passthrough is disabled in v1. Export will keep video only.";
     }
 
     result.sourceEncodedBy = readShellStringProperty(filePath, PKEY_Media_EncodedBy);
@@ -1612,7 +1823,7 @@ AAction MainWindow::window_Drop(const Control&, const DEArgs& e){
 
     const auto items{co_await view.GetStorageItemsAsync()};
     if(items.Size() != 1){
-        setStatusMessage(L"Only support a single .mp4 or .mov file");
+        setStatusMessage(L"Only support a single .mp4/.mov/.avi (H.264) file");
         co_return;
     }
 
@@ -1627,8 +1838,8 @@ AAction MainWindow::window_Drop(const Control&, const DEArgs& e){
         const auto ext{file.FileType()};
         wstring lower{ext.c_str()};
         transform(lower.begin(), lower.end(), lower.begin(), ::towlower);
-        if(lower != L".mp4" && lower != L".mov"){
-            setStatusMessage(L"Only .mp4 and .mov files are supported");
+        if(lower != L".mp4" && lower != L".mov" && lower != L".avi"){
+            setStatusMessage(L"Only .mp4, .mov, and .avi (H.264) files are supported");
             co_return;
         }
     }
@@ -1747,13 +1958,17 @@ void MainWindow::updateAudioUiAndPlaybackState(){
         return;
     }
     const auto hasAudio{sourceHasAudio()};
+    const auto audioHardDisabled{m_mediaInfo.audioDisabledForThisSource};
     if(!hasAudio){
         m_prj.keepAudio(false);
     }
+    if(audioHardDisabled){
+        m_prj.keepAudio(false);
+    }
 
-    KeepAudioCheckBox().IsEnabled(hasAudio);
-    KeepAudioCheckBox().IsChecked(box_value(hasAudio && m_prj.keepAudio()).as<IReference<bool>>());
-    AudioCrossfadeComboBox().IsEnabled(hasAudio && m_prj.keepAudio());
+    KeepAudioCheckBox().IsEnabled(hasAudio && !audioHardDisabled);
+    KeepAudioCheckBox().IsChecked(box_value(hasAudio && !audioHardDisabled && m_prj.keepAudio()).as<IReference<bool>>());
+    AudioCrossfadeComboBox().IsEnabled(hasAudio && !audioHardDisabled && m_prj.keepAudio());
     applyAudioSettingsToPlayer();
 }
 

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -43,6 +43,8 @@ struct MediaInspectionResult{
     wstring keyFrameInterval{};
     wstring allSamplesIndependent{};
     wstring maxKeyFrameSpacing{};
+    bool audioDisabledForThisSource{false};
+    wstring audioDisabledReason{};
 };
 
 struct MainWindow: MainWindowT<MainWindow>{

--- a/Win/llvc/readme.txt
+++ b/Win/llvc/readme.txt
@@ -25,3 +25,20 @@ https://docs.microsoft.com/windows/apps/winui/winui3/
 Learn more about C++/WinRT here:
 http://aka.ms/cppwinrt/
 ========================================================================
+
+========================================================================
+Manual Test Checklist (AVI input v1)
+========================================================================
+
+- H264-in-AVI:
+  - opens successfully
+  - keyframe/index inspection succeeds
+  - export writes MP4 and resulting file plays with no visible video artifacts
+
+- Non-H264 AVI (CRAM / MJPG / Xvid / DivX / etc.):
+  - open is rejected
+  - rejection message explains AVI is H.264-only in v1 and includes the codec
+
+- AVI without robust timestamps or sync/keyframe markers:
+  - open is rejected with "convert to MP4 first" guidance
+


### PR DESCRIPTION
### Motivation
- Provide limited, safe support for `.avi` input in v1 while enforcing a no-reencode, H.264-only stream-copy export path.
- Fail fast and give clear user guidance for unsupported AVI cases (non-H.264 codecs, multiple video streams, missing timestamps/sync info, or missing mux support).
- Keep changes minimal and localized to input gating, validation helpers, and the export path to avoid architectural changes or accidental re-encoding.

### Description
- Added AVI detection and gating helpers: `isAviPath`, `IsAviH264StreamCopyCandidate(...)`, and `BuildUnsupportedAviReason(...)` in `Win/llvc/MainWindow.xaml.cpp` to enumerate native media types and accept only native H.264 compressed types.
- Implemented robust AVI timestamp and sync validation in `validateAviSampleTimesAndSyncFlags(...)` which synthesizes CFR only when the container/frame-rate is sane and otherwise rejects with a clear message.
- Forced MP4-only export for AVI inputs by extending `pickExportOutputPath(...)` (now `mp4Only` flag) in `Win/llvc/Export.ixx` and plumbing the `sourceIsAvi` flag through `MainWindow.Export.cpp` to enforce an MP4 sink and to validate H.264 sequence header presence for passthrough.
- Kept audio conservative: AVI audio passthrough is hard-disabled in v1 (UI note and `MediaInspectionResult.audioDisabledForThisSource`), and the export path skips audio for AVI; the existing audio pipeline remains unchanged for MP4/MOV.
- Updated UI/UX text and properties dialog to advertise `AVI (H.264 only)` support and to surface precise rejection reasons; added a short manual test checklist to `README.md` and `Win/llvc/readme.txt`.

### Testing
- Ran repository/environment checks: `git status --short` to confirm staged changes and `cmake --version` to validate build tooling presence; both completed successfully.
- Attempted a full MSBuild of the solution with `msbuild Win/trifles-win.sln /t:Build /p:Configuration=Release`, but the operation failed in this environment because `msbuild` is not installed (tooling limitation), so a native build verification was not possible here.
- No automated unit tests were added for this change; manual test checklist entries were added to `README.md` and `Win/llvc/readme.txt` to guide QA validation (H.264-in-AVI open/export, non-H.264 AVI rejection, timestamp/sync rejection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec99c07888333a13107fef5451671)