### PR TITLE
Add cut-at-cursor shortcuts and right-edge quick-action cheat sheet

### DIFF
--- a/Win/llvc/MainWindow.Export.cpp
+++ b/Win/llvc/MainWindow.Export.cpp
@@ -43,8 +43,8 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
     MFLifetime mf{};
 
     const wstring sourcePath{m_prj.videoFile().Path().c_str()};
-    const auto sourceDuration100ns{max<int64_t>(0, static_cast<int64_t>(llround(max(0.0, m_timelineDurationSeconds) * 10'000'000.0)))};
-    const auto outputDuration100ns{m_prj.outputDuration100ns(m_timelineDurationSeconds)};
+    const auto sourceDuration100ns{m_prj.timelineDuration100ns()};
+    const auto outputDuration100ns{m_prj.outputDuration100ns()};
 
     const filesystem::path sourceFsPath{sourcePath};
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -93,6 +93,8 @@
                             <TextBlock Text="Spacebar - play/pause video" TextWrapping="Wrap"/>
                             <TextBlock Text="Left Arrow - previous frame" TextWrapping="Wrap"/>
                             <TextBlock Text="Right Arrow - next frame" TextWrapping="Wrap"/>
+                            <TextBlock Text="Up Arrow - previous marker" TextWrapping="Wrap"/>
+                            <TextBlock Text="Down Arrow - next marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+M - toggle cut mark" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete - mark scene cut" TextWrapping="Wrap"/>
                             <TextBlock Text="Insert - mark scene kept" TextWrapping="Wrap"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -40,6 +40,10 @@
             <controls:MenuBarItem Title="Edit">
                 <MenuFlyoutItem Text="Undo	Ctrl+Z" Click="undoMenuItem_Click"/>
                 <MenuFlyoutItem Text="Redo	Ctrl+Y" Click="redoMenuItem_Click"/>
+                <MenuFlyoutSeparator/>
+                <MenuFlyoutItem Text="Toggle cut mark	Ctrl+M" Click="toggleCutMarkerAtCursorMenuItem_Click"/>
+                <MenuFlyoutItem Text="Mark scene cut	Delete" Click="markSceneCutAtCursorMenuItem_Click"/>
+                <MenuFlyoutItem Text="Mark scene kept	Insert" Click="markSceneKeptAtCursorMenuItem_Click"/>
             </controls:MenuBarItem>
 
             <controls:MenuBarItem Title="Tools">
@@ -72,6 +76,33 @@
 
                     <Button x:Name="VideoDetailsCollapseMarker" Width="24" HorizontalAlignment="Right" VerticalAlignment="Stretch" Padding="0"
                             Content="❮" Click="videoDetailsCollapseMarker_Click" ToolTipService.ToolTip="Collapse details panel"/>
+                </Grid>
+            </Border>
+            <Button x:Name="CheatSheetOpenMarker" Width="26" Height="64" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,4,0" Padding="0"
+                    Content="❮" Click="cheatSheetOpenMarker_Click" ToolTipService.ToolTip="Show quick actions" IsTabStop="False" Visibility="Collapsed"/>
+
+            <Border x:Name="CheatSheetPanel" Width="220" HorizontalAlignment="Right" VerticalAlignment="Stretch" Margin="4" Padding="10" CornerRadius="4"
+                    BorderBrush="#707070" BorderThickness="1" Background="#E6101010" IsTabStop="False">
+                <Grid IsTabStop="False">
+                    <Button x:Name="CheatSheetCollapseMarker" Width="24" HorizontalAlignment="Left" VerticalAlignment="Stretch" Padding="0"
+                            Content="❯" Click="cheatSheetCollapseMarker_Click" ToolTipService.ToolTip="Hide quick actions" IsTabStop="False"/>
+
+                    <ScrollViewer Margin="30,0,0,0" VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled" IsTabStop="False">
+                        <StackPanel Spacing="4" IsTabStop="False">
+                            <TextBlock Text="Quick actions" FontWeight="SemiBold"/>
+                            <TextBlock Text="Play pause — Space" TextWrapping="Wrap"/>
+                            <TextBlock Text="Frame back — Left" TextWrapping="Wrap"/>
+                            <TextBlock Text="Frame forward — Right" TextWrapping="Wrap"/>
+                            <TextBlock Text="Toggle cut mark — Ctrl+M" TextWrapping="Wrap"/>
+                            <TextBlock Text="Mark scene cut — Delete" TextWrapping="Wrap"/>
+                            <TextBlock Text="Mark scene kept — Insert" TextWrapping="Wrap"/>
+                            <TextBlock Text="Drag seek"/>
+                            <TextBlock Text="Right-click mark"/>
+                            <TextBlock Text="Ctrl+click scene" TextWrapping="Wrap"/>
+                            <TextBlock Text="Tick seek"/>
+                            <TextBlock Text="Drop video"/>
+                        </StackPanel>
+                    </ScrollViewer>
                 </Grid>
             </Border>
         </Grid>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -79,10 +79,10 @@
                 </Grid>
             </Border>
             <Button x:Name="CheatSheetOpenMarker" Width="26" Height="64" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,4,0" Padding="0"
-                    Content="❮" Click="cheatSheetOpenMarker_Click" ToolTipService.ToolTip="Show quick actions" IsTabStop="False" Visibility="Collapsed"/>
+                    Content="❮" Click="cheatSheetOpenMarker_Click" ToolTipService.ToolTip="Show quick actions" IsTabStop="False"/>
 
             <Border x:Name="CheatSheetPanel" Width="220" HorizontalAlignment="Right" VerticalAlignment="Stretch" Margin="4" Padding="10" CornerRadius="4"
-                    BorderBrush="#707070" BorderThickness="1" Background="#E6101010" IsTabStop="False">
+                    BorderBrush="#707070" BorderThickness="1" Background="#E6101010" IsTabStop="False" Visibility="Collapsed">
                 <Grid IsTabStop="False">
                     <Button x:Name="CheatSheetCollapseMarker" Width="24" HorizontalAlignment="Left" VerticalAlignment="Stretch" Padding="0"
                             Content="❯" Click="cheatSheetCollapseMarker_Click" ToolTipService.ToolTip="Hide quick actions" IsTabStop="False"/>
@@ -90,17 +90,17 @@
                     <ScrollViewer Margin="30,0,0,0" VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled" IsTabStop="False">
                         <StackPanel Spacing="4" IsTabStop="False">
                             <TextBlock Text="Quick actions" FontWeight="SemiBold"/>
-                            <TextBlock Text="Play pause — Space" TextWrapping="Wrap"/>
-                            <TextBlock Text="Frame back — Left" TextWrapping="Wrap"/>
-                            <TextBlock Text="Frame forward — Right" TextWrapping="Wrap"/>
-                            <TextBlock Text="Toggle cut mark — Ctrl+M" TextWrapping="Wrap"/>
-                            <TextBlock Text="Mark scene cut — Delete" TextWrapping="Wrap"/>
-                            <TextBlock Text="Mark scene kept — Insert" TextWrapping="Wrap"/>
-                            <TextBlock Text="Drag seek"/>
-                            <TextBlock Text="Right-click mark"/>
-                            <TextBlock Text="Ctrl+click scene" TextWrapping="Wrap"/>
-                            <TextBlock Text="Tick seek"/>
-                            <TextBlock Text="Drop video"/>
+                            <TextBlock Text="Play/pause: Space key" TextWrapping="Wrap"/>
+                            <TextBlock Text="Frame back: Left key" TextWrapping="Wrap"/>
+                            <TextBlock Text="Frame forward: Right key" TextWrapping="Wrap"/>
+                            <TextBlock Text="Toggle mark: Ctrl+M" TextWrapping="Wrap"/>
+                            <TextBlock Text="Scene cut: Delete key" TextWrapping="Wrap"/>
+                            <TextBlock Text="Scene kept: Insert key" TextWrapping="Wrap"/>
+                            <TextBlock Text="Seek timeline: drag cursor"/>
+                            <TextBlock Text="Toggle mark: right-click"/>
+                            <TextBlock Text="Toggle scene: Ctrl+click" TextWrapping="Wrap"/>
+                            <TextBlock Text="Seek point: tick click"/>
+                            <TextBlock Text="Load video: file drop"/>
                         </StackPanel>
                     </ScrollViewer>
                 </Grid>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -99,7 +99,7 @@
                             <TextBlock Text="Drag cursor - seek timeline"/>
                             <TextBlock Text="Right-click - toggle mark"/>
                             <TextBlock Text="Ctrl+click - toggle scene" TextWrapping="Wrap"/>
-                            <TextBlock Text="Tick click - seek point"/>
+                            <TextBlock Text="Timeline ruler click - seek point"/>
                             <TextBlock Text="File drop - load video"/>
                         </StackPanel>
                     </ScrollViewer>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -90,17 +90,17 @@
                     <ScrollViewer Margin="30,0,0,0" VerticalScrollMode="Enabled" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled" IsTabStop="False">
                         <StackPanel Spacing="4" IsTabStop="False">
                             <TextBlock Text="Quick actions" FontWeight="SemiBold"/>
-                            <TextBlock Text="Play/pause: Space key" TextWrapping="Wrap"/>
-                            <TextBlock Text="Frame back: Left key" TextWrapping="Wrap"/>
-                            <TextBlock Text="Frame forward: Right key" TextWrapping="Wrap"/>
-                            <TextBlock Text="Toggle mark: Ctrl+M" TextWrapping="Wrap"/>
-                            <TextBlock Text="Scene cut: Delete key" TextWrapping="Wrap"/>
-                            <TextBlock Text="Scene kept: Insert key" TextWrapping="Wrap"/>
-                            <TextBlock Text="Seek timeline: drag cursor"/>
-                            <TextBlock Text="Toggle mark: right-click"/>
-                            <TextBlock Text="Toggle scene: Ctrl+click" TextWrapping="Wrap"/>
-                            <TextBlock Text="Seek point: tick click"/>
-                            <TextBlock Text="Load video: file drop"/>
+                            <TextBlock Text="Spacebar - play/pause video" TextWrapping="Wrap"/>
+                            <TextBlock Text="Left Arrow - previous frame" TextWrapping="Wrap"/>
+                            <TextBlock Text="Right Arrow - next frame" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+M - toggle cut mark" TextWrapping="Wrap"/>
+                            <TextBlock Text="Delete - mark scene cut" TextWrapping="Wrap"/>
+                            <TextBlock Text="Insert - mark scene kept" TextWrapping="Wrap"/>
+                            <TextBlock Text="Drag cursor - seek timeline"/>
+                            <TextBlock Text="Right-click - toggle mark"/>
+                            <TextBlock Text="Ctrl+click - toggle scene" TextWrapping="Wrap"/>
+                            <TextBlock Text="Tick click - seek point"/>
+                            <TextBlock Text="File drop - load video"/>
                         </StackPanel>
                     </ScrollViewer>
                 </Grid>
@@ -136,7 +136,7 @@
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right" VerticalAlignment="Center">
                     <Button x:Name="ReevaluateClearCutMarkersButton" Content="⟳" Width="34" IsTabStop="False" Click="reevaluateClearCutMarkersButton_Click" ToolTipService.ToolTip="Reevaluate clear cut markers"/>
                     <TextBlock Text="Zoom" VerticalAlignment="Center"/>
-                    <Slider x:Name="TimelineZoomSlider" Width="240" IsTabStop="False" Minimum="1" Maximum="24" Value="4" SmallChange="1" LargeChange="4" ValueChanged="timelineZoomSlider_ValueChanged"/>
+                    <Slider x:Name="TimelineZoomSlider" Width="240" IsTabStop="False" Minimum="1" Maximum="24" Value="4" SmallChange="1" LargeChange="4" ValueChanged="timelineZoomSlider_ValueChanged" PointerWheelChanged="timelineZoomSlider_PointerWheelChanged"/>
                 </StackPanel>
             </Grid>
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1320,7 +1320,7 @@ bool MainWindow::moveCursorToMarker(int direction){
         return false;
     }
 
-    const auto markers{m_prj.buildRapMarkersFromSelection()};
+    const auto& markers{m_prj.frameIndex()};
     if(markers.empty()){
         return false;
     }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -786,6 +786,20 @@ void MainWindow::timelineZoomSlider_ValueChanged(const Control&, const RBVArgs&)
     tryFocusTimelineCanvas(FocusState::Programmatic);
 }
 
+void MainWindow::timelineZoomSlider_PointerWheelChanged(const Control&, const PREArgs& args){
+    const auto point{args.GetCurrentPoint(TimelineZoomSlider())};
+    const auto delta{point.Properties().MouseWheelDelta()};
+    if(delta == 0){
+        return;
+    }
+
+    auto slider{TimelineZoomSlider()};
+    const auto direction{delta > 0 ? 1.0 : -1.0};
+    const auto step{max(0.1, slider.SmallChange())};
+    slider.Value(clamp(slider.Value() + (direction * step), slider.Minimum(), slider.Maximum()));
+    args.Handled(true);
+}
+
 void MainWindow::keepAudioCheckBox_Changed(const Control&, const REArgs&){
     if(m_isApplyingUndoRedoState){
         return;
@@ -888,9 +902,20 @@ void MainWindow::timelineCanvas_PointerMoved(const Control&, const PREArgs& e){
     e.Handled(true);
 }
 
-bool MainWindow::toggleSelectedKeyframeAtCanvasX(double pointerX){
+optional<int64_t> MainWindow::timelinePointToTime100ns(double pointerX, double width) const{
+    if(m_timelineDurationSeconds <= 0 || width <= 0){
+        return nullopt;
+    }
+
+    const auto duration100ns{static_cast<int64_t>(m_timelineDurationSeconds * 10'000'000.0)};
+    const auto clampedX{clamp(pointerX, 0.0, width)};
+    return static_cast<int64_t>((clampedX / width) * duration100ns);
+}
+
+bool MainWindow::toggleSelectedKeyframeAtTime100ns(int64_t time100ns){
     (void)pushUndoStateIfChanged();
-    if(!m_prj.toggleSelectedKeyframeAtCanvasX(pointerX, TimelineTickCanvas().Width(), m_timelineDurationSeconds, m_mediaInfo.frameRate)){
+    const auto duration100ns{static_cast<int64_t>(m_timelineDurationSeconds * 10'000'000.0)};
+    if(!m_prj.toggleSelectedKeyframeAtTime100ns(time100ns, duration100ns, m_mediaInfo.frameRate)){
         return false;
     }
 
@@ -905,7 +930,7 @@ bool MainWindow::toggleSelectedKeyframeAtCanvasX(double pointerX){
 void MainWindow::timelineCanvas_PointerReleased(const Control&, const PREArgs& e){
     const auto point{e.GetCurrentPoint(TimelineCanvas())};
     if(point.Properties().PointerUpdateKind() == PointerUpdateKind::RightButtonReleased){
-        if(toggleSelectedKeyframeAtCanvasX(point.Position().X)){
+        if(const auto time100ns{timelinePointToTime100ns(point.Position().X, TimelineCanvas().Width())}; time100ns && toggleSelectedKeyframeAtTime100ns(*time100ns)){
             e.Handled(true);
             return;
         }
@@ -922,7 +947,9 @@ void MainWindow::timelineCanvas_PointerReleased(const Control&, const PREArgs& e
 
     if(!dragged){
         if(isControlModifierActive(e.KeyModifiers())){
-            toggleCutBlockAtCanvasX(point.Position().X);
+            if(const auto time100ns{timelinePointToTime100ns(point.Position().X, TimelineCanvas().Width())}){
+                toggleCutBlockAtTime100ns(*time100ns);
+            }
         }else{
             seekTimelineToCanvasX(point.Position().X);
         }
@@ -951,15 +978,17 @@ void MainWindow::timelineCanvas_Loaded(const Control&, const REArgs&){
 
 void MainWindow::timelineTickCanvas_PointerReleased(const Control&, const PREArgs& e){
     const auto point{e.GetCurrentPoint(TimelineTickCanvas())};
-    if(point.Properties().PointerUpdateKind() == PointerUpdateKind::RightButtonReleased && toggleSelectedKeyframeAtCanvasX(point.Position().X)){
-        tryFocusTimelineCanvas(FocusState::Programmatic);
-        e.Handled(true);
-        return;
+    if(point.Properties().PointerUpdateKind() == PointerUpdateKind::RightButtonReleased){
+        if(const auto time100ns{timelinePointToTime100ns(point.Position().X, TimelineTickCanvas().Width())}; time100ns && toggleSelectedKeyframeAtTime100ns(*time100ns)){
+            tryFocusTimelineCanvas(FocusState::Programmatic);
+            e.Handled(true);
+            return;
+        }
     }
 
     if(point.Properties().PointerUpdateKind() == PointerUpdateKind::LeftButtonReleased){
         if(isControlModifierActive(e.KeyModifiers())){
-            if(toggleCutBlockAtCanvasX(point.Position().X)){
+            if(const auto time100ns{timelinePointToTime100ns(point.Position().X, TimelineTickCanvas().Width())}; time100ns && toggleCutBlockAtTime100ns(*time100ns)){
                 tryFocusTimelineCanvas(FocusState::Programmatic);
                 e.Handled(true);
                 return;
@@ -1181,9 +1210,10 @@ void MainWindow::renderCutOverlays(){
 }
 
 
-bool MainWindow::toggleCutBlockAtCanvasX(double pointerX){
+bool MainWindow::toggleCutBlockAtTime100ns(int64_t time100ns){
     (void)pushUndoStateIfChanged();
-    if(!m_prj.toggleCutBlockAtCanvasX(pointerX, TimelineCanvas().Width(), m_timelineDurationSeconds)){
+    const auto duration100ns{static_cast<int64_t>(m_timelineDurationSeconds * 10'000'000.0)};
+    if(!m_prj.toggleCutBlockAtTime100ns(time100ns, duration100ns)){
         return false;
     }
 
@@ -1192,9 +1222,10 @@ bool MainWindow::toggleCutBlockAtCanvasX(double pointerX){
     return true;
 }
 
-bool MainWindow::setCutBlockAtCanvasX(double pointerX, bool cutScene){
+bool MainWindow::setCutBlockAtTime100ns(int64_t time100ns, bool cutScene){
     (void)pushUndoStateIfChanged();
-    if(!m_prj.setCutBlockAtCanvasX(pointerX, TimelineCanvas().Width(), m_timelineDurationSeconds, cutScene)){
+    const auto duration100ns{static_cast<int64_t>(m_timelineDurationSeconds * 10'000'000.0)};
+    if(!m_prj.setCutBlockAtTime100ns(time100ns, duration100ns, cutScene)){
         return false;
     }
 
@@ -1204,11 +1235,17 @@ bool MainWindow::setCutBlockAtCanvasX(double pointerX, bool cutScene){
 }
 
 bool MainWindow::toggleCutMarkerAtCursor(){
-    return toggleSelectedKeyframeAtCanvasX(Controls::Canvas::GetLeft(TimelineCursor()));
+    if(const auto time100ns{timelinePointToTime100ns(Controls::Canvas::GetLeft(TimelineCursor()), TimelineTickCanvas().Width())}){
+        return toggleSelectedKeyframeAtTime100ns(*time100ns);
+    }
+    return false;
 }
 
 bool MainWindow::markSceneAtCursor(bool cutScene){
-    return setCutBlockAtCanvasX(Controls::Canvas::GetLeft(TimelineCursor()), cutScene);
+    if(const auto time100ns{timelinePointToTime100ns(Controls::Canvas::GetLeft(TimelineCursor()), TimelineCanvas().Width())}){
+        return setCutBlockAtTime100ns(*time100ns, cutScene);
+    }
+    return false;
 }
 
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -719,7 +719,7 @@ void MainWindow::reevaluateClearCutMarkersButton_Click(const Control&, const REA
         return;
     }
 
-    const auto previousCutRanges{m_prj.buildCutRanges100ns(m_timelineDurationSeconds)};
+    const auto previousCutRanges{m_prj.buildCutRanges100ns()};
     const auto beforeState{captureUndoRedoState()};
     const auto hasUndoSnapshot{pushUndoStateIfChanged()};
     vector<IndexedFrameSample> updatedMarkers;
@@ -750,8 +750,8 @@ void MainWindow::reevaluateClearCutMarkersButton_Click(const Control&, const REA
     m_prj.frameIndex() = std::move(updatedMarkers);
     m_prj.refreshSelectedMarkers();
 
-    const auto totalDuration100ns{static_cast<int64_t>(m_timelineDurationSeconds * HNS_PER_SECOND)};
-    const auto sceneBoundaries{m_prj.buildSceneBoundaries100ns(totalDuration100ns)};
+    const auto totalDuration100ns{m_prj.timelineDuration100ns()};
+    const auto sceneBoundaries{m_prj.buildSceneBoundaries100ns()};
     m_prj.cutScenes().clear();
     for(size_t i{}; i + 1 < sceneBoundaries.size(); ++i){
         const auto midpoint{sceneBoundaries[i] + (sceneBoundaries[i + 1] - sceneBoundaries[i]) / 2};
@@ -902,20 +902,19 @@ void MainWindow::timelineCanvas_PointerMoved(const Control&, const PREArgs& e){
     e.Handled(true);
 }
 
-optional<int64_t> MainWindow::timelinePointToTime100ns(double pointerX, double width) const{
-    if(m_timelineDurationSeconds <= 0 || width <= 0){
-        return nullopt;
+std::optional<int64_t> MainWindow::timelinePointToTime100ns(double pointerX, double width) const{
+    const auto duration100ns{m_prj.timelineDuration100ns()};
+    if(duration100ns <= 0 || width <= 0){
+        return std::nullopt;
     }
 
-    const auto duration100ns{static_cast<int64_t>(m_timelineDurationSeconds * 10'000'000.0)};
     const auto clampedX{clamp(pointerX, 0.0, width)};
     return static_cast<int64_t>((clampedX / width) * duration100ns);
 }
 
 bool MainWindow::toggleSelectedKeyframeAtTime100ns(int64_t time100ns){
     (void)pushUndoStateIfChanged();
-    const auto duration100ns{static_cast<int64_t>(m_timelineDurationSeconds * 10'000'000.0)};
-    if(!m_prj.toggleSelectedKeyframeAtTime100ns(time100ns, duration100ns, m_mediaInfo.frameRate)){
+    if(!m_prj.toggleSelectedKeyframeAtTime100ns(time100ns, m_mediaInfo.frameRate)){
         return false;
     }
 
@@ -1001,6 +1000,7 @@ void MainWindow::timelineTickCanvas_PointerReleased(const Control&, const PREArg
 void MainWindow::onNaturalDurationChanged(const MPSession& sender, const Control&){
     const auto duration{sender.NaturalDuration()};
     m_timelineDurationSeconds = max(0.0, duration.count() / 10'000'000.0);
+    m_prj.timelineDuration100ns(max<int64_t>(0, duration.count()));
 
     if(m_prj.videoFile() && m_timelineDurationSeconds > 0){
         const auto weak{get_weak()};
@@ -1186,7 +1186,7 @@ void MainWindow::renderCutOverlays(){
         return;
     }
 
-    const auto cutRanges100ns{m_prj.buildCutRanges100ns(m_timelineDurationSeconds)};
+    const auto cutRanges100ns{m_prj.buildCutRanges100ns()};
     const auto overlayColor {Windows::UI::ColorHelper::FromArgb(180, 0, 0, 0)};
     for(const auto& [startTime100ns, endTime100ns]: cutRanges100ns){
         const auto start{clamp((static_cast<double>(startTime100ns) / 10'000'000.0) / m_timelineDurationSeconds, 0.0, 1.0)};
@@ -1212,8 +1212,7 @@ void MainWindow::renderCutOverlays(){
 
 bool MainWindow::toggleCutBlockAtTime100ns(int64_t time100ns){
     (void)pushUndoStateIfChanged();
-    const auto duration100ns{static_cast<int64_t>(m_timelineDurationSeconds * 10'000'000.0)};
-    if(!m_prj.toggleCutBlockAtTime100ns(time100ns, duration100ns)){
+    if(!m_prj.toggleCutBlockAtTime100ns(time100ns)){
         return false;
     }
 
@@ -1224,8 +1223,7 @@ bool MainWindow::toggleCutBlockAtTime100ns(int64_t time100ns){
 
 bool MainWindow::setCutBlockAtTime100ns(int64_t time100ns, bool cutScene){
     (void)pushUndoStateIfChanged();
-    const auto duration100ns{static_cast<int64_t>(m_timelineDurationSeconds * 10'000'000.0)};
-    if(!m_prj.setCutBlockAtTime100ns(time100ns, duration100ns, cutScene)){
+    if(!m_prj.setCutBlockAtTime100ns(time100ns, cutScene)){
         return false;
     }
 
@@ -1259,7 +1257,7 @@ bool MainWindow::trySkipCurrentCutDuringPlayback(){
         return false;
     }
 
-    const auto cutRanges100ns{m_prj.buildCutRanges100ns(m_timelineDurationSeconds)};
+    const auto cutRanges100ns{m_prj.buildCutRanges100ns()};
     const auto now100ns{max<int64_t>(0, m_player.PlaybackSession().Position().count())};
     for(const auto& [start100ns, end100ns]: cutRanges100ns){
         if(now100ns >= start100ns && now100ns < end100ns){
@@ -1963,7 +1961,7 @@ void MainWindow::clearErrorMessage(){
 }
 
 void MainWindow::refreshStatusInfoSection(){
-    const auto outputDuration100ns{m_prj.outputDuration100ns(m_timelineDurationSeconds)};
+    const auto outputDuration100ns{m_prj.outputDuration100ns()};
     wstring text{L"Estimated output: "};
     text += formatTimelineDurationText(outputDuration100ns);
     InfoText().Text(text);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1192,6 +1192,25 @@ bool MainWindow::toggleCutBlockAtCanvasX(double pointerX){
     return true;
 }
 
+bool MainWindow::setCutBlockAtCanvasX(double pointerX, bool cutScene){
+    (void)pushUndoStateIfChanged();
+    if(!m_prj.setCutBlockAtCanvasX(pointerX, TimelineCanvas().Width(), m_timelineDurationSeconds, cutScene)){
+        return false;
+    }
+
+    renderCutOverlays();
+    updateWindowTitle();
+    return true;
+}
+
+bool MainWindow::toggleCutMarkerAtCursor(){
+    return toggleSelectedKeyframeAtCanvasX(Controls::Canvas::GetLeft(TimelineCursor()));
+}
+
+bool MainWindow::markSceneAtCursor(bool cutScene){
+    return setCutBlockAtCanvasX(Controls::Canvas::GetLeft(TimelineCursor()), cutScene);
+}
+
 
 bool MainWindow::trySkipCurrentCutDuringPlayback(){
     if(!m_player || m_prj.cutScenes().empty() || m_timelineDurationSeconds <= 0){
@@ -1312,6 +1331,11 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
             args.Handled(true);
             return true;
         }
+        if(args.Key() == VirtualKey::M){
+            (void)toggleCutMarkerAtCursor();
+            args.Handled(true);
+            return true;
+        }
     }
 
     if(focusOnMenu || focusInDialog){
@@ -1338,6 +1362,14 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         return true;
     case VirtualKey::Right:
         stepByFrame(1);
+        args.Handled(true);
+        return true;
+    case VirtualKey::Delete:
+        (void)markSceneAtCursor(true);
+        args.Handled(true);
+        return true;
+    case VirtualKey::Insert:
+        (void)markSceneAtCursor(false);
         args.Handled(true);
         return true;
     default:
@@ -1387,6 +1419,17 @@ void MainWindow::videoDetailsOpenMarker_Click(const Control&, const REArgs&){
 
 void MainWindow::videoDetailsCollapseMarker_Click(const Control&, const REArgs&){
     setVideoDetailsPanelExpanded(false);
+}
+
+void MainWindow::cheatSheetOpenMarker_Click(const Control&, const REArgs&){
+    CheatSheetPanel().Visibility(Visibility::Visible);
+    CheatSheetOpenMarker().Visibility(Visibility::Collapsed);
+}
+
+void MainWindow::cheatSheetCollapseMarker_Click(const Control&, const REArgs&){
+    CheatSheetPanel().Visibility(Visibility::Collapsed);
+    CheatSheetOpenMarker().Visibility(Visibility::Visible);
+    tryFocusTimelineCanvas(FocusState::Programmatic);
 }
 
 TS MainWindow::secondsToTimeSpan(double seconds){
@@ -1578,6 +1621,21 @@ AAction MainWindow::aboutMenuItem_Click(const Control&, const REArgs&){
 
 AAction MainWindow::optionsMenuItem_Click(const Control&, const REArgs&){
     co_await showOptionsDialogAsync();
+}
+
+AAction MainWindow::toggleCutMarkerAtCursorMenuItem_Click(const Control&, const REArgs&){
+    (void)toggleCutMarkerAtCursor();
+    co_return;
+}
+
+AAction MainWindow::markSceneCutAtCursorMenuItem_Click(const Control&, const REArgs&){
+    (void)markSceneAtCursor(true);
+    co_return;
+}
+
+AAction MainWindow::markSceneKeptAtCursorMenuItem_Click(const Control&, const REArgs&){
+    (void)markSceneAtCursor(false);
+    co_return;
 }
 
 AAction MainWindow::pickAndLoadVideoAsync(){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1309,6 +1309,71 @@ void MainWindow::stepByFrame(int delta){
     updateTimelineCursorFromPlayback();
 }
 
+
+bool MainWindow::moveCursorToMarker(int direction){
+    if(direction == 0){
+        return false;
+    }
+
+    const auto duration100ns{m_prj.timelineDuration100ns()};
+    if(duration100ns <= 0){
+        return false;
+    }
+
+    const auto markers{m_prj.buildRapMarkersFromSelection()};
+    if(markers.empty()){
+        return false;
+    }
+
+    int64_t current100ns{};
+    if(m_player){
+        current100ns = max<int64_t>(0, m_player.PlaybackSession().Position().count());
+    }else if(const auto cursor100ns{timelinePointToTime100ns(Controls::Canvas::GetLeft(TimelineCursor()), TimelineCanvas().Width())}){
+        current100ns = *cursor100ns;
+    }
+
+    int64_t target100ns{current100ns};
+    if(direction < 0){
+        auto candidateFound{false};
+        for(const auto& marker: markers){
+            if(marker.time100ns >= current100ns){
+                break;
+            }
+            target100ns = marker.time100ns;
+            candidateFound = true;
+        }
+        if(!candidateFound){
+            return false;
+        }
+    }else{
+        const auto it{find_if(markers.begin(), markers.end(), [current100ns](const auto& marker){
+            return marker.time100ns > current100ns;
+        })};
+        if(it == markers.end()){
+            return false;
+        }
+        target100ns = it->time100ns;
+    }
+
+    if(m_player){
+        m_player.PlaybackSession().Position(TimeSpan{target100ns});
+        updateTimelineCursorFromPlayback();
+        return true;
+    }
+
+    const auto width{TimelineCanvas().Width()};
+    if(width > 0){
+        const auto ratio{clamp(static_cast<double>(target100ns) / duration100ns, 0.0, 1.0)};
+        const auto left{ratio * width};
+        Controls::Canvas::SetLeft(TimelineCursor(), left);
+        ensureTimelineCursorVisible(left);
+        syncTimelineHorizontalScrollBar();
+        return true;
+    }
+
+    return false;
+}
+
 void MainWindow::tryFocusTimelineCanvas(FState focusState){
     const auto canvas{TimelineCanvas()};
     if(canvas && canvas.XamlRoot()){
@@ -1397,6 +1462,14 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         return true;
     case VirtualKey::Right:
         stepByFrame(1);
+        args.Handled(true);
+        return true;
+    case VirtualKey::Up:
+        (void)moveCursorToMarker(-1);
+        args.Handled(true);
+        return true;
+    case VirtualKey::Down:
+        (void)moveCursorToMarker(1);
         args.Handled(true);
         return true;
     case VirtualKey::Delete:

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -73,6 +74,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     void stopButton_Click(const Control& sender, const REArgs& args);
     void reevaluateClearCutMarkersButton_Click(const Control& sender, const REArgs& args);
     void timelineZoomSlider_ValueChanged(const Control& sender, const RBVArgs& args);
+    void timelineZoomSlider_PointerWheelChanged(const Control& sender, const PREArgs& args);
     void keepAudioCheckBox_Changed(const Control& sender, const REArgs& args);
     void audioCrossfadeComboBox_SelectionChanged(const Control& sender, const Control& args);
     void timelineHorizontalScrollBar_ValueChanged(const Control& sender, const RBVArgs& args);
@@ -180,9 +182,10 @@ private:
     void seekTimelineToCanvasX(double pointerX);
     void renderKeyframeTicks();
     void renderCutOverlays();
-    bool toggleSelectedKeyframeAtCanvasX(double pointerX);
-    bool toggleCutBlockAtCanvasX(double pointerX);
-    bool setCutBlockAtCanvasX(double pointerX, bool cutScene);
+    std::optional<int64_t> timelinePointToTime100ns(double pointerX, double width) const;
+    bool toggleSelectedKeyframeAtTime100ns(int64_t time100ns);
+    bool toggleCutBlockAtTime100ns(int64_t time100ns);
+    bool setCutBlockAtTime100ns(int64_t time100ns, bool cutScene);
     bool toggleCutMarkerAtCursor();
     bool markSceneAtCursor(bool cutScene);
     bool trySkipCurrentCutDuringPlayback();

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -190,6 +190,7 @@ private:
     bool markSceneAtCursor(bool cutScene);
     bool trySkipCurrentCutDuringPlayback();
     void stepByFrame(int delta);
+    bool moveCursorToMarker(int direction);
     void ensureTimelineCursorVisible(double cursorLeft);
     void tryFocusTimelineCanvas(const FState focusState);
     bool handleStorylineKeyDown(const KRArgs& args);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -90,6 +90,8 @@ struct MainWindow: MainWindowT<MainWindow>{
     void rootGrid_PointerReleased(const Control& sender, const PREArgs& args);
     void videoDetailsOpenMarker_Click(const Control& sender, const REArgs& args);
     void videoDetailsCollapseMarker_Click(const Control& sender, const REArgs& args);
+    void cheatSheetOpenMarker_Click(const Control& sender, const REArgs& args);
+    void cheatSheetCollapseMarker_Click(const Control& sender, const REArgs& args);
     AAction newProjectMenuItem_Click(const Control& sender, const REArgs& args);
     AAction undoMenuItem_Click(const Control& sender, const REArgs& args);
     AAction redoMenuItem_Click(const Control& sender, const REArgs& args);
@@ -106,6 +108,9 @@ struct MainWindow: MainWindowT<MainWindow>{
     AAction manualMenuItem_Click(const Control& sender, const REArgs& args);
     AAction aboutMenuItem_Click(const Control& sender, const REArgs& args);
     AAction optionsMenuItem_Click(const Control& sender, const REArgs& args);
+    AAction toggleCutMarkerAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
+    AAction markSceneCutAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
+    AAction markSceneKeptAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     void window_DragOver(const Control& sender, const DEArgs& args);
     AAction window_Drop(const Control& sender, const DEArgs& args);
     void onClosed(const Control& sender, const WEArgs& args);
@@ -177,6 +182,9 @@ private:
     void renderCutOverlays();
     bool toggleSelectedKeyframeAtCanvasX(double pointerX);
     bool toggleCutBlockAtCanvasX(double pointerX);
+    bool setCutBlockAtCanvasX(double pointerX, bool cutScene);
+    bool toggleCutMarkerAtCursor();
+    bool markSceneAtCursor(bool cutScene);
     bool trySkipCurrentCutDuringPlayback();
     void stepByFrame(int delta);
     void ensureTimelineCursorVisible(double cursorLeft);

--- a/Win/llvc/Project.ixx
+++ b/Win/llvc/Project.ixx
@@ -45,22 +45,24 @@ struct Project final{
     inline decltype(auto) cutScenes(this auto& self)      { return (self.m_cutScenes); }
 
     vector<IndexedFrameSample> buildRapMarkersFromSelection() const;
-    vector<pair<int64_t, int64_t>> buildCutRanges100ns(double tlDurationSeconds) const;
-    vector<int64_t> buildSceneBoundaries100ns(int64_t totalDuration100ns) const;
+    vector<pair<int64_t, int64_t>> buildCutRanges100ns() const;
+    vector<int64_t> buildSceneBoundaries100ns() const;
     vector<pair<int64_t, int64_t>> buildEffectiveCutRangesWithRapPreroll(int64_t totalDuration100ns, const vector<int64_t>& rapTimes100ns) const;
-    int64_t outputDuration100ns(double tlDurationSeconds) const;
+    int64_t outputDuration100ns() const;
     void refreshSelectedMarkers();
     void remapCutScenesAfterMarkerRemoval(uint32_t removePos);
     void remapCutScenesAfterMarkerInsertion(uint32_t insertPos);
-    bool toggleSelectedKeyframeAtTime100ns(int64_t time100ns, int64_t totalDuration100ns, double fps);
-    bool toggleCutBlockAtTime100ns(int64_t time100ns, int64_t totalDuration100ns);
-    bool setCutBlockAtTime100ns(int64_t time100ns, int64_t totalDuration100ns, bool cutScene);
+    void timelineDuration100ns(int64_t duration);
+    inline int64_t timelineDuration100ns() const{ return m_timelineDuration100ns; }
+    bool toggleSelectedKeyframeAtTime100ns(int64_t time100ns, double fps);
+    bool toggleCutBlockAtTime100ns(int64_t time100ns);
+    bool setCutBlockAtTime100ns(int64_t time100ns, bool cutScene);
 
 private:
     wstring _buildProjectSnapshot() const;
     wstring _serializeCutMarkers() const;
     static vector<IndexedFrameSample> _parseKeyframeVector(const wstring& text);
-    optional<size_t> _sceneIndexAtTime100ns(int64_t time100ns, int64_t totalDuration100ns) const;
+    std::optional<size_t> _sceneIndexAtTime100ns(int64_t time100ns) const;
 
 private:
     // these are persisted on disk
@@ -72,6 +74,7 @@ private:
     vector<uint32_t> m_selectedKeyFrames{};
     vector<uint32_t> m_cutScenes{};
 
+    int64_t m_timelineDuration100ns{0};
     bool m_isDirty{false};
     wstring m_lastSavedProjectSnapshot{}; // must be *after* all the members to reflect proper initial state
 };
@@ -134,6 +137,7 @@ void Project::clearTimeline(){
     m_frameIndex.clear();
     m_selectedKeyFrames.clear();
     m_cutScenes.clear();
+    m_timelineDuration100ns = 0;
 }
 
 Project::AAction Project::open(const SFile& file){
@@ -224,10 +228,8 @@ vector<IndexedFrameSample> Project::buildRapMarkersFromSelection() const{
     return rapMarkers;
 }
 
-vector<pair<int64_t, int64_t>> Project::buildCutRanges100ns(double tlDurationSeconds) const{
-    const auto duration100ns{static_cast<int64_t>(tlDurationSeconds * 10'000'000.0)};
-
-    const auto boundaries{buildSceneBoundaries100ns(duration100ns)};
+vector<pair<int64_t, int64_t>> Project::buildCutRanges100ns() const{
+    const auto boundaries{buildSceneBoundaries100ns()};
     if(boundaries.size() < 2){
         return {};
     }
@@ -257,7 +259,8 @@ vector<pair<int64_t, int64_t>> Project::buildCutRanges100ns(double tlDurationSec
     return merged;
 }
 
-vector<int64_t> Project::buildSceneBoundaries100ns(int64_t totalDuration100ns) const{
+vector<int64_t> Project::buildSceneBoundaries100ns() const{
+    const auto totalDuration100ns{m_timelineDuration100ns};
     const auto markers{buildRapMarkersFromSelection()};
     vector<int64_t> boundaries;
     boundaries.reserve(markers.size() + 2);
@@ -278,7 +281,22 @@ vector<int64_t> Project::buildSceneBoundaries100ns(int64_t totalDuration100ns) c
 }
 
 vector<pair<int64_t, int64_t>> Project::buildEffectiveCutRangesWithRapPreroll(int64_t totalDuration100ns, const vector<int64_t>& rapTimes100ns) const{
-    const auto boundaries{buildSceneBoundaries100ns(totalDuration100ns)};
+    const auto markers{buildRapMarkersFromSelection()};
+    vector<int64_t> boundaries;
+    boundaries.reserve(markers.size() + 2);
+    boundaries.push_back(0);
+    for(const auto& marker: markers){
+        boundaries.push_back(clamp<int64_t>(marker.time100ns, 0, totalDuration100ns));
+    }
+    boundaries.push_back(totalDuration100ns);
+    sort(boundaries.begin(), boundaries.end());
+    boundaries.erase(unique(boundaries.begin(), boundaries.end()), boundaries.end());
+    if(boundaries.empty() || boundaries.front() != 0){
+        boundaries.insert(boundaries.begin(), 0);
+    }
+    if(boundaries.back() != totalDuration100ns){
+        boundaries.push_back(totalDuration100ns);
+    }
     if(boundaries.size() < 2){
         return {};
     }
@@ -349,9 +367,9 @@ vector<pair<int64_t, int64_t>> Project::buildEffectiveCutRangesWithRapPreroll(in
     return mergedCuts;
 }
 
-int64_t Project::outputDuration100ns(double tlDurationSeconds) const{
-    const auto sourceDuration100ns{max<int64_t>(0, static_cast<int64_t>(llround(max(0.0, tlDurationSeconds) * 10'000'000.0)))};
-    const auto cutRanges100ns{buildCutRanges100ns(tlDurationSeconds)};
+int64_t Project::outputDuration100ns() const{
+    const auto sourceDuration100ns{m_timelineDuration100ns};
+    const auto cutRanges100ns{buildCutRanges100ns()};
 
     int64_t removedTotal100ns{};
     for(const auto& [start, end]: cutRanges100ns){
@@ -415,16 +433,20 @@ void Project::remapCutScenesAfterMarkerInsertion(uint32_t insertPos){
     m_cutScenes = std::move(updatedCuts);
 }
 
-bool Project::toggleSelectedKeyframeAtTime100ns(int64_t time100ns, int64_t totalDuration100ns, double fps){
-    if(totalDuration100ns <= 0){
+void Project::timelineDuration100ns(int64_t duration){
+    m_timelineDuration100ns = max<int64_t>(0, duration);
+}
+
+bool Project::toggleSelectedKeyframeAtTime100ns(int64_t time100ns, double fps){
+    if(m_timelineDuration100ns <= 0){
         return false;
     }
 
-    constexpr auto hitTolerance100ns{50'000};
-    const auto clicked100ns{clamp<int64_t>(time100ns, 0, totalDuration100ns)};
+    constexpr int64_t hitTolerance100ns{50'000};
+    const auto clicked100ns{clamp<int64_t>(time100ns, 0, m_timelineDuration100ns)};
 
     auto nearestIndex{m_frameIndex.size()};
-    auto nearestDistance{hitTolerance100ns + 1};
+    int64_t nearestDistance{hitTolerance100ns + 1};
     for(size_t i{0}; i < m_frameIndex.size(); ++i){
         const auto distance{llabs(m_frameIndex[i].time100ns - clicked100ns)};
         if(distance <= hitTolerance100ns && distance < nearestDistance){
@@ -454,8 +476,8 @@ bool Project::toggleSelectedKeyframeAtTime100ns(int64_t time100ns, int64_t total
     return true;
 }
 
-bool Project::toggleCutBlockAtTime100ns(int64_t time100ns, int64_t totalDuration100ns){
-    const auto sceneIndex{_sceneIndexAtTime100ns(time100ns, totalDuration100ns)};
+bool Project::toggleCutBlockAtTime100ns(int64_t time100ns){
+    const auto sceneIndex{_sceneIndexAtTime100ns(time100ns)};
     if(!sceneIndex){
         return false;
     }
@@ -471,8 +493,8 @@ bool Project::toggleCutBlockAtTime100ns(int64_t time100ns, int64_t totalDuration
     return true;
 }
 
-bool Project::setCutBlockAtTime100ns(int64_t time100ns, int64_t totalDuration100ns, bool cutScene){
-    const auto sceneIndex{_sceneIndexAtTime100ns(time100ns, totalDuration100ns)};
+bool Project::setCutBlockAtTime100ns(int64_t time100ns, bool cutScene){
+    const auto sceneIndex{_sceneIndexAtTime100ns(time100ns)};
     if(!sceneIndex){
         return false;
     }
@@ -491,15 +513,15 @@ bool Project::setCutBlockAtTime100ns(int64_t time100ns, int64_t totalDuration100
 }
 
 
-optional<size_t> Project::_sceneIndexAtTime100ns(int64_t time100ns, int64_t totalDuration100ns) const{
-    if(totalDuration100ns <= 0){
-        return nullopt;
+std::optional<size_t> Project::_sceneIndexAtTime100ns(int64_t time100ns) const{
+    if(m_timelineDuration100ns <= 0){
+        return std::nullopt;
     }
 
-    const auto clicked100ns{clamp<int64_t>(time100ns, 0, totalDuration100ns)};
-    const auto boundaries{buildSceneBoundaries100ns(totalDuration100ns)};
+    const auto clicked100ns{clamp<int64_t>(time100ns, 0, m_timelineDuration100ns)};
+    const auto boundaries{buildSceneBoundaries100ns()};
     if(boundaries.size() < 2){
-        return nullopt;
+        return std::nullopt;
     }
 
     auto sceneIndex{boundaries.size() - 2};

--- a/Win/llvc/Project.ixx
+++ b/Win/llvc/Project.ixx
@@ -54,6 +54,7 @@ struct Project final{
     void remapCutScenesAfterMarkerInsertion(uint32_t insertPos);
     bool toggleSelectedKeyframeAtCanvasX(double pointerX, double width, double tlDurationSeconds, double fps);
     bool toggleCutBlockAtCanvasX(double pointerX, double width, double tlDurationSeconds);
+    bool setCutBlockAtCanvasX(double pointerX, double width, double tlDurationSeconds, bool cutScene);
 
 private:
     wstring _buildProjectSnapshot() const;
@@ -477,6 +478,38 @@ bool Project::toggleCutBlockAtCanvasX(double pointerX, double width, double tlDu
         m_cutScenes.push_back(static_cast<uint32_t>(sceneIndex));
         sort(m_cutScenes.begin(), m_cutScenes.end());
     }else{
+        m_cutScenes.erase(it);
+    }
+
+    return true;
+}
+
+bool Project::setCutBlockAtCanvasX(double pointerX, double width, double tlDurationSeconds, bool cutScene){
+    if(tlDurationSeconds <= 0 || width <= 0){
+        return false;
+    }
+
+    const auto clicked100ns{static_cast<int64_t>(clamp(pointerX, 0.0, width) / width * (tlDurationSeconds * 10'000'000.0))};
+    const auto boundaries{buildSceneBoundaries100ns(static_cast<int64_t>(tlDurationSeconds * 10'000'000.0))};
+    if(boundaries.size() < 2){
+        return false;
+    }
+
+    auto sceneIndex{boundaries.size() - 2};
+    for(size_t i{0}; i + 1 < boundaries.size(); ++i){
+        if(clicked100ns < boundaries[i + 1]){
+            sceneIndex = i;
+            break;
+        }
+    }
+
+    const auto it{find(m_cutScenes.begin(), m_cutScenes.end(), sceneIndex)};
+    if(cutScene){
+        if(it == m_cutScenes.end()){
+            m_cutScenes.push_back(static_cast<uint32_t>(sceneIndex));
+            sort(m_cutScenes.begin(), m_cutScenes.end());
+        }
+    } else if(it != m_cutScenes.end()){
         m_cutScenes.erase(it);
     }
 

--- a/Win/llvc/Project.ixx
+++ b/Win/llvc/Project.ixx
@@ -52,14 +52,15 @@ struct Project final{
     void refreshSelectedMarkers();
     void remapCutScenesAfterMarkerRemoval(uint32_t removePos);
     void remapCutScenesAfterMarkerInsertion(uint32_t insertPos);
-    bool toggleSelectedKeyframeAtCanvasX(double pointerX, double width, double tlDurationSeconds, double fps);
-    bool toggleCutBlockAtCanvasX(double pointerX, double width, double tlDurationSeconds);
-    bool setCutBlockAtCanvasX(double pointerX, double width, double tlDurationSeconds, bool cutScene);
+    bool toggleSelectedKeyframeAtTime100ns(int64_t time100ns, int64_t totalDuration100ns, double fps);
+    bool toggleCutBlockAtTime100ns(int64_t time100ns, int64_t totalDuration100ns);
+    bool setCutBlockAtTime100ns(int64_t time100ns, int64_t totalDuration100ns, bool cutScene);
 
 private:
     wstring _buildProjectSnapshot() const;
     wstring _serializeCutMarkers() const;
     static vector<IndexedFrameSample> _parseKeyframeVector(const wstring& text);
+    optional<size_t> _sceneIndexAtTime100ns(int64_t time100ns, int64_t totalDuration100ns) const;
 
 private:
     // these are persisted on disk
@@ -414,20 +415,19 @@ void Project::remapCutScenesAfterMarkerInsertion(uint32_t insertPos){
     m_cutScenes = std::move(updatedCuts);
 }
 
-bool Project::toggleSelectedKeyframeAtCanvasX(double pointerX, double width, double tlDurationSeconds, double fps){
-    if(tlDurationSeconds <= 0 || width <= 0){
+bool Project::toggleSelectedKeyframeAtTime100ns(int64_t time100ns, int64_t totalDuration100ns, double fps){
+    if(totalDuration100ns <= 0){
         return false;
     }
 
-    constexpr auto hitTolerancePx{4.0};
-    const auto clicked100ns{static_cast<int64_t>(clamp(pointerX, 0.0, width) / width * (tlDurationSeconds * 10'000'000.0))};
+    constexpr auto hitTolerance100ns{50'000};
+    const auto clicked100ns{clamp<int64_t>(time100ns, 0, totalDuration100ns)};
 
     auto nearestIndex{m_frameIndex.size()};
-    auto nearestDistance{hitTolerancePx + 1.0};
+    auto nearestDistance{hitTolerance100ns + 1};
     for(size_t i{0}; i < m_frameIndex.size(); ++i){
-        const auto x{clamp((static_cast<double>(m_frameIndex[i].time100ns) / (tlDurationSeconds * 10'000'000.0)) * width, 0.0, width)};
-        const auto distance{fabs(pointerX - x)};
-        if(distance <= hitTolerancePx && distance < nearestDistance){
+        const auto distance{llabs(m_frameIndex[i].time100ns - clicked100ns)};
+        if(distance <= hitTolerance100ns && distance < nearestDistance){
             nearestDistance = distance;
             nearestIndex = i;
         }
@@ -454,28 +454,15 @@ bool Project::toggleSelectedKeyframeAtCanvasX(double pointerX, double width, dou
     return true;
 }
 
-bool Project::toggleCutBlockAtCanvasX(double pointerX, double width, double tlDurationSeconds){
-    if(tlDurationSeconds <= 0 || width <= 0){
+bool Project::toggleCutBlockAtTime100ns(int64_t time100ns, int64_t totalDuration100ns){
+    const auto sceneIndex{_sceneIndexAtTime100ns(time100ns, totalDuration100ns)};
+    if(!sceneIndex){
         return false;
     }
 
-    const auto clicked100ns{static_cast<int64_t>(clamp(pointerX, 0.0, width) / width * (tlDurationSeconds * 10'000'000.0))};
-    const auto boundaries{buildSceneBoundaries100ns(static_cast<int64_t>(tlDurationSeconds * 10'000'000.0))};
-    if(boundaries.size() < 2){
-        return false;
-    }
-
-    auto sceneIndex{boundaries.size() - 2};
-    for(size_t i{0}; i + 1 < boundaries.size(); ++i){
-        if(clicked100ns < boundaries[i + 1]){
-            sceneIndex = i;
-            break;
-        }
-    }
-
-    const auto it{find(m_cutScenes.begin(), m_cutScenes.end(), sceneIndex)};
+    const auto it{find(m_cutScenes.begin(), m_cutScenes.end(), *sceneIndex)};
     if(it == m_cutScenes.end()){
-        m_cutScenes.push_back(static_cast<uint32_t>(sceneIndex));
+        m_cutScenes.push_back(static_cast<uint32_t>(*sceneIndex));
         sort(m_cutScenes.begin(), m_cutScenes.end());
     }else{
         m_cutScenes.erase(it);
@@ -484,15 +471,35 @@ bool Project::toggleCutBlockAtCanvasX(double pointerX, double width, double tlDu
     return true;
 }
 
-bool Project::setCutBlockAtCanvasX(double pointerX, double width, double tlDurationSeconds, bool cutScene){
-    if(tlDurationSeconds <= 0 || width <= 0){
+bool Project::setCutBlockAtTime100ns(int64_t time100ns, int64_t totalDuration100ns, bool cutScene){
+    const auto sceneIndex{_sceneIndexAtTime100ns(time100ns, totalDuration100ns)};
+    if(!sceneIndex){
         return false;
     }
 
-    const auto clicked100ns{static_cast<int64_t>(clamp(pointerX, 0.0, width) / width * (tlDurationSeconds * 10'000'000.0))};
-    const auto boundaries{buildSceneBoundaries100ns(static_cast<int64_t>(tlDurationSeconds * 10'000'000.0))};
+    const auto it{find(m_cutScenes.begin(), m_cutScenes.end(), *sceneIndex)};
+    if(cutScene){
+        if(it == m_cutScenes.end()){
+            m_cutScenes.push_back(static_cast<uint32_t>(*sceneIndex));
+            sort(m_cutScenes.begin(), m_cutScenes.end());
+        }
+    } else if(it != m_cutScenes.end()){
+        m_cutScenes.erase(it);
+    }
+
+    return true;
+}
+
+
+optional<size_t> Project::_sceneIndexAtTime100ns(int64_t time100ns, int64_t totalDuration100ns) const{
+    if(totalDuration100ns <= 0){
+        return nullopt;
+    }
+
+    const auto clicked100ns{clamp<int64_t>(time100ns, 0, totalDuration100ns)};
+    const auto boundaries{buildSceneBoundaries100ns(totalDuration100ns)};
     if(boundaries.size() < 2){
-        return false;
+        return nullopt;
     }
 
     auto sceneIndex{boundaries.size() - 2};
@@ -503,17 +510,7 @@ bool Project::setCutBlockAtCanvasX(double pointerX, double width, double tlDurat
         }
     }
 
-    const auto it{find(m_cutScenes.begin(), m_cutScenes.end(), sceneIndex)};
-    if(cutScene){
-        if(it == m_cutScenes.end()){
-            m_cutScenes.push_back(static_cast<uint32_t>(sceneIndex));
-            sort(m_cutScenes.begin(), m_cutScenes.end());
-        }
-    } else if(it != m_cutScenes.end()){
-        m_cutScenes.erase(it);
-    }
-
-    return true;
+    return sceneIndex;
 }
 
 wstring Project::_buildProjectSnapshot() const{


### PR DESCRIPTION
### Motivation
- Provide quick keyboard access to common timeline editing operations so users can toggle cut markers and mark scenes without mouse-only interaction. 
- Allow deterministic marking of a scene as cut or kept via dedicated keys rather than only toggling state. 
- Surface a compact, non-intrusive quick-action cheat-sheet on the right edge so users can discover mouse/keyboard actions at a glance without stealing keyboard focus.

### Description
- Added Edit menu items and command handlers for `Toggle cut mark (Ctrl+M)`, `Mark scene cut (Delete)`, and `Mark scene kept (Insert)` in `Win/llvc/MainWindow.xaml` and wired async menu handlers in `MainWindow.xaml.cpp`.
- Implemented keyboard handling to invoke the same actions from `handleStorylineKeyDown` so `Ctrl+M`, `Delete`, and `Insert` operate at the timeline cursor; added helper methods `toggleCutMarkerAtCursor`, `markSceneAtCursor`, and `setCutBlockAtCanvasX` in `MainWindow.xaml.cpp` and declarations in `MainWindow.xaml.h`.
- Added an explicit project-level API `Project::setCutBlockAtCanvasX(...)` in `Win/llvc/Project.ixx` to set a scene at a given canvas position to cut or kept (instead of only toggling), and adapted undo/overlay rendering calls to keep UI consistent.
- Added a narrow right-edge fly-out (`CheatSheetPanel`) with concise 1–4 word action labels and left-edge close control in `MainWindow.xaml`; panel content and controls are marked non-tabbable to avoid capturing keyboard focus.

### Testing
- No automated tests were executed for this UI-focused change in this environment; changes were limited to UI wiring and project state manipulation and should be verified by building the WinUI app and performing manual UI checks for the new shortcuts, menu items, and cheat-sheet behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0eb60ead08333a9dc95a86676af1b)