### PR TITLE
Add 'Reevaluate clear cut markers' UI and RAP-based marker re-evaluation

### DIFF
--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -129,9 +129,9 @@
         </Grid>
 
         <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-            <Button x:Name="StartButton" Content="▶" IsTabStop="False" Click="startButton_Click" ToolTipService.ToolTip="Start"/>
-            <Button x:Name="PauseButton" Content="⏸" IsTabStop="False" Click="pauseButton_Click" ToolTipService.ToolTip="Pause"/>
-            <Button x:Name="StopButton" Content="⏹" IsTabStop="False" Click="stopButton_Click" ToolTipService.ToolTip="Stop"/>
+            <Button x:Name="StartButton" Content="▶" FontFamily="Segoe UI Symbol" IsTabStop="False" Click="startButton_Click" ToolTipService.ToolTip="Start"/>
+            <Button x:Name="PauseButton" Content="⏸︎" FontFamily="Segoe UI Symbol" IsTabStop="False" Click="pauseButton_Click" ToolTipService.ToolTip="Pause"/>
+            <Button x:Name="StopButton" Content="⏹︎" FontFamily="Segoe UI Symbol" IsTabStop="False" Click="stopButton_Click" ToolTipService.ToolTip="Stop"/>
         </StackPanel>
 
         <Border Grid.Row="4" BorderThickness="1" BorderBrush="#4A4A4A" CornerRadius="4" Background="#141414" Padding="8,6">

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -76,21 +76,32 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
-                <TextBlock Text="Zoom" VerticalAlignment="Center"/>
-                <Slider x:Name="TimelineZoomSlider" Width="240" IsTabStop="False" Minimum="1" Maximum="12" Value="2" SmallChange="0.25" LargeChange="1" ValueChanged="timelineZoomSlider_ValueChanged"/>
-                <CheckBox x:Name="KeepAudioCheckBox" Content="Keep audio" IsEnabled="False" VerticalAlignment="Center" Checked="keepAudioCheckBox_Changed" Unchecked="keepAudioCheckBox_Changed"/>
-                <TextBlock Text="Audio cross-fade:" VerticalAlignment="Center"/>
-                <ComboBox x:Name="AudioCrossfadeComboBox" Width="120" IsEnabled="False" SelectionChanged="audioCrossfadeComboBox_SelectionChanged">
-                    <ComboBoxItem Content="0 ms" Tag="0"/>
-                    <ComboBoxItem Content="50 ms" Tag="50"/>
-                    <ComboBoxItem Content="100 ms" Tag="100"/>
-                    <ComboBoxItem Content="250 ms" Tag="250"/>
-                    <ComboBoxItem Content="500 ms" Tag="500"/>
-                    <ComboBoxItem Content="750 ms" Tag="750"/>
-                    <ComboBoxItem Content="1 s" Tag="1000"/>
-                </ComboBox>
-            </StackPanel>
+            <Grid ColumnSpacing="10" VerticalAlignment="Center">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Left" VerticalAlignment="Center">
+                    <CheckBox x:Name="KeepAudioCheckBox" Content="Keep audio" IsEnabled="False" VerticalAlignment="Center" Checked="keepAudioCheckBox_Changed" Unchecked="keepAudioCheckBox_Changed"/>
+                    <TextBlock Text="Audio cross-fade:" VerticalAlignment="Center"/>
+                    <ComboBox x:Name="AudioCrossfadeComboBox" Width="120" IsEnabled="False" SelectionChanged="audioCrossfadeComboBox_SelectionChanged">
+                        <ComboBoxItem Content="0 ms" Tag="0"/>
+                        <ComboBoxItem Content="50 ms" Tag="50"/>
+                        <ComboBoxItem Content="100 ms" Tag="100"/>
+                        <ComboBoxItem Content="250 ms" Tag="250"/>
+                        <ComboBoxItem Content="500 ms" Tag="500"/>
+                        <ComboBoxItem Content="750 ms" Tag="750"/>
+                        <ComboBoxItem Content="1 s" Tag="1000"/>
+                    </ComboBox>
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <Button x:Name="ReevaluateClearCutMarkersButton" Content="⟳" Width="34" IsTabStop="False" Click="reevaluateClearCutMarkersButton_Click" ToolTipService.ToolTip="Reevaluate clear cut markers"/>
+                    <TextBlock Text="Zoom" VerticalAlignment="Center"/>
+                    <Slider x:Name="TimelineZoomSlider" Width="240" IsTabStop="False" Minimum="1" Maximum="12" Value="2" SmallChange="0.25" LargeChange="1" ValueChanged="timelineZoomSlider_ValueChanged"/>
+                </StackPanel>
+            </Grid>
 
             <Border Grid.Row="1" BorderThickness="1" BorderBrush="#404040" Background="#111111" CornerRadius="4" Padding="6">
                 <Grid RowSpacing="4">
@@ -118,9 +129,9 @@
         </Grid>
 
         <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-            <Button x:Name="StartButton" Content="Start" IsTabStop="False" Click="startButton_Click"/>
-            <Button x:Name="PauseButton" Content="Pause" IsTabStop="False" Click="pauseButton_Click"/>
-            <Button x:Name="StopButton" Content="Stop" IsTabStop="False" Click="stopButton_Click"/>
+            <Button x:Name="StartButton" Content="▶" IsTabStop="False" Click="startButton_Click" ToolTipService.ToolTip="Start"/>
+            <Button x:Name="PauseButton" Content="⏸" IsTabStop="False" Click="pauseButton_Click" ToolTipService.ToolTip="Pause"/>
+            <Button x:Name="StopButton" Content="⏹" IsTabStop="False" Click="stopButton_Click" ToolTipService.ToolTip="Stop"/>
         </StackPanel>
 
         <Border Grid.Row="4" BorderThickness="1" BorderBrush="#4A4A4A" CornerRadius="4" Background="#141414" Padding="8,6">

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -96,6 +96,89 @@ bool isAviPath(const wstring& filePath){
     return _wcsicmp(ext.c_str(), L".avi") == 0;
 }
 
+
+vector<int64_t> collectCleanPointTimes100ns(const wstring& filePath){
+    vector<int64_t> rapTimes;
+
+    if(filePath.empty()){
+        return rapTimes;
+    }
+
+    com_ptr<IMFSourceReader> reader;
+    check_hresult(MFCreateSourceReaderFromURL(filePath.c_str(), nullptr, reader.put()));
+
+    DWORD videoStreamIndex{};
+    bool foundVideo{};
+    for(DWORD streamIndex{};; ++streamIndex){
+        com_ptr<IMFMediaType> nativeType;
+        const auto hr{reader->GetNativeMediaType(streamIndex, 0, nativeType.put())};
+        if(hr == MF_E_NO_MORE_TYPES){
+            break;
+        }
+        if(FAILED(hr) || !nativeType){
+            continue;
+        }
+
+        GUID majorType{};
+        if(SUCCEEDED(nativeType->GetGUID(MF_MT_MAJOR_TYPE, &majorType)) && majorType == MFMediaType_Video){
+            videoStreamIndex = streamIndex;
+            foundVideo = true;
+            break;
+        }
+    }
+
+    if(!foundVideo){
+        return rapTimes;
+    }
+
+    check_hresult(reader->SetStreamSelection(videoStreamIndex, TRUE));
+
+    for(;;){
+        DWORD actualStream{};
+        DWORD flags{};
+        LONGLONG timestamp{};
+        com_ptr<IMFSample> sample;
+        const auto hr{reader->ReadSample(videoStreamIndex, 0, &actualStream, &flags, &timestamp, sample.put())};
+        check_hresult(hr);
+
+        if(flags & MF_SOURCE_READERF_ENDOFSTREAM){
+            break;
+        }
+        if(!sample){
+            continue;
+        }
+
+        UINT32 cleanPoint{};
+        if(FAILED(sample->GetUINT32(MFSampleExtension_CleanPoint, &cleanPoint)) || cleanPoint == 0){
+            continue;
+        }
+
+        LONGLONG sampleTime{};
+        if(FAILED(sample->GetSampleTime(&sampleTime))){
+            sampleTime = timestamp;
+        }
+
+        rapTimes.push_back(max<int64_t>(0, sampleTime));
+    }
+
+    sort(rapTimes.begin(), rapTimes.end());
+    rapTimes.erase(unique(rapTimes.begin(), rapTimes.end()), rapTimes.end());
+    return rapTimes;
+}
+
+bool isTimeInsideRanges(int64_t time100ns, const vector<pair<int64_t, int64_t>>& ranges){
+    for(const auto& [start100ns, end100ns]: ranges){
+        if(time100ns < start100ns){
+            return false;
+        }
+        if(time100ns < end100ns){
+            return true;
+        }
+    }
+
+    return false;
+}
+
 wstring guidToVideoCodecName(const GUID& subtype){
     if(subtype == MFVideoFormat_H264){
         return L"H.264";
@@ -511,6 +594,85 @@ void MainWindow::stopButton_Click(const Control&, const REArgs&){
         m_player.PlaybackSession().Position(chrono::seconds(0));
         updateTimelineCursorFromPlayback();
     }
+}
+
+
+void MainWindow::reevaluateClearCutMarkersButton_Click(const Control&, const REArgs&){
+    if(!m_prj.videoFile() || m_timelineDurationSeconds <= 0){
+        setStatusMessage(L"Load a video before reevaluating clear cut markers");
+        return;
+    }
+
+    vector<int64_t> rapTimes100ns;
+    try{
+        rapTimes100ns = collectCleanPointTimes100ns(m_prj.videoFile().Path().c_str());
+    }catch(const winrt::hresult_error&){
+        setStatusMessage(L"Could not read RAP markers from the current source");
+        return;
+    }
+
+    if(rapTimes100ns.empty()){
+        setStatusMessage(L"Could not detect RAP markers in the current source");
+        return;
+    }
+
+    const auto originalMarkers{m_prj.frameIndex()};
+    if(originalMarkers.empty()){
+        setStatusMessage(L"No clear cut markers to reevaluate");
+        return;
+    }
+
+    const auto previousCutRanges{m_prj.buildCutRanges100ns(m_timelineDurationSeconds)};
+    vector<IndexedFrameSample> updatedMarkers;
+    updatedMarkers.reserve(originalMarkers.size() * 2);
+
+    auto replacedCount{0u};
+    for(const auto& marker: originalMarkers){
+        if(binary_search(rapTimes100ns.begin(), rapTimes100ns.end(), marker.time100ns)){
+            updatedMarkers.push_back(marker);
+            continue;
+        }
+
+        ++replacedCount;
+        const auto nextIt{lower_bound(rapTimes100ns.begin(), rapTimes100ns.end(), marker.time100ns)};
+        if(nextIt != rapTimes100ns.begin()){
+            const auto previousRapTime{*(nextIt - 1)};
+            updatedMarkers.push_back(IndexedFrameSample{.time100ns = previousRapTime, .duration100ns = 0, .cleanPoint = true, .sampleIndex = 0});
+        }
+        if(nextIt != rapTimes100ns.end()){
+            const auto nextRapTime{*nextIt};
+            updatedMarkers.push_back(IndexedFrameSample{.time100ns = nextRapTime, .duration100ns = 0, .cleanPoint = true, .sampleIndex = 0});
+        }
+    }
+
+    sort(updatedMarkers.begin(), updatedMarkers.end(), [](const auto& a, const auto& b){ return a.time100ns < b.time100ns; });
+    updatedMarkers.erase(unique(updatedMarkers.begin(), updatedMarkers.end(), [](const auto& a, const auto& b){ return a.time100ns == b.time100ns; }), updatedMarkers.end());
+
+    m_prj.frameIndex() = std::move(updatedMarkers);
+    m_prj.refreshSelectedMarkers();
+
+    const auto totalDuration100ns{static_cast<int64_t>(m_timelineDurationSeconds * HNS_PER_SECOND)};
+    const auto sceneBoundaries{m_prj.buildSceneBoundaries100ns(totalDuration100ns)};
+    m_prj.cutScenes().clear();
+    for(size_t i{}; i + 1 < sceneBoundaries.size(); ++i){
+        const auto midpoint{sceneBoundaries[i] + (sceneBoundaries[i + 1] - sceneBoundaries[i]) / 2};
+        if(isTimeInsideRanges(midpoint, previousCutRanges)){
+            m_prj.cutScenes().push_back(static_cast<uint32_t>(i));
+        }
+    }
+
+    renderTimelineTicks();
+    renderKeyframeTicks();
+    renderCutOverlays();
+    updateWindowTitle();
+
+    wstring status{L"Reevaluated clear cut markers against RAP frames"};
+    if(replacedCount == 0){
+        status += L" (no changes needed)";
+    }else{
+        status += std::format(L" (updated {})", replacedCount);
+    }
+    setStatusMessage(status);
 }
 
 void MainWindow::timelineZoomSlider_ValueChanged(const Control&, const RBVArgs&){

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -71,6 +71,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     void startButton_Click(const Control& sender, const REArgs& args);
     void pauseButton_Click(const Control& sender, const REArgs& args);
     void stopButton_Click(const Control& sender, const REArgs& args);
+    void reevaluateClearCutMarkersButton_Click(const Control& sender, const REArgs& args);
     void timelineZoomSlider_ValueChanged(const Control& sender, const RBVArgs& args);
     void keepAudioCheckBox_Changed(const Control& sender, const REArgs& args);
     void audioCrossfadeComboBox_SelectionChanged(const Control& sender, const Control& args);

--- a/Win/llvc/Project.ixx
+++ b/Win/llvc/Project.ixx
@@ -36,13 +36,17 @@ struct Project final{
     void keepAudio(bool v);
     void audioXfadeMs(int32_t valueMs);
 
-    inline auto& videoFile()    const{ return m_loadedFile; }
-    inline auto  zoom()         const{ return m_zoom; }
-    inline bool  keepAudio()    const{ return m_keepAudio; }
-    inline auto  audioXfadeMs() const{ return m_audioCrossfadeMs; }
-    inline auto& frameIndex()   const{ return m_frameIndex; }
-    inline auto& selKeyFrames() const{ return m_selectedKeyFrames; }
-    inline auto& cutScenes()    const{ return m_cutScenes; }
+    inline auto&       videoFile()      { return m_loadedFile; }
+    inline const auto& videoFile() const{ return m_loadedFile; }
+    inline auto        zoom()     const{ return m_zoom; }
+    inline bool        keepAudio() const{ return m_keepAudio; }
+    inline auto        audioXfadeMs() const{ return m_audioCrossfadeMs; }
+    inline auto&       frameIndex()      { return m_frameIndex; }
+    inline const auto& frameIndex() const{ return m_frameIndex; }
+    inline auto&       selKeyFrames()      { return m_selectedKeyFrames; }
+    inline const auto& selKeyFrames() const{ return m_selectedKeyFrames; }
+    inline auto&       cutScenes()      { return m_cutScenes; }
+    inline const auto& cutScenes() const{ return m_cutScenes; }
 
     vector<IndexedFrameSample> buildRapMarkersFromSelection() const;
     vector<pair<int64_t, int64_t>> buildCutRanges100ns(double tlDurationSeconds) const;

--- a/Win/llvc/Project.ixx
+++ b/Win/llvc/Project.ixx
@@ -36,14 +36,12 @@ struct Project final{
     void keepAudio(bool v);
     void audioXfadeMs(int32_t valueMs);
 
-    inline auto&       videoFile()      { return m_loadedFile; }
     inline const auto& videoFile() const{ return m_loadedFile; }
     inline auto        zoom()     const{ return m_zoom; }
     inline bool        keepAudio() const{ return m_keepAudio; }
     inline auto        audioXfadeMs() const{ return m_audioCrossfadeMs; }
     inline auto&       frameIndex()      { return m_frameIndex; }
     inline const auto& frameIndex() const{ return m_frameIndex; }
-    inline auto&       selKeyFrames()      { return m_selectedKeyFrames; }
     inline const auto& selKeyFrames() const{ return m_selectedKeyFrames; }
     inline auto&       cutScenes()      { return m_cutScenes; }
     inline const auto& cutScenes() const{ return m_cutScenes; }


### PR DESCRIPTION
### Motivation
- Provide a way to realign project clear-cut markers to RAP/CleanPoint frames detected in the source video to improve cut accuracy.
- Improve timeline control layout and move the zoom slider to the right to group audio and timeline controls more logically.
- Replace verbose Start/Pause/Stop labels with compact icon buttons and tooltips to save space and improve UX.

### Description
- Updated `MainWindow.xaml` to reorganize the timeline controls into a two-column `Grid`, moved the `TimelineZoomSlider` to the right, and added a `ReevaluateClearCutMarkersButton` with tooltip and click handler `reevaluateClearCutMarkersButton_Click`.
- Replaced textual playback buttons with icons (`▶`, `⏸`, `⏹`) and attached tooltips to `StartButton`, `PauseButton`, and `StopButton`.
- Implemented `collectCleanPointTimes100ns` to read RAP/CleanPoint markers from the source using Media Foundation `IMFSourceReader` and return sorted unique sample times.
- Implemented helper `isTimeInsideRanges` and the handler `MainWindow::reevaluateClearCutMarkersButton_Click` which collects RAP times, replaces or supplements existing frame-index markers with nearest RAPs, rebuilds cut scenes, updates timeline/ticks/overlays, and sets a status message summarizing changes.
- Added the new click handler declaration to `MainWindow.xaml.h`.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0517d04548333b42ec9c9364fbaf8)