### PR TITLE
llvc: add detachable preview window with full-screen toggle

### DIFF
--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -41,15 +41,18 @@
                 <MenuFlyoutItem Text="Undo	Ctrl+Z" Click="undoMenuItem_Click"/>
                 <MenuFlyoutItem Text="Redo	Ctrl+Y" Click="redoMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
+                <MenuFlyoutItem Text="Reevaluate clear cut markers	Ctrl+R" Click="reevaluateClearCutMarkersButton_Click"/>
+                <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="Toggle cut mark	Ctrl+M" Click="toggleCutMarkerAtCursorMenuItem_Click"/>
                 <MenuFlyoutItem Text="Mark scene cut	Delete" Click="markSceneCutAtCursorMenuItem_Click"/>
                 <MenuFlyoutItem Text="Mark scene kept	Insert" Click="markSceneKeptAtCursorMenuItem_Click"/>
             </controls:MenuBarItem>
+            <controls:MenuBarItem Title="View">
+                <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
+                <MenuFlyoutItem Text="Toggle preview full-screen	F11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
+            </controls:MenuBarItem>
 
             <controls:MenuBarItem Title="Tools">
-                <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
-                <MenuFlyoutItem Text="Toggle preview full-screen\tF11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
-                <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="Options" Click="optionsMenuItem_Click"/>
             </controls:MenuBarItem>
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -41,18 +41,9 @@
                 <MenuFlyoutItem Text="Undo	Ctrl+Z" Click="undoMenuItem_Click"/>
                 <MenuFlyoutItem Text="Redo	Ctrl+Y" Click="redoMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Reevaluate clear cut markers	Ctrl+R" Click="reevaluateClearCutMarkersButton_Click"/>
-                <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="Toggle cut mark	Ctrl+M" Click="toggleCutMarkerAtCursorMenuItem_Click"/>
                 <MenuFlyoutItem Text="Mark scene cut	Delete" Click="markSceneCutAtCursorMenuItem_Click"/>
                 <MenuFlyoutItem Text="Mark scene kept	Insert" Click="markSceneKeptAtCursorMenuItem_Click"/>
-            </controls:MenuBarItem>
-            <controls:MenuBarItem Title="View">
-                <MenuFlyoutItem Text="Zoom in timeline	Ctrl+Plus" Click="zoomInTimelineMenuItem_Click"/>
-                <MenuFlyoutItem Text="Zoom out timeline	Ctrl+Minus" Click="zoomOutTimelineMenuItem_Click"/>
-                <MenuFlyoutSeparator/>
-                <MenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
-                <MenuFlyoutItem Text="Toggle preview full-screen	F11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
             </controls:MenuBarItem>
 
             <controls:MenuBarItem Title="Tools">
@@ -106,8 +97,6 @@
                             <TextBlock Text="Up Arrow: prev. marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Down Arrow: next marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+M: toggle cut mark" TextWrapping="Wrap"/>
-                            <TextBlock Text="Ctrl+Plus: zoom in timeline" TextWrapping="Wrap"/>
-                            <TextBlock Text="Ctrl+Minus: zoom out timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete: cut scene" TextWrapping="Wrap"/>
                             <TextBlock Text="Insert: keep scene" TextWrapping="Wrap"/>
                             <TextBlock Text=""/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -48,7 +48,7 @@
                 <MenuFlyoutItem Text="Mark scene kept	Insert" Click="markSceneKeptAtCursorMenuItem_Click"/>
             </controls:MenuBarItem>
             <controls:MenuBarItem Title="View">
-                <MenuFlyoutItem Text="Zoom in timeline	Ctrl++" Click="zoomInTimelineMenuItem_Click"/>
+                <MenuFlyoutItem Text="Zoom in timeline	Ctrl+=" Click="zoomInTimelineMenuItem_Click"/>
                 <MenuFlyoutItem Text="Zoom out timeline	Ctrl+-" Click="zoomOutTimelineMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
                 <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
@@ -106,7 +106,7 @@
                             <TextBlock Text="Up Arrow: prev. marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Down Arrow: next marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+M: toggle cut mark" TextWrapping="Wrap"/>
-                            <TextBlock Text="Ctrl++: zoom in timeline" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+=: zoom in timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+-: zoom out timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete: cut scene" TextWrapping="Wrap"/>
                             <TextBlock Text="Insert: keep scene" TextWrapping="Wrap"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -48,8 +48,8 @@
                 <MenuFlyoutItem Text="Mark scene kept	Insert" Click="markSceneKeptAtCursorMenuItem_Click"/>
             </controls:MenuBarItem>
             <controls:MenuBarItem Title="View">
-                <MenuFlyoutItem Text="Zoom in timeline	Ctrl+Plus" Click="zoomInTimelineMenuItem_Click"/>
-                <MenuFlyoutItem Text="Zoom out timeline	Ctrl+Minus" Click="zoomOutTimelineMenuItem_Click"/>
+                <MenuFlyoutItem Text="Zoom in timeline	Ctrl+=" Click="zoomInTimelineMenuItem_Click"/>
+                <MenuFlyoutItem Text="Zoom out timeline	Ctrl+-" Click="zoomOutTimelineMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
                 <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
                 <MenuFlyoutItem Text="Toggle preview full-screen	F11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
@@ -106,8 +106,8 @@
                             <TextBlock Text="Up Arrow: prev. marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Down Arrow: next marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+M: toggle cut mark" TextWrapping="Wrap"/>
-                            <TextBlock Text="Ctrl+Plus: zoom in timeline" TextWrapping="Wrap"/>
-                            <TextBlock Text="Ctrl+Minus: zoom out timeline" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+=: zoom in timeline" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+-: zoom out timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete: cut scene" TextWrapping="Wrap"/>
                             <TextBlock Text="Insert: keep scene" TextWrapping="Wrap"/>
                             <TextBlock Text=""/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -51,7 +51,7 @@
                 <MenuFlyoutItem Text="Zoom in timeline	Ctrl+Plus" Click="zoomInTimelineMenuItem_Click"/>
                 <MenuFlyoutItem Text="Zoom out timeline	Ctrl+Minus" Click="zoomOutTimelineMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
+                <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
                 <MenuFlyoutItem Text="Toggle preview full-screen	F11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
             </controls:MenuBarItem>
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -48,8 +48,8 @@
                 <MenuFlyoutItem Text="Mark scene kept	Insert" Click="markSceneKeptAtCursorMenuItem_Click"/>
             </controls:MenuBarItem>
             <controls:MenuBarItem Title="View">
-                <MenuFlyoutItem Text="Zoom in timeline	Ctrl+=" Click="zoomInTimelineMenuItem_Click"/>
-                <MenuFlyoutItem Text="Zoom out timeline	Ctrl+-" Click="zoomOutTimelineMenuItem_Click"/>
+                <MenuFlyoutItem Text="Zoom in timeline	Ctrl+Plus" Click="zoomInTimelineMenuItem_Click"/>
+                <MenuFlyoutItem Text="Zoom out timeline	Ctrl+Minus" Click="zoomOutTimelineMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
                 <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
                 <MenuFlyoutItem Text="Toggle preview full-screen	F11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
@@ -106,8 +106,8 @@
                             <TextBlock Text="Up Arrow: prev. marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Down Arrow: next marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+M: toggle cut mark" TextWrapping="Wrap"/>
-                            <TextBlock Text="Ctrl+=: zoom in timeline" TextWrapping="Wrap"/>
-                            <TextBlock Text="Ctrl+-: zoom out timeline" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+Plus: zoom in timeline" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+Minus: zoom out timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete: cut scene" TextWrapping="Wrap"/>
                             <TextBlock Text="Insert: keep scene" TextWrapping="Wrap"/>
                             <TextBlock Text=""/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -41,9 +41,18 @@
                 <MenuFlyoutItem Text="Undo	Ctrl+Z" Click="undoMenuItem_Click"/>
                 <MenuFlyoutItem Text="Redo	Ctrl+Y" Click="redoMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
+                <MenuFlyoutItem Text="Reevaluate clear cut markers	Ctrl+R" Click="reevaluateClearCutMarkersButton_Click"/>
+                <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="Toggle cut mark	Ctrl+M" Click="toggleCutMarkerAtCursorMenuItem_Click"/>
                 <MenuFlyoutItem Text="Mark scene cut	Delete" Click="markSceneCutAtCursorMenuItem_Click"/>
                 <MenuFlyoutItem Text="Mark scene kept	Insert" Click="markSceneKeptAtCursorMenuItem_Click"/>
+            </controls:MenuBarItem>
+            <controls:MenuBarItem Title="View">
+                <MenuFlyoutItem Text="Zoom in timeline	Ctrl+Plus" Click="zoomInTimelineMenuItem_Click"/>
+                <MenuFlyoutItem Text="Zoom out timeline	Ctrl+Minus" Click="zoomOutTimelineMenuItem_Click"/>
+                <MenuFlyoutSeparator/>
+                <MenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
+                <MenuFlyoutItem Text="Toggle preview full-screen	F11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
             </controls:MenuBarItem>
 
             <controls:MenuBarItem Title="Tools">
@@ -97,6 +106,8 @@
                             <TextBlock Text="Up Arrow: prev. marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Down Arrow: next marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+M: toggle cut mark" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+Plus: zoom in timeline" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+Minus: zoom out timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete: cut scene" TextWrapping="Wrap"/>
                             <TextBlock Text="Insert: keep scene" TextWrapping="Wrap"/>
                             <TextBlock Text=""/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -47,6 +47,9 @@
             </controls:MenuBarItem>
 
             <controls:MenuBarItem Title="Tools">
+                <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
+                <MenuFlyoutItem Text="Toggle preview full-screen\tF11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
+                <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="Options" Click="optionsMenuItem_Click"/>
             </controls:MenuBarItem>
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -51,7 +51,7 @@
                 <MenuFlyoutItem Text="Zoom in timeline	Ctrl+Plus" Click="zoomInTimelineMenuItem_Click"/>
                 <MenuFlyoutItem Text="Zoom out timeline	Ctrl+Minus" Click="zoomOutTimelineMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
-                <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
+                <MenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
                 <MenuFlyoutItem Text="Toggle preview full-screen	F11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
             </controls:MenuBarItem>
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -48,7 +48,7 @@
                 <MenuFlyoutItem Text="Mark scene kept	Insert" Click="markSceneKeptAtCursorMenuItem_Click"/>
             </controls:MenuBarItem>
             <controls:MenuBarItem Title="View">
-                <MenuFlyoutItem Text="Zoom in timeline	Ctrl+=" Click="zoomInTimelineMenuItem_Click"/>
+                <MenuFlyoutItem Text="Zoom in timeline	Ctrl++" Click="zoomInTimelineMenuItem_Click"/>
                 <MenuFlyoutItem Text="Zoom out timeline	Ctrl+-" Click="zoomOutTimelineMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
                 <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
@@ -106,7 +106,7 @@
                             <TextBlock Text="Up Arrow: prev. marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Down Arrow: next marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+M: toggle cut mark" TextWrapping="Wrap"/>
-                            <TextBlock Text="Ctrl+=: zoom in timeline" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl++: zoom in timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+-: zoom out timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete: cut scene" TextWrapping="Wrap"/>
                             <TextBlock Text="Insert: keep scene" TextWrapping="Wrap"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -48,6 +48,9 @@
                 <MenuFlyoutItem Text="Mark scene kept	Insert" Click="markSceneKeptAtCursorMenuItem_Click"/>
             </controls:MenuBarItem>
             <controls:MenuBarItem Title="View">
+                <MenuFlyoutItem Text="Zoom in timeline	Ctrl++" Click="zoomInTimelineMenuItem_Click"/>
+                <MenuFlyoutItem Text="Zoom out timeline	Ctrl+-" Click="zoomOutTimelineMenuItem_Click"/>
+                <MenuFlyoutSeparator/>
                 <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
                 <MenuFlyoutItem Text="Toggle preview full-screen	F11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
             </controls:MenuBarItem>
@@ -103,6 +106,8 @@
                             <TextBlock Text="Up Arrow: prev. marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Down Arrow: next marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+M: toggle cut mark" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl++: zoom in timeline" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+-: zoom out timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete: cut scene" TextWrapping="Wrap"/>
                             <TextBlock Text="Insert: keep scene" TextWrapping="Wrap"/>
                             <TextBlock Text=""/>

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1574,6 +1574,14 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         previewWindow.Activate();
         root.Focus(FocusState::Programmatic);
 
+        Activate();
+        const auto weakThis{get_weak()};
+        DispatcherQueue().TryEnqueue([weakThis]{
+            if(const auto self{weakThis.get()}){
+                self->tryFocusTimelineCanvas(FocusState::Programmatic);
+            }
+        });
+
         m_separatePreviewClosedRevoker = previewWindow.Closed(auto_revoke, {this, &MainWindow::onSeparatePreviewWindowClosed});
         m_separatePreviewWindow = previewWindow;
         m_isSeparatePreviewWindowOpen = true;

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1547,14 +1547,6 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         root.PreviewKeyDown(detachedKeyHandler);
         root.KeyDown(detachedKeyHandler);
 
-        Input::KeyEventHandler tunnelKeys{[weakSelf](const IInspectable&, const KRArgs& e){
-            if(const auto self{weakSelf.get()}){
-                self->onSeparatePreviewWindowKeyDown(e);
-            }
-        }};
-        root.AddHandler(UIElement::PreviewKeyDownEvent(), tunnelKeys.as<IInspectable>(), true);
-        root.AddHandler(UIElement::KeyDownEvent(), tunnelKeys.as<IInspectable>(), true);
-
         root.Children().Append(detachedPreview);
 
         previewWindow.Content(root);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1547,13 +1547,13 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         root.PreviewKeyDown(detachedKeyHandler);
         root.KeyDown(detachedKeyHandler);
 
-        const IInspectable tunnelKeys{Input::KeyEventHandler{[weakSelf](const IInspectable&, const KRArgs& e){
+        Input::KeyEventHandler tunnelKeys{[weakSelf](const IInspectable&, const KRArgs& e){
             if(const auto self{weakSelf.get()}){
                 self->onSeparatePreviewWindowKeyDown(e);
             }
-        }}};
-        root.AddHandler(UIElement::PreviewKeyDownEvent(), tunnelKeys, true);
-        root.AddHandler(UIElement::KeyDownEvent(), tunnelKeys, true);
+        }};
+        root.AddHandler(UIElement::PreviewKeyDownEvent(), tunnelKeys.as<IInspectable>(), true);
+        root.AddHandler(UIElement::KeyDownEvent(), tunnelKeys.as<IInspectable>(), true);
 
         root.Children().Append(detachedPreview);
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -90,40 +90,6 @@ namespace{
 
 constexpr int64_t HNS_PER_SECOND{10'000'000LL};
 
-
-template<typename T>
-optional<T> tryReadSetting(Windows::Foundation::Collections::IMap<hstring, IInspectable>& values, const wchar_t* key){
-    if(!values.HasKey(key)){
-        return nullopt;
-    }
-
-    try{
-        return unbox_value<T>(values.Lookup(key));
-    }catch(const winrt::hresult_error&){
-        values.Remove(key);
-        return nullopt;
-    }
-}
-
-optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IMap<hstring, IInspectable>& values, const wchar_t* key){
-    if(const auto asBool{tryReadSetting<bool>(values, key)}){
-        return asBool;
-    }
-    if(const auto asInt{tryReadSetting<int32_t>(values, key)}){
-        return *asInt != 0;
-    }
-    if(const auto asText{tryReadSetting<hstring>(values, key)}){
-        const auto text{to_hstring(trim(asText->c_str()))};
-        if(_wcsicmp(text.c_str(), L"true") == 0 || _wcsicmp(text.c_str(), L"1") == 0){
-            return true;
-        }
-        if(_wcsicmp(text.c_str(), L"false") == 0 || _wcsicmp(text.c_str(), L"0") == 0){
-            return false;
-        }
-    }
-    return nullopt;
-}
-
 bool isAviPath(const wstring& filePath){
     if(filePath.size() < 4){
         return false;
@@ -593,22 +559,18 @@ HWND MainWindow::getWindowHandle() const{
 
 void MainWindow::restoreWindowPlacement(){
     const auto localSettings{ApplicationData::Current().LocalSettings()};
-    auto values{localSettings.Values()};
+    const auto values{localSettings.Values()};
 
-    const auto left{tryReadSetting<int32_t>(values, W_POS_L)};
-    const auto top{tryReadSetting<int32_t>(values, W_POS_T)};
-    const auto widthDips{tryReadSetting<int32_t>(values, W_POS_W)};
-    const auto heightDips{tryReadSetting<int32_t>(values, W_POS_H)};
-    if(!left || !top || !widthDips || !heightDips){
+    if(!values.HasKey(W_POS_L) || !values.HasKey(W_POS_T) || !values.HasKey(W_POS_W) || !values.HasKey(W_POS_H)){
         return;
     }
 
     ::llvc::WindowPlacementState state{};
-    state.left = *left;
-    state.top = *top;
-    state.widthDips = *widthDips;
-    state.heightDips = *heightDips;
-    state.dpi = tryReadSetting<int32_t>(values, W_POS_DPI).value_or(96);
+    state.left = unbox_value<int32_t>(values.Lookup(W_POS_L));
+    state.top = unbox_value<int32_t>(values.Lookup(W_POS_T));
+    state.widthDips = unbox_value<int32_t>(values.Lookup(W_POS_W));
+    state.heightDips = unbox_value<int32_t>(values.Lookup(W_POS_H));
+    state.dpi = values.HasKey(W_POS_DPI) ? unbox_value<int32_t>(values.Lookup(W_POS_DPI)) : 96;
 
     const auto hwnd{getWindowHandle()};
     if(!applyWindowPlacement(hwnd, state, hwnd, false)){
@@ -621,23 +583,25 @@ void MainWindow::restoreWindowPlacement(){
 }
 
 void MainWindow::loadAppSettings(){
-    auto values{ApplicationData::Current().LocalSettings().Values()};
+    const auto values{ApplicationData::Current().LocalSettings().Values()};
 
     m_maxRecentVideos = S_DEFAULT_MAX_RECENT;
     m_maxRecentProjects = S_DEFAULT_MAX_RECENT;
 
-    if(const auto parsed{tryReadSetting<int32_t>(values, S_MAX_RECENT_VIDEOS)}){
-        m_maxRecentVideos = static_cast<uint32_t>(clamp(*parsed, 1, 20));
+    if(values.HasKey(S_MAX_RECENT_VIDEOS)){
+        const auto parsed{unbox_value<int32_t>(values.Lookup(S_MAX_RECENT_VIDEOS))};
+        m_maxRecentVideos = static_cast<uint32_t>(clamp(parsed, 1, 20));
     }
-    if(const auto parsed{tryReadSetting<int32_t>(values, S_MAX_RECENT_PROJECTS)}){
-        m_maxRecentProjects = static_cast<uint32_t>(clamp(*parsed, 1, 20));
+    if(values.HasKey(S_MAX_RECENT_PROJECTS)){
+        const auto parsed{unbox_value<int32_t>(values.Lookup(S_MAX_RECENT_PROJECTS))};
+        m_maxRecentProjects = static_cast<uint32_t>(clamp(parsed, 1, 20));
     }
 
-    if(const auto recentVideosText{tryReadSetting<hstring>(values, S_RECENT_VIDEOS)}){
-        m_recentVideos = splitRecentItems(recentVideosText->c_str());
+    if(values.HasKey(S_RECENT_VIDEOS)){
+        m_recentVideos = splitRecentItems(unbox_value<hstring>(values.Lookup(S_RECENT_VIDEOS)).c_str());
     }
-    if(const auto recentProjectsText{tryReadSetting<hstring>(values, S_RECENT_PROJECTS)}){
-        m_recentProjects = splitRecentItems(recentProjectsText->c_str());
+    if(values.HasKey(S_RECENT_PROJECTS)){
+        m_recentProjects = splitRecentItems(unbox_value<hstring>(values.Lookup(S_RECENT_PROJECTS)).c_str());
     }
     if(m_recentVideos.size() > m_maxRecentVideos){
         m_recentVideos.resize(m_maxRecentVideos);
@@ -646,26 +610,24 @@ void MainWindow::loadAppSettings(){
         m_recentProjects.resize(m_maxRecentProjects);
     }
 
-    m_restorePreviewDetachedOnStartup = tryReadBoolSetting(values, S_SEPARATE_PREVIEW_DETACHED).value_or(false);
+    m_restorePreviewDetachedOnStartup = values.HasKey(S_SEPARATE_PREVIEW_DETACHED)
+        && unbox_value<bool>(values.Lookup(S_SEPARATE_PREVIEW_DETACHED));
 
-    const auto previewLeft{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_L)};
-    const auto previewTop{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_T)};
-    const auto previewWidthDips{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_W)};
-    const auto previewHeightDips{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_H)};
-    if(previewLeft && previewTop && previewWidthDips && previewHeightDips){
-        m_separatePreviewLeft = *previewLeft;
-        m_separatePreviewTop = *previewTop;
-        m_separatePreviewWidthDips = max<int32_t>(320, *previewWidthDips);
-        m_separatePreviewHeightDips = max<int32_t>(200, *previewHeightDips);
-        m_separatePreviewDpi = max<int32_t>(96, tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_DPI).value_or(96));
+    if(values.HasKey(S_SEPARATE_PREVIEW_L) && values.HasKey(S_SEPARATE_PREVIEW_T) && values.HasKey(S_SEPARATE_PREVIEW_W) && values.HasKey(S_SEPARATE_PREVIEW_H)){
+        m_separatePreviewLeft = unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_L));
+        m_separatePreviewTop = unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_T));
+        m_separatePreviewWidthDips = max<int32_t>(320, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_W)));
+        m_separatePreviewHeightDips = max<int32_t>(200, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_H)));
+        m_separatePreviewDpi = values.HasKey(S_SEPARATE_PREVIEW_DPI) ? max<int32_t>(96, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_DPI))) : 96;
         m_hasSeparatePreviewPlacement = true;
     }
 
-    m_restorePreviewFullscreenOnStartup = tryReadBoolSetting(values, S_SEPARATE_PREVIEW_FULLSCREEN).value_or(false);
+    m_restorePreviewFullscreenOnStartup = values.HasKey(S_SEPARATE_PREVIEW_FULLSCREEN)
+        && unbox_value<bool>(values.Lookup(S_SEPARATE_PREVIEW_FULLSCREEN));
 }
 
 void MainWindow::saveAppSettings() const{
-    auto values{ApplicationData::Current().LocalSettings().Values()};
+    const auto values{ApplicationData::Current().LocalSettings().Values()};
     values.Insert(S_MAX_RECENT_VIDEOS, box_value(static_cast<int32_t>(m_maxRecentVideos)));
     values.Insert(S_MAX_RECENT_PROJECTS, box_value(static_cast<int32_t>(m_maxRecentProjects)));
     values.Insert(S_RECENT_VIDEOS, box_value(hstring(joinRecentItems(m_recentVideos))));
@@ -690,7 +652,7 @@ void MainWindow::saveWindowPlacement() const{
     }
 
     const auto localSettings{ApplicationData::Current().LocalSettings()};
-    auto values{localSettings.Values()};
+    const auto values{localSettings.Values()};
     values.Insert(W_POS_L, box_value(captured->left));
     values.Insert(W_POS_T, box_value(captured->top));
     values.Insert(W_POS_W, box_value(captured->widthDips));

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1719,11 +1719,28 @@ void MainWindow::restoreSeparatePreviewPlacement(HWND previewHwnd){
     const auto width{dipsToPixels(m_separatePreviewWidthDips, currentDpi)};
     const auto height{dipsToPixels(m_separatePreviewHeightDips, currentDpi)};
     RECT desiredRect{m_separatePreviewLeft, m_separatePreviewTop, m_separatePreviewLeft + width, m_separatePreviewTop + height};
+
     if(!isRectVisibleOnAnyMonitor(desiredRect)){
-        return;
+        MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
+        const auto mainMonitor{::MonitorFromWindow(getWindowHandle(), MONITOR_DEFAULTTONEAREST)};
+        if(mainMonitor && ::GetMonitorInfoW(mainMonitor, &monitorInfo)){
+            const auto fallbackWidth{min(width, static_cast<int32_t>(monitorInfo.rcWork.right - monitorInfo.rcWork.left))};
+            const auto fallbackHeight{min(height, static_cast<int32_t>(monitorInfo.rcWork.bottom - monitorInfo.rcWork.top))};
+            desiredRect.left = monitorInfo.rcWork.left;
+            desiredRect.top = monitorInfo.rcWork.top;
+            desiredRect.right = desiredRect.left + fallbackWidth;
+            desiredRect.bottom = desiredRect.top + fallbackHeight;
+        }
     }
 
-    ::SetWindowPos(previewHwnd, nullptr, desiredRect.left, desiredRect.top, width, height, SWP_NOACTIVATE | SWP_NOZORDER);
+    ::SetWindowPos(
+        previewHwnd,
+        nullptr,
+        desiredRect.left,
+        desiredRect.top,
+        desiredRect.right - desiredRect.left,
+        desiredRect.bottom - desiredRect.top,
+        SWP_NOACTIVATE | SWP_NOZORDER);
 
     if(m_separatePreviewWasMaximized){
         ::ShowWindow(previewHwnd, SW_MAXIMIZE);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1591,6 +1591,7 @@ void MainWindow::window_KeyDown(const Control&, const KRArgs& args){
 void MainWindow::separatePreviewWindowMenuItem_Click(const Control&, const REArgs&){
     const auto targetOpen{!m_isSeparatePreviewWindowOpen};
     if(!setSeparatePreviewWindowOpen(targetOpen)){
+        SeparatePreviewWindowMenuItem().IsChecked(m_isSeparatePreviewWindowOpen);
     }
 }
 
@@ -1618,6 +1619,7 @@ void MainWindow::adjustTimelineZoomBy(int delta){
 
 bool MainWindow::setSeparatePreviewWindowOpen(bool open){
     if(open == m_isSeparatePreviewWindowOpen){
+        SeparatePreviewWindowMenuItem().IsChecked(open);
         return true;
     }
 
@@ -1677,6 +1679,7 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
             (void)toggleSeparatePreviewFullscreen();
         }
 
+        SeparatePreviewWindowMenuItem().IsChecked(true);
         setStatusMessage(L"Preview opened in separate window");
         return true;
     }
@@ -1696,6 +1699,7 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
     m_isSeparatePreviewWindowOpen = false;
     m_isSeparatePreviewFullscreen = false;
     m_restorePreviewDetachedOnStartup = false;
+    SeparatePreviewWindowMenuItem().IsChecked(false);
     setStatusMessage(L"Preview restored to main window");
     return true;
 }
@@ -1716,6 +1720,7 @@ void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
         m_restorePreviewDetachedOnStartup = false;
     }
     PreviewPlayer().SetMediaPlayer(m_player);
+    SeparatePreviewWindowMenuItem().IsChecked(false);
     setStatusMessage(L"Preview restored to main window");
 }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -92,20 +92,20 @@ constexpr int64_t HNS_PER_SECOND{10'000'000LL};
 
 
 template<typename T>
-optional<T> tryReadSetting(Windows::Foundation::Collections::IMap<hstring, IInspectable>& values, const wchar_t* key){
+std::optional<T> tryReadSetting(Windows::Foundation::Collections::IPropertySet& values, const wchar_t* key){
     if(!values.HasKey(key)){
-        return nullopt;
+        return std::nullopt;
     }
 
     try{
         return unbox_value<T>(values.Lookup(key));
     }catch(const winrt::hresult_error&){
         values.Remove(key);
-        return nullopt;
+        return std::nullopt;
     }
 }
 
-optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IMap<hstring, IInspectable>& values, const wchar_t* key){
+std::optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IPropertySet& values, const wchar_t* key){
     if(const auto asBool{tryReadSetting<bool>(values, key)}){
         return asBool;
     }
@@ -121,7 +121,7 @@ optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IMap<hstring
             return false;
         }
     }
-    return nullopt;
+    return std::nullopt;
 }
 
 bool isAviPath(const wstring& filePath){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -113,7 +113,7 @@ std::optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IProper
         return *asInt != 0;
     }
     if(const auto asText{tryReadSetting<hstring>(values, key)}){
-        const auto text{trim(asText->c_str())};
+        const auto text{to_hstring(trim(asText->c_str()))};
         if(_wcsicmp(text.c_str(), L"true") == 0 || _wcsicmp(text.c_str(), L"1") == 0){
             return true;
         }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -90,6 +90,40 @@ namespace{
 
 constexpr int64_t HNS_PER_SECOND{10'000'000LL};
 
+
+template<typename T>
+optional<T> tryReadSetting(Windows::Foundation::Collections::IMap<hstring, IInspectable>& values, const wchar_t* key){
+    if(!values.HasKey(key)){
+        return nullopt;
+    }
+
+    try{
+        return unbox_value<T>(values.Lookup(key));
+    }catch(const winrt::hresult_error&){
+        values.Remove(key);
+        return nullopt;
+    }
+}
+
+optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IMap<hstring, IInspectable>& values, const wchar_t* key){
+    if(const auto asBool{tryReadSetting<bool>(values, key)}){
+        return asBool;
+    }
+    if(const auto asInt{tryReadSetting<int32_t>(values, key)}){
+        return *asInt != 0;
+    }
+    if(const auto asText{tryReadSetting<hstring>(values, key)}){
+        const auto text{to_hstring(trim(asText->c_str()))};
+        if(_wcsicmp(text.c_str(), L"true") == 0 || _wcsicmp(text.c_str(), L"1") == 0){
+            return true;
+        }
+        if(_wcsicmp(text.c_str(), L"false") == 0 || _wcsicmp(text.c_str(), L"0") == 0){
+            return false;
+        }
+    }
+    return nullopt;
+}
+
 bool isAviPath(const wstring& filePath){
     if(filePath.size() < 4){
         return false;
@@ -559,18 +593,22 @@ HWND MainWindow::getWindowHandle() const{
 
 void MainWindow::restoreWindowPlacement(){
     const auto localSettings{ApplicationData::Current().LocalSettings()};
-    const auto values{localSettings.Values()};
+    auto values{localSettings.Values()};
 
-    if(!values.HasKey(W_POS_L) || !values.HasKey(W_POS_T) || !values.HasKey(W_POS_W) || !values.HasKey(W_POS_H)){
+    const auto left{tryReadSetting<int32_t>(values, W_POS_L)};
+    const auto top{tryReadSetting<int32_t>(values, W_POS_T)};
+    const auto widthDips{tryReadSetting<int32_t>(values, W_POS_W)};
+    const auto heightDips{tryReadSetting<int32_t>(values, W_POS_H)};
+    if(!left || !top || !widthDips || !heightDips){
         return;
     }
 
     ::llvc::WindowPlacementState state{};
-    state.left = unbox_value<int32_t>(values.Lookup(W_POS_L));
-    state.top = unbox_value<int32_t>(values.Lookup(W_POS_T));
-    state.widthDips = unbox_value<int32_t>(values.Lookup(W_POS_W));
-    state.heightDips = unbox_value<int32_t>(values.Lookup(W_POS_H));
-    state.dpi = values.HasKey(W_POS_DPI) ? unbox_value<int32_t>(values.Lookup(W_POS_DPI)) : 96;
+    state.left = *left;
+    state.top = *top;
+    state.widthDips = *widthDips;
+    state.heightDips = *heightDips;
+    state.dpi = tryReadSetting<int32_t>(values, W_POS_DPI).value_or(96);
 
     const auto hwnd{getWindowHandle()};
     if(!applyWindowPlacement(hwnd, state, hwnd, false)){
@@ -583,25 +621,23 @@ void MainWindow::restoreWindowPlacement(){
 }
 
 void MainWindow::loadAppSettings(){
-    const auto values{ApplicationData::Current().LocalSettings().Values()};
+    auto values{ApplicationData::Current().LocalSettings().Values()};
 
     m_maxRecentVideos = S_DEFAULT_MAX_RECENT;
     m_maxRecentProjects = S_DEFAULT_MAX_RECENT;
 
-    if(values.HasKey(S_MAX_RECENT_VIDEOS)){
-        const auto parsed{unbox_value<int32_t>(values.Lookup(S_MAX_RECENT_VIDEOS))};
-        m_maxRecentVideos = static_cast<uint32_t>(clamp(parsed, 1, 20));
+    if(const auto parsed{tryReadSetting<int32_t>(values, S_MAX_RECENT_VIDEOS)}){
+        m_maxRecentVideos = static_cast<uint32_t>(clamp(*parsed, 1, 20));
     }
-    if(values.HasKey(S_MAX_RECENT_PROJECTS)){
-        const auto parsed{unbox_value<int32_t>(values.Lookup(S_MAX_RECENT_PROJECTS))};
-        m_maxRecentProjects = static_cast<uint32_t>(clamp(parsed, 1, 20));
+    if(const auto parsed{tryReadSetting<int32_t>(values, S_MAX_RECENT_PROJECTS)}){
+        m_maxRecentProjects = static_cast<uint32_t>(clamp(*parsed, 1, 20));
     }
 
-    if(values.HasKey(S_RECENT_VIDEOS)){
-        m_recentVideos = splitRecentItems(unbox_value<hstring>(values.Lookup(S_RECENT_VIDEOS)).c_str());
+    if(const auto recentVideosText{tryReadSetting<hstring>(values, S_RECENT_VIDEOS)}){
+        m_recentVideos = splitRecentItems(recentVideosText->c_str());
     }
-    if(values.HasKey(S_RECENT_PROJECTS)){
-        m_recentProjects = splitRecentItems(unbox_value<hstring>(values.Lookup(S_RECENT_PROJECTS)).c_str());
+    if(const auto recentProjectsText{tryReadSetting<hstring>(values, S_RECENT_PROJECTS)}){
+        m_recentProjects = splitRecentItems(recentProjectsText->c_str());
     }
     if(m_recentVideos.size() > m_maxRecentVideos){
         m_recentVideos.resize(m_maxRecentVideos);
@@ -610,24 +646,26 @@ void MainWindow::loadAppSettings(){
         m_recentProjects.resize(m_maxRecentProjects);
     }
 
-    m_restorePreviewDetachedOnStartup = values.HasKey(S_SEPARATE_PREVIEW_DETACHED)
-        && unbox_value<bool>(values.Lookup(S_SEPARATE_PREVIEW_DETACHED));
+    m_restorePreviewDetachedOnStartup = tryReadBoolSetting(values, S_SEPARATE_PREVIEW_DETACHED).value_or(false);
 
-    if(values.HasKey(S_SEPARATE_PREVIEW_L) && values.HasKey(S_SEPARATE_PREVIEW_T) && values.HasKey(S_SEPARATE_PREVIEW_W) && values.HasKey(S_SEPARATE_PREVIEW_H)){
-        m_separatePreviewLeft = unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_L));
-        m_separatePreviewTop = unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_T));
-        m_separatePreviewWidthDips = max<int32_t>(320, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_W)));
-        m_separatePreviewHeightDips = max<int32_t>(200, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_H)));
-        m_separatePreviewDpi = values.HasKey(S_SEPARATE_PREVIEW_DPI) ? max<int32_t>(96, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_DPI))) : 96;
+    const auto previewLeft{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_L)};
+    const auto previewTop{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_T)};
+    const auto previewWidthDips{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_W)};
+    const auto previewHeightDips{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_H)};
+    if(previewLeft && previewTop && previewWidthDips && previewHeightDips){
+        m_separatePreviewLeft = *previewLeft;
+        m_separatePreviewTop = *previewTop;
+        m_separatePreviewWidthDips = max<int32_t>(320, *previewWidthDips);
+        m_separatePreviewHeightDips = max<int32_t>(200, *previewHeightDips);
+        m_separatePreviewDpi = max<int32_t>(96, tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_DPI).value_or(96));
         m_hasSeparatePreviewPlacement = true;
     }
 
-    m_restorePreviewFullscreenOnStartup = values.HasKey(S_SEPARATE_PREVIEW_FULLSCREEN)
-        && unbox_value<bool>(values.Lookup(S_SEPARATE_PREVIEW_FULLSCREEN));
+    m_restorePreviewFullscreenOnStartup = tryReadBoolSetting(values, S_SEPARATE_PREVIEW_FULLSCREEN).value_or(false);
 }
 
 void MainWindow::saveAppSettings() const{
-    const auto values{ApplicationData::Current().LocalSettings().Values()};
+    auto values{ApplicationData::Current().LocalSettings().Values()};
     values.Insert(S_MAX_RECENT_VIDEOS, box_value(static_cast<int32_t>(m_maxRecentVideos)));
     values.Insert(S_MAX_RECENT_PROJECTS, box_value(static_cast<int32_t>(m_maxRecentProjects)));
     values.Insert(S_RECENT_VIDEOS, box_value(hstring(joinRecentItems(m_recentVideos))));
@@ -652,7 +690,7 @@ void MainWindow::saveWindowPlacement() const{
     }
 
     const auto localSettings{ApplicationData::Current().LocalSettings()};
-    const auto values{localSettings.Values()};
+    auto values{localSettings.Values()};
     values.Insert(W_POS_L, box_value(captured->left));
     values.Insert(W_POS_T, box_value(captured->top));
     values.Insert(W_POS_W, box_value(captured->widthDips));

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -671,7 +671,6 @@ void MainWindow::onClosed(const Control&, const WEArgs&){
 
     if(m_separatePreviewWindow){
         m_separatePreviewClosedRevoker.revoke();
-        m_separatePreviewActivatedRevoker.revoke();
         m_separatePreviewWindow.Close();
         m_separatePreviewWindow = nullptr;
     }
@@ -1551,24 +1550,8 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         previewWindow.Content(root);
         previewWindow.Activate();
 
-        HWND previewHwnd{};
-        check_hresult(previewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd));
-        if(previewHwnd){
-            const auto exStyle{::GetWindowLongPtrW(previewHwnd, GWL_EXSTYLE)};
-            ::SetWindowLongPtrW(previewHwnd, GWL_EXSTYLE, exStyle | WS_EX_NOACTIVATE);
-            ::SetWindowPos(previewHwnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED | SWP_NOACTIVATE);
-        }
-
         m_separatePreviewClosedRevoker = previewWindow.Closed(auto_revoke, {this, &MainWindow::onSeparatePreviewWindowClosed});
-        m_separatePreviewActivatedRevoker = previewWindow.Activated(auto_revoke, {this, &MainWindow::onSeparatePreviewWindowActivated});
         m_separatePreviewWindow = previewWindow;
-
-        Activate();
-        const auto mainHwnd{getWindowHandle()};
-        if(mainHwnd){
-            ::SetForegroundWindow(mainHwnd);
-            ::SetFocus(mainHwnd);
-        }
         m_isSeparatePreviewWindowOpen = true;
         m_isSeparatePreviewFullscreen = false;
         PreviewPlayer().SetMediaPlayer(nullptr);
@@ -1579,7 +1562,6 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
 
     if(m_separatePreviewWindow){
         m_separatePreviewClosedRevoker.revoke();
-        m_separatePreviewActivatedRevoker.revoke();
         m_separatePreviewWindow.Close();
         m_separatePreviewWindow = nullptr;
     }
@@ -1594,7 +1576,6 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
 
 void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
     m_separatePreviewClosedRevoker.revoke();
-    m_separatePreviewActivatedRevoker.revoke();
     m_separatePreviewWindow = nullptr;
     m_isSeparatePreviewWindowOpen = false;
     m_isSeparatePreviewFullscreen = false;
@@ -1603,29 +1584,8 @@ void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
     setStatusMessage(L"Preview restored to main window");
 }
 
-void MainWindow::onSeparatePreviewWindowActivated(const Control&, const winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs& args){
-    if(args.WindowActivationState() == winrt::Microsoft::UI::Xaml::WindowActivationState::Deactivated){
-        return;
-    }
-
-    Activate();
-    const auto mainHwnd{getWindowHandle()};
-    if(mainHwnd){
-        ::SetForegroundWindow(mainHwnd);
-        ::SetFocus(mainHwnd);
-    }
-}
-
 void MainWindow::onSeparatePreviewWindowKeyDown(const KRArgs& args){
-    if(handleStorylineKeyDown(args)){
-        Activate();
-        const auto mainHwnd{getWindowHandle()};
-        if(mainHwnd){
-            ::SetForegroundWindow(mainHwnd);
-            ::SetFocus(mainHwnd);
-        }
-        tryFocusTimelineCanvas(FocusState::Programmatic);
-    }
+    (void)handleStorylineKeyDown(args);
 }
 
 bool MainWindow::toggleSeparatePreviewFullscreen(){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -397,7 +397,7 @@ constexpr auto S_SEPARATE_PREVIEW_T{L"SeparatePreviewTop"};
 constexpr auto S_SEPARATE_PREVIEW_W{L"SeparatePreviewWidth"};
 constexpr auto S_SEPARATE_PREVIEW_H{L"SeparatePreviewHeight"};
 constexpr auto S_SEPARATE_PREVIEW_DPI{L"SeparatePreviewDpi"};
-constexpr auto S_SEPARATE_PREVIEW_MAX{L"SeparatePreviewMaximized"};
+constexpr auto S_SEPARATE_PREVIEW_FULLSCREEN{L"SeparatePreviewFullscreen"};
 
 constexpr auto P_FILE_PATH{L"file_path"};
 constexpr auto P_STORYLINE_ZOOM{L"storyline_zoom"};
@@ -650,9 +650,11 @@ void MainWindow::loadAppSettings(){
         m_separatePreviewWidthDips = max<int32_t>(320, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_W)));
         m_separatePreviewHeightDips = max<int32_t>(200, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_H)));
         m_separatePreviewDpi = values.HasKey(S_SEPARATE_PREVIEW_DPI) ? max<int32_t>(96, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_DPI))) : 96;
-        m_separatePreviewWasMaximized = values.HasKey(S_SEPARATE_PREVIEW_MAX) && unbox_value<bool>(values.Lookup(S_SEPARATE_PREVIEW_MAX));
         m_hasSeparatePreviewPlacement = true;
     }
+
+    m_restorePreviewFullscreenOnStartup = values.HasKey(S_SEPARATE_PREVIEW_FULLSCREEN)
+        && unbox_value<bool>(values.Lookup(S_SEPARATE_PREVIEW_FULLSCREEN));
 }
 
 void MainWindow::saveAppSettings() const{
@@ -662,6 +664,7 @@ void MainWindow::saveAppSettings() const{
     values.Insert(S_RECENT_VIDEOS, box_value(hstring(joinRecentItems(m_recentVideos))));
     values.Insert(S_RECENT_PROJECTS, box_value(hstring(joinRecentItems(m_recentProjects))));
     values.Insert(S_SEPARATE_PREVIEW_DETACHED, box_value(m_restorePreviewDetachedOnStartup));
+    values.Insert(S_SEPARATE_PREVIEW_FULLSCREEN, box_value(m_restorePreviewFullscreenOnStartup));
 
     if(m_hasSeparatePreviewPlacement){
         values.Insert(S_SEPARATE_PREVIEW_L, box_value(m_separatePreviewLeft));
@@ -669,7 +672,6 @@ void MainWindow::saveAppSettings() const{
         values.Insert(S_SEPARATE_PREVIEW_W, box_value(m_separatePreviewWidthDips));
         values.Insert(S_SEPARATE_PREVIEW_H, box_value(m_separatePreviewHeightDips));
         values.Insert(S_SEPARATE_PREVIEW_DPI, box_value(m_separatePreviewDpi));
-        values.Insert(S_SEPARATE_PREVIEW_MAX, box_value(m_separatePreviewWasMaximized));
     }
 }
 
@@ -707,6 +709,7 @@ void MainWindow::onClosed(const Control&, const WEArgs&){
     m_mainWindowActivatedRevoker.revoke();
 
     m_restorePreviewDetachedOnStartup = m_isSeparatePreviewWindowOpen;
+    m_restorePreviewFullscreenOnStartup = m_isSeparatePreviewWindowOpen && m_isSeparatePreviewFullscreen;
 
     if(m_separatePreviewWindow){
         HWND previewHwnd{};
@@ -1634,6 +1637,11 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         m_isSeparatePreviewFullscreen = false;
         m_restorePreviewDetachedOnStartup = true;
         PreviewPlayer().SetMediaPlayer(nullptr);
+
+        if(m_restorePreviewFullscreenOnStartup){
+            (void)toggleSeparatePreviewFullscreen();
+        }
+
         SeparatePreviewWindowMenuItem().IsChecked(true);
         setStatusMessage(L"Preview opened in separate window");
         return true;
@@ -1693,12 +1701,8 @@ void MainWindow::saveSeparatePreviewPlacement(HWND previewHwnd){
         return;
     }
 
-    WINDOWPLACEMENT placement{.length = sizeof(placement)};
-    if(::GetWindowPlacement(previewHwnd, &placement) && placement.showCmd == SW_SHOWMAXIMIZED){
-        m_separatePreviewWasMaximized = true;
-        bounds = placement.rcNormalPosition;
-    }else{
-        m_separatePreviewWasMaximized = false;
+    if(m_isSeparatePreviewFullscreen && (m_separatePreviewRestoreRect.right > m_separatePreviewRestoreRect.left) && (m_separatePreviewRestoreRect.bottom > m_separatePreviewRestoreRect.top)){
+        bounds = m_separatePreviewRestoreRect;
     }
 
     const auto dpi{::GetDpiForWindow(previewHwnd)};
@@ -1742,9 +1746,6 @@ void MainWindow::restoreSeparatePreviewPlacement(HWND previewHwnd){
         desiredRect.bottom - desiredRect.top,
         SWP_NOACTIVATE | SWP_NOZORDER);
 
-    if(m_separatePreviewWasMaximized){
-        ::ShowWindow(previewHwnd, SW_MAXIMIZE);
-    }
 }
 
 bool MainWindow::toggleSeparatePreviewFullscreen(){
@@ -1791,6 +1792,7 @@ bool MainWindow::toggleSeparatePreviewFullscreen(){
             SWP_FRAMECHANGED | SWP_SHOWWINDOW);
 
         m_isSeparatePreviewFullscreen = true;
+        m_restorePreviewFullscreenOnStartup = true;
         setStatusMessage(L"Separate preview: full-screen on");
         return true;
     }
@@ -1807,6 +1809,7 @@ bool MainWindow::toggleSeparatePreviewFullscreen(){
         SWP_FRAMECHANGED | SWP_SHOWWINDOW);
 
     m_isSeparatePreviewFullscreen = false;
+    m_restorePreviewFullscreenOnStartup = false;
     setStatusMessage(L"Separate preview: full-screen off");
     return true;
 }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -27,7 +27,6 @@
 #include <mfreadwrite.h>
 
 #include <microsoft.ui.xaml.window.h>
-#include <Microsoft.UI.Interop.h>
 #include <propkey.h>
 #include <propsys.h>
 #include <propvarutil.h>
@@ -37,7 +36,6 @@
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Media.Imaging.h>
 #include <winrt/Microsoft.UI.Xaml.Shapes.h>
-#include <winrt/Microsoft.UI.Windowing.h>
 #include <winrt/Windows.UI.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
@@ -59,7 +57,6 @@ using namespace Microsoft::UI::Xaml;
 using namespace Microsoft::UI::Input;
 using namespace Microsoft::UI::Xaml::Controls;
 using namespace Microsoft::UI::Xaml::Input;
-using namespace Microsoft::UI::Windowing;
 using namespace Windows::Foundation;
 using namespace Windows::Media::Playback;
 using namespace Windows::Storage;
@@ -1588,15 +1585,54 @@ bool MainWindow::toggleSeparatePreviewFullscreen(){
         return false;
     }
 
-    const auto previewAppWindow{AppWindow::GetFromWindowId(GetWindowIdFromWindow(previewHwnd))};
-    if(!previewAppWindow){
-        setErrorMessage(L"Could not control preview window presenter");
-        return false;
+    if(!m_isSeparatePreviewFullscreen){
+        RECT currentRect{};
+        if(!::GetWindowRect(previewHwnd, &currentRect)){
+            setErrorMessage(L"Could not read preview window bounds");
+            return false;
+        }
+
+        m_separatePreviewRestoreRect = currentRect;
+        m_separatePreviewRestoreStyle = ::GetWindowLongPtrW(previewHwnd, GWL_STYLE);
+        m_separatePreviewRestoreExStyle = ::GetWindowLongPtrW(previewHwnd, GWL_EXSTYLE);
+
+        const auto fullscreenStyle{m_separatePreviewRestoreStyle & ~(WS_OVERLAPPEDWINDOW)};
+        ::SetWindowLongPtrW(previewHwnd, GWL_STYLE, fullscreenStyle);
+
+        MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
+        const auto monitor{::MonitorFromWindow(previewHwnd, MONITOR_DEFAULTTONEAREST)};
+        if(!monitor || !::GetMonitorInfoW(monitor, &monitorInfo)){
+            setErrorMessage(L"Could not resolve preview monitor bounds");
+            return false;
+        }
+
+        ::SetWindowPos(
+            previewHwnd,
+            HWND_TOP,
+            monitorInfo.rcMonitor.left,
+            monitorInfo.rcMonitor.top,
+            monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left,
+            monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top,
+            SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+
+        m_isSeparatePreviewFullscreen = true;
+        setStatusMessage(L"Separate preview: full-screen on");
+        return true;
     }
 
-    m_isSeparatePreviewFullscreen = !m_isSeparatePreviewFullscreen;
-    previewAppWindow.SetPresenter(m_isSeparatePreviewFullscreen ? AppWindowPresenterKind::FullScreen : AppWindowPresenterKind::Default);
-    setStatusMessage(m_isSeparatePreviewFullscreen ? L"Separate preview: full-screen on" : L"Separate preview: full-screen off");
+    ::SetWindowLongPtrW(previewHwnd, GWL_STYLE, m_separatePreviewRestoreStyle);
+    ::SetWindowLongPtrW(previewHwnd, GWL_EXSTYLE, m_separatePreviewRestoreExStyle);
+    ::SetWindowPos(
+        previewHwnd,
+        HWND_NOTOPMOST,
+        m_separatePreviewRestoreRect.left,
+        m_separatePreviewRestoreRect.top,
+        m_separatePreviewRestoreRect.right - m_separatePreviewRestoreRect.left,
+        m_separatePreviewRestoreRect.bottom - m_separatePreviewRestoreRect.top,
+        SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+
+    m_isSeparatePreviewFullscreen = false;
+    setStatusMessage(L"Separate preview: full-screen off");
     return true;
 }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1591,7 +1591,6 @@ void MainWindow::window_KeyDown(const Control&, const KRArgs& args){
 void MainWindow::separatePreviewWindowMenuItem_Click(const Control&, const REArgs&){
     const auto targetOpen{!m_isSeparatePreviewWindowOpen};
     if(!setSeparatePreviewWindowOpen(targetOpen)){
-        SeparatePreviewWindowMenuItem().IsChecked(m_isSeparatePreviewWindowOpen);
     }
 }
 
@@ -1619,7 +1618,6 @@ void MainWindow::adjustTimelineZoomBy(int delta){
 
 bool MainWindow::setSeparatePreviewWindowOpen(bool open){
     if(open == m_isSeparatePreviewWindowOpen){
-        SeparatePreviewWindowMenuItem().IsChecked(open);
         return true;
     }
 
@@ -1679,7 +1677,6 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
             (void)toggleSeparatePreviewFullscreen();
         }
 
-        SeparatePreviewWindowMenuItem().IsChecked(true);
         setStatusMessage(L"Preview opened in separate window");
         return true;
     }
@@ -1699,7 +1696,6 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
     m_isSeparatePreviewWindowOpen = false;
     m_isSeparatePreviewFullscreen = false;
     m_restorePreviewDetachedOnStartup = false;
-    SeparatePreviewWindowMenuItem().IsChecked(false);
     setStatusMessage(L"Preview restored to main window");
     return true;
 }
@@ -1720,7 +1716,6 @@ void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
         m_restorePreviewDetachedOnStartup = false;
     }
     PreviewPlayer().SetMediaPlayer(m_player);
-    SeparatePreviewWindowMenuItem().IsChecked(false);
     setStatusMessage(L"Preview restored to main window");
 }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1465,12 +1465,12 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
             args.Handled(true);
             return true;
         }
-        if(args.Key() == VirtualKey::Add || args.Key() == VirtualKey::OemPlus){
+        if(args.Key() == VirtualKey::Add || args.Key() == static_cast<VirtualKey>(187)){
             adjustTimelineZoomBy(1);
             args.Handled(true);
             return true;
         }
-        if(args.Key() == VirtualKey::Subtract || args.Key() == VirtualKey::OemMinus){
+        if(args.Key() == VirtualKey::Subtract || args.Key() == static_cast<VirtualKey>(189)){
             adjustTimelineZoomBy(-1);
             args.Handled(true);
             return true;

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1443,6 +1443,11 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
             args.Handled(true);
             return true;
         }
+        if(args.Key() == VirtualKey::R){
+            reevaluateClearCutMarkersButton_Click(nullptr, {});
+            args.Handled(true);
+            return true;
+        }
     }
 
     if(focusOnMenu || focusInDialog){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -27,6 +27,7 @@
 #include <mfreadwrite.h>
 
 #include <microsoft.ui.xaml.window.h>
+#include <Microsoft.UI.Interop.h>
 #include <propkey.h>
 #include <propsys.h>
 #include <propvarutil.h>
@@ -36,6 +37,7 @@
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Media.Imaging.h>
 #include <winrt/Microsoft.UI.Xaml.Shapes.h>
+#include <winrt/Microsoft.UI.Windowing.h>
 #include <winrt/Windows.UI.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
@@ -57,6 +59,7 @@ using namespace Microsoft::UI::Xaml;
 using namespace Microsoft::UI::Input;
 using namespace Microsoft::UI::Xaml::Controls;
 using namespace Microsoft::UI::Xaml::Input;
+using namespace Microsoft::UI::Windowing;
 using namespace Windows::Foundation;
 using namespace Windows::Media::Playback;
 using namespace Windows::Storage;
@@ -668,6 +671,13 @@ void MainWindow::onClosed(const Control&, const WEArgs&){
     }
 
     m_naturalDurationChangedRevoker.revoke();
+
+    if(m_separatePreviewWindow){
+        m_separatePreviewClosedRevoker.revoke();
+        m_separatePreviewWindow.Close();
+        m_separatePreviewWindow = nullptr;
+    }
+
     saveWindowPlacement();
     saveAppSettings();
 }
@@ -1480,6 +1490,10 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         (void)markSceneAtCursor(false);
         args.Handled(true);
         return true;
+    case VirtualKey::F11:
+        (void)toggleSeparatePreviewFullscreen();
+        args.Handled(true);
+        return true;
     default:
         return false;
     }
@@ -1491,6 +1505,99 @@ void MainWindow::window_PreviewKeyDown(const Control&, const KRArgs& args){
 
 void MainWindow::window_KeyDown(const Control&, const KRArgs& args){
     (void)handleStorylineKeyDown(args);
+}
+
+void MainWindow::separatePreviewWindowMenuItem_Click(const Control&, const REArgs&){
+    const auto targetOpen{!m_isSeparatePreviewWindowOpen};
+    if(!setSeparatePreviewWindowOpen(targetOpen)){
+        SeparatePreviewWindowMenuItem().IsChecked(m_isSeparatePreviewWindowOpen);
+    }
+}
+
+void MainWindow::toggleSeparatePreviewFullscreenMenuItem_Click(const Control&, const REArgs&){
+    (void)toggleSeparatePreviewFullscreen();
+}
+
+bool MainWindow::setSeparatePreviewWindowOpen(bool open){
+    if(open == m_isSeparatePreviewWindowOpen){
+        SeparatePreviewWindowMenuItem().IsChecked(open);
+        return true;
+    }
+
+    if(open){
+        auto previewWindow{Window()};
+        previewWindow.Title(L"llvc - Video preview");
+
+        Controls::Grid root{};
+        root.Background(Media::SolidColorBrush(Windows::UI::ColorHelper::FromArgb(0xFF, 0x08, 0x08, 0x08)));
+
+        Controls::MediaPlayerElement detachedPreview{};
+        detachedPreview.AreTransportControlsEnabled(true);
+        detachedPreview.HorizontalAlignment(HorizontalAlignment::Stretch);
+        detachedPreview.VerticalAlignment(VerticalAlignment::Stretch);
+        detachedPreview.SetMediaPlayer(m_player);
+        root.Children().Append(detachedPreview);
+
+        previewWindow.Content(root);
+        previewWindow.Activate();
+
+        m_separatePreviewClosedRevoker = previewWindow.Closed(auto_revoke, {this, &MainWindow::onSeparatePreviewWindowClosed});
+        m_separatePreviewWindow = previewWindow;
+        m_isSeparatePreviewWindowOpen = true;
+        m_isSeparatePreviewFullscreen = false;
+        PreviewPlayer().SetMediaPlayer(nullptr);
+        SeparatePreviewWindowMenuItem().IsChecked(true);
+        setStatusMessage(L"Preview opened in separate window");
+        return true;
+    }
+
+    if(m_separatePreviewWindow){
+        m_separatePreviewClosedRevoker.revoke();
+        m_separatePreviewWindow.Close();
+        m_separatePreviewWindow = nullptr;
+    }
+
+    PreviewPlayer().SetMediaPlayer(m_player);
+    m_isSeparatePreviewWindowOpen = false;
+    m_isSeparatePreviewFullscreen = false;
+    SeparatePreviewWindowMenuItem().IsChecked(false);
+    setStatusMessage(L"Preview restored to main window");
+    return true;
+}
+
+void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
+    m_separatePreviewClosedRevoker.revoke();
+    m_separatePreviewWindow = nullptr;
+    m_isSeparatePreviewWindowOpen = false;
+    m_isSeparatePreviewFullscreen = false;
+    PreviewPlayer().SetMediaPlayer(m_player);
+    SeparatePreviewWindowMenuItem().IsChecked(false);
+    setStatusMessage(L"Preview restored to main window");
+}
+
+bool MainWindow::toggleSeparatePreviewFullscreen(){
+    if(!m_isSeparatePreviewWindowOpen || !m_separatePreviewWindow){
+        setStatusMessage(L"Open the separate preview window first");
+        return false;
+    }
+
+    HWND previewHwnd{};
+    check_hresult(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd));
+    if(!previewHwnd){
+        setErrorMessage(L"Could not resolve preview window handle");
+        return false;
+    }
+
+    const auto previewAppWindow{AppWindow::GetFromWindowId(GetWindowIdFromWindow(previewHwnd))};
+    if(!previewAppWindow){
+        setErrorMessage(L"Could not control preview window presenter");
+        return false;
+    }
+
+    m_isSeparatePreviewFullscreen = !m_isSeparatePreviewFullscreen;
+    previewAppWindow.SetPresenter(m_isSeparatePreviewFullscreen ? AppWindowPresenterKind::FullScreen : AppWindowPresenterKind::Default);
+    setStatusMessage(m_isSeparatePreviewFullscreen ? L"Separate preview: full-screen on" : L"Separate preview: full-screen off");
+    return true;
 }
 
 void MainWindow::rootGrid_PointerReleased(const Control&, const PREArgs& args){
@@ -1711,6 +1818,7 @@ AAction MainWindow::manualMenuItem_Click(const Control& sender, const REArgs& ar
         L"• Cut markers: Right-Click on the timeline/tick bar to toggle a marker at the desired frame. Markers split the video into scenes.\n"
         L"• Cut scene toggling: Ctrl+Left-Click a scene block to mark/unmark that whole scene for cutting; dark overlays indicate sections that will be removed.\n"
         L"• Preview start/pause/stop skipping cut scenes.\n"
+        L"• Preview window: Tools → Preview in separate window opens a movable second window; use F11 to toggle full-screen.\n"
         L"• Audio controls: Keep/remove audio and configure cross-fade for segment transitions.\n"
         L"• Project files: Save and reopen .llvc projects with timeline state.\n"
         L"• Export: Render a lossless cut based on your selected ranges (auto-adjusting to proper cut points if necessary).\n\n"

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -811,6 +811,7 @@ void MainWindow::timelineZoomSlider_ValueChanged(const Control&, const RBVArgs&)
     if(m_prj.videoFile() && m_timelineDurationSeconds > 0){
         renderTimelineAsync();
     }
+    ensureCurrentTimelineCursorVisible();
     updateWindowTitle();
     tryFocusTimelineCanvas(FocusState::Programmatic);
 }
@@ -1135,6 +1136,12 @@ void MainWindow::ensureTimelineCursorVisible(double cursorLeft){
     }
 }
 
+void MainWindow::ensureCurrentTimelineCursorVisible(){
+    const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
+    ensureTimelineCursorVisible(cursorLeft);
+    syncTimelineHorizontalScrollBar();
+}
+
 void MainWindow::renderTimelineTicks(){
     TimelineTickCanvas().Children().Clear();
 
@@ -1336,9 +1343,7 @@ void MainWindow::stepByFrame(int delta){
     const auto target {clamp(current + (direction * frameStep100ns), 0LL, duration100ns)};
     m_player.PlaybackSession().Position(TimeSpan{target});
     updateTimelineCursorFromPlayback();
-    const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
-    ensureTimelineCursorVisible(cursorLeft);
-    syncTimelineHorizontalScrollBar();
+    ensureCurrentTimelineCursorVisible();
 }
 
 
@@ -1390,9 +1395,7 @@ bool MainWindow::moveCursorToMarker(int direction){
     if(m_player){
         m_player.PlaybackSession().Position(TimeSpan{target100ns});
         updateTimelineCursorFromPlayback();
-        const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
-        ensureTimelineCursorVisible(cursorLeft);
-        syncTimelineHorizontalScrollBar();
+        ensureCurrentTimelineCursorVisible();
         return true;
     }
 
@@ -2916,10 +2919,11 @@ winrt::fire_and_forget MainWindow::renderTimelineAsync(){
         }
 
         updateTimelineCursorFromPlayback();
-        if(!renderDuringExport && m_player && m_player.PlaybackSession().PlaybackState() == MediaPlaybackState::Playing){
-            ensureTimelineCursorVisible(Controls::Canvas::GetLeft(TimelineCursor()));
+        if(!renderDuringExport){
+            ensureCurrentTimelineCursorVisible();
+        }else{
+            syncTimelineHorizontalScrollBar();
         }
-        syncTimelineHorizontalScrollBar();
 
         if(!renderDuringExport){
             wstring status{L"Loaded: "};

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1591,7 +1591,7 @@ void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
     setStatusMessage(L"Preview restored to main window");
 }
 
-void MainWindow::onSeparatePreviewWindowActivated(const winrt::Microsoft::UI::Xaml::Window&, const winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs& args){
+void MainWindow::onSeparatePreviewWindowActivated(const Control&, const winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs& args){
     if(args.WindowActivationState() == winrt::Microsoft::UI::Xaml::WindowActivationState::Deactivated){
         return;
     }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -671,6 +671,7 @@ void MainWindow::onClosed(const Control&, const WEArgs&){
 
     if(m_separatePreviewWindow){
         m_separatePreviewClosedRevoker.revoke();
+        m_separatePreviewActivatedRevoker.revoke();
         m_separatePreviewWindow.Close();
         m_separatePreviewWindow = nullptr;
     }
@@ -1538,8 +1539,24 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         previewWindow.Content(root);
         previewWindow.Activate();
 
+        HWND previewHwnd{};
+        check_hresult(previewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd));
+        if(previewHwnd){
+            const auto exStyle{::GetWindowLongPtrW(previewHwnd, GWL_EXSTYLE)};
+            ::SetWindowLongPtrW(previewHwnd, GWL_EXSTYLE, exStyle | WS_EX_NOACTIVATE);
+            ::SetWindowPos(previewHwnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED | SWP_NOACTIVATE);
+        }
+
         m_separatePreviewClosedRevoker = previewWindow.Closed(auto_revoke, {this, &MainWindow::onSeparatePreviewWindowClosed});
+        m_separatePreviewActivatedRevoker = previewWindow.Activated(auto_revoke, {this, &MainWindow::onSeparatePreviewWindowActivated});
         m_separatePreviewWindow = previewWindow;
+
+        Activate();
+        const auto mainHwnd{getWindowHandle()};
+        if(mainHwnd){
+            ::SetForegroundWindow(mainHwnd);
+            ::SetFocus(mainHwnd);
+        }
         m_isSeparatePreviewWindowOpen = true;
         m_isSeparatePreviewFullscreen = false;
         PreviewPlayer().SetMediaPlayer(nullptr);
@@ -1550,6 +1567,7 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
 
     if(m_separatePreviewWindow){
         m_separatePreviewClosedRevoker.revoke();
+        m_separatePreviewActivatedRevoker.revoke();
         m_separatePreviewWindow.Close();
         m_separatePreviewWindow = nullptr;
     }
@@ -1564,12 +1582,26 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
 
 void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
     m_separatePreviewClosedRevoker.revoke();
+    m_separatePreviewActivatedRevoker.revoke();
     m_separatePreviewWindow = nullptr;
     m_isSeparatePreviewWindowOpen = false;
     m_isSeparatePreviewFullscreen = false;
     PreviewPlayer().SetMediaPlayer(m_player);
     SeparatePreviewWindowMenuItem().IsChecked(false);
     setStatusMessage(L"Preview restored to main window");
+}
+
+void MainWindow::onSeparatePreviewWindowActivated(const winrt::Microsoft::UI::Xaml::Window&, const winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs& args){
+    if(args.WindowActivationState() == winrt::Microsoft::UI::Xaml::WindowActivationState::Deactivated){
+        return;
+    }
+
+    Activate();
+    const auto mainHwnd{getWindowHandle()};
+    if(mainHwnd){
+        ::SetForegroundWindow(mainHwnd);
+        ::SetFocus(mainHwnd);
+    }
 }
 
 bool MainWindow::toggleSeparatePreviewFullscreen(){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -391,6 +391,13 @@ constexpr auto S_RECENT_PROJECTS{L"RecentProjects"};
 constexpr auto S_MAX_RECENT_VIDEOS{L"MaxRecentVideos"};
 constexpr auto S_MAX_RECENT_PROJECTS{L"MaxRecentProjects"};
 constexpr auto S_DEFAULT_MAX_RECENT{5};
+constexpr auto S_SEPARATE_PREVIEW_DETACHED{L"SeparatePreviewDetached"};
+constexpr auto S_SEPARATE_PREVIEW_L{L"SeparatePreviewLeft"};
+constexpr auto S_SEPARATE_PREVIEW_T{L"SeparatePreviewTop"};
+constexpr auto S_SEPARATE_PREVIEW_W{L"SeparatePreviewWidth"};
+constexpr auto S_SEPARATE_PREVIEW_H{L"SeparatePreviewHeight"};
+constexpr auto S_SEPARATE_PREVIEW_DPI{L"SeparatePreviewDpi"};
+constexpr auto S_SEPARATE_PREVIEW_MAX{L"SeparatePreviewMaximized"};
 
 constexpr auto P_FILE_PATH{L"file_path"};
 constexpr auto P_STORYLINE_ZOOM{L"storyline_zoom"};
@@ -535,6 +542,10 @@ MainWindow::MainWindow(){
     refreshRecentProjectsMenu();
     updateWindowTitle();
     refreshStatusInfoSection();
+
+    if(m_restorePreviewDetachedOnStartup){
+        (void)setSeparatePreviewWindowOpen(true);
+    }
 }
 
 HWND MainWindow::getWindowHandle() const{
@@ -629,6 +640,19 @@ void MainWindow::loadAppSettings(){
     if(m_recentProjects.size() > m_maxRecentProjects){
         m_recentProjects.resize(m_maxRecentProjects);
     }
+
+    m_restorePreviewDetachedOnStartup = values.HasKey(S_SEPARATE_PREVIEW_DETACHED)
+        && unbox_value<bool>(values.Lookup(S_SEPARATE_PREVIEW_DETACHED));
+
+    if(values.HasKey(S_SEPARATE_PREVIEW_L) && values.HasKey(S_SEPARATE_PREVIEW_T) && values.HasKey(S_SEPARATE_PREVIEW_W) && values.HasKey(S_SEPARATE_PREVIEW_H)){
+        m_separatePreviewLeft = unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_L));
+        m_separatePreviewTop = unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_T));
+        m_separatePreviewWidthDips = max<int32_t>(320, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_W)));
+        m_separatePreviewHeightDips = max<int32_t>(200, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_H)));
+        m_separatePreviewDpi = values.HasKey(S_SEPARATE_PREVIEW_DPI) ? max<int32_t>(96, unbox_value<int32_t>(values.Lookup(S_SEPARATE_PREVIEW_DPI))) : 96;
+        m_separatePreviewWasMaximized = values.HasKey(S_SEPARATE_PREVIEW_MAX) && unbox_value<bool>(values.Lookup(S_SEPARATE_PREVIEW_MAX));
+        m_hasSeparatePreviewPlacement = true;
+    }
 }
 
 void MainWindow::saveAppSettings() const{
@@ -637,6 +661,16 @@ void MainWindow::saveAppSettings() const{
     values.Insert(S_MAX_RECENT_PROJECTS, box_value(static_cast<int32_t>(m_maxRecentProjects)));
     values.Insert(S_RECENT_VIDEOS, box_value(hstring(joinRecentItems(m_recentVideos))));
     values.Insert(S_RECENT_PROJECTS, box_value(hstring(joinRecentItems(m_recentProjects))));
+    values.Insert(S_SEPARATE_PREVIEW_DETACHED, box_value(m_restorePreviewDetachedOnStartup));
+
+    if(m_hasSeparatePreviewPlacement){
+        values.Insert(S_SEPARATE_PREVIEW_L, box_value(m_separatePreviewLeft));
+        values.Insert(S_SEPARATE_PREVIEW_T, box_value(m_separatePreviewTop));
+        values.Insert(S_SEPARATE_PREVIEW_W, box_value(m_separatePreviewWidthDips));
+        values.Insert(S_SEPARATE_PREVIEW_H, box_value(m_separatePreviewHeightDips));
+        values.Insert(S_SEPARATE_PREVIEW_DPI, box_value(m_separatePreviewDpi));
+        values.Insert(S_SEPARATE_PREVIEW_MAX, box_value(m_separatePreviewWasMaximized));
+    }
 }
 
 void MainWindow::saveWindowPlacement() const{
@@ -672,7 +706,14 @@ void MainWindow::onClosed(const Control&, const WEArgs&){
     m_naturalDurationChangedRevoker.revoke();
     m_mainWindowActivatedRevoker.revoke();
 
+    m_restorePreviewDetachedOnStartup = m_isSeparatePreviewWindowOpen;
+
     if(m_separatePreviewWindow){
+        HWND previewHwnd{};
+        if(SUCCEEDED(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
+            saveSeparatePreviewPlacement(previewHwnd);
+        }
+
         m_separatePreviewClosedRevoker.revoke();
         m_separatePreviewWindow.Close();
         m_separatePreviewWindow = nullptr;
@@ -1574,6 +1615,11 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         previewWindow.Activate();
         root.Focus(FocusState::Programmatic);
 
+        HWND previewHwnd{};
+        if(SUCCEEDED(previewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
+            restoreSeparatePreviewPlacement(previewHwnd);
+        }
+
         Activate();
         const auto weakThis{get_weak()};
         DispatcherQueue().TryEnqueue([weakThis]{
@@ -1586,6 +1632,7 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         m_separatePreviewWindow = previewWindow;
         m_isSeparatePreviewWindowOpen = true;
         m_isSeparatePreviewFullscreen = false;
+        m_restorePreviewDetachedOnStartup = true;
         PreviewPlayer().SetMediaPlayer(nullptr);
         SeparatePreviewWindowMenuItem().IsChecked(true);
         setStatusMessage(L"Preview opened in separate window");
@@ -1593,6 +1640,11 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
     }
 
     if(m_separatePreviewWindow){
+        HWND previewHwnd{};
+        if(SUCCEEDED(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
+            saveSeparatePreviewPlacement(previewHwnd);
+        }
+
         m_separatePreviewClosedRevoker.revoke();
         m_separatePreviewWindow.Close();
         m_separatePreviewWindow = nullptr;
@@ -1601,16 +1653,27 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
     PreviewPlayer().SetMediaPlayer(m_player);
     m_isSeparatePreviewWindowOpen = false;
     m_isSeparatePreviewFullscreen = false;
+    m_restorePreviewDetachedOnStartup = false;
     SeparatePreviewWindowMenuItem().IsChecked(false);
     setStatusMessage(L"Preview restored to main window");
     return true;
 }
 
 void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
+    if(m_separatePreviewWindow){
+        HWND previewHwnd{};
+        if(SUCCEEDED(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
+            saveSeparatePreviewPlacement(previewHwnd);
+        }
+    }
+
     m_separatePreviewClosedRevoker.revoke();
     m_separatePreviewWindow = nullptr;
     m_isSeparatePreviewWindowOpen = false;
     m_isSeparatePreviewFullscreen = false;
+    if(!m_isClosing){
+        m_restorePreviewDetachedOnStartup = false;
+    }
     PreviewPlayer().SetMediaPlayer(m_player);
     SeparatePreviewWindowMenuItem().IsChecked(false);
     setStatusMessage(L"Preview restored to main window");
@@ -1618,6 +1681,53 @@ void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
 
 void MainWindow::onSeparatePreviewWindowKeyDown(const KRArgs& args){
     (void)handleStorylineKeyDown(args);
+}
+
+void MainWindow::saveSeparatePreviewPlacement(HWND previewHwnd){
+    if(!previewHwnd){
+        return;
+    }
+
+    RECT bounds{};
+    if(!::GetWindowRect(previewHwnd, &bounds)){
+        return;
+    }
+
+    WINDOWPLACEMENT placement{.length = sizeof(placement)};
+    if(::GetWindowPlacement(previewHwnd, &placement) && placement.showCmd == SW_SHOWMAXIMIZED){
+        m_separatePreviewWasMaximized = true;
+        bounds = placement.rcNormalPosition;
+    }else{
+        m_separatePreviewWasMaximized = false;
+    }
+
+    const auto dpi{::GetDpiForWindow(previewHwnd)};
+    m_separatePreviewLeft = static_cast<int32_t>(bounds.left);
+    m_separatePreviewTop = static_cast<int32_t>(bounds.top);
+    m_separatePreviewWidthDips = pixelsToDips(static_cast<int32_t>(bounds.right - bounds.left), dpi);
+    m_separatePreviewHeightDips = pixelsToDips(static_cast<int32_t>(bounds.bottom - bounds.top), dpi);
+    m_separatePreviewDpi = static_cast<int32_t>(dpi);
+    m_hasSeparatePreviewPlacement = true;
+}
+
+void MainWindow::restoreSeparatePreviewPlacement(HWND previewHwnd){
+    if(!previewHwnd || !m_hasSeparatePreviewPlacement){
+        return;
+    }
+
+    const auto currentDpi{::GetDpiForWindow(previewHwnd)};
+    const auto width{dipsToPixels(m_separatePreviewWidthDips, currentDpi)};
+    const auto height{dipsToPixels(m_separatePreviewHeightDips, currentDpi)};
+    RECT desiredRect{m_separatePreviewLeft, m_separatePreviewTop, m_separatePreviewLeft + width, m_separatePreviewTop + height};
+    if(!isRectVisibleOnAnyMonitor(desiredRect)){
+        return;
+    }
+
+    ::SetWindowPos(previewHwnd, nullptr, desiredRect.left, desiredRect.top, width, height, SWP_NOACTIVATE | SWP_NOZORDER);
+
+    if(m_separatePreviewWasMaximized){
+        ::ShowWindow(previewHwnd, SW_MAXIMIZE);
+    }
 }
 
 bool MainWindow::toggleSeparatePreviewFullscreen(){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -811,6 +811,7 @@ void MainWindow::timelineZoomSlider_ValueChanged(const Control&, const RBVArgs&)
     if(m_prj.videoFile() && m_timelineDurationSeconds > 0){
         renderTimelineAsync();
     }
+    //ensureCurrentTimelineCursorVisible(); XXX: for some reason this line causes a terminating exception
     updateWindowTitle();
     tryFocusTimelineCanvas(FocusState::Programmatic);
 }
@@ -1135,6 +1136,12 @@ void MainWindow::ensureTimelineCursorVisible(double cursorLeft){
     }
 }
 
+void MainWindow::ensureCurrentTimelineCursorVisible(){
+    const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
+    ensureTimelineCursorVisible(cursorLeft);
+    syncTimelineHorizontalScrollBar();
+}
+
 void MainWindow::renderTimelineTicks(){
     TimelineTickCanvas().Children().Clear();
 
@@ -1336,9 +1343,7 @@ void MainWindow::stepByFrame(int delta){
     const auto target {clamp(current + (direction * frameStep100ns), 0LL, duration100ns)};
     m_player.PlaybackSession().Position(TimeSpan{target});
     updateTimelineCursorFromPlayback();
-    const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
-    ensureTimelineCursorVisible(cursorLeft);
-    syncTimelineHorizontalScrollBar();
+    ensureCurrentTimelineCursorVisible();
 }
 
 
@@ -1390,9 +1395,7 @@ bool MainWindow::moveCursorToMarker(int direction){
     if(m_player){
         m_player.PlaybackSession().Position(TimeSpan{target100ns});
         updateTimelineCursorFromPlayback();
-        const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
-        ensureTimelineCursorVisible(cursorLeft);
-        syncTimelineHorizontalScrollBar();
+        ensureCurrentTimelineCursorVisible();
         return true;
     }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -811,7 +811,6 @@ void MainWindow::timelineZoomSlider_ValueChanged(const Control&, const RBVArgs&)
     if(m_prj.videoFile() && m_timelineDurationSeconds > 0){
         renderTimelineAsync();
     }
-    ensureCurrentTimelineCursorVisible();
     updateWindowTitle();
     tryFocusTimelineCanvas(FocusState::Programmatic);
 }
@@ -1136,12 +1135,6 @@ void MainWindow::ensureTimelineCursorVisible(double cursorLeft){
     }
 }
 
-void MainWindow::ensureCurrentTimelineCursorVisible(){
-    const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
-    ensureTimelineCursorVisible(cursorLeft);
-    syncTimelineHorizontalScrollBar();
-}
-
 void MainWindow::renderTimelineTicks(){
     TimelineTickCanvas().Children().Clear();
 
@@ -1343,7 +1336,9 @@ void MainWindow::stepByFrame(int delta){
     const auto target {clamp(current + (direction * frameStep100ns), 0LL, duration100ns)};
     m_player.PlaybackSession().Position(TimeSpan{target});
     updateTimelineCursorFromPlayback();
-    ensureCurrentTimelineCursorVisible();
+    const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
+    ensureTimelineCursorVisible(cursorLeft);
+    syncTimelineHorizontalScrollBar();
 }
 
 
@@ -1395,7 +1390,9 @@ bool MainWindow::moveCursorToMarker(int direction){
     if(m_player){
         m_player.PlaybackSession().Position(TimeSpan{target100ns});
         updateTimelineCursorFromPlayback();
-        ensureCurrentTimelineCursorVisible();
+        const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
+        ensureTimelineCursorVisible(cursorLeft);
+        syncTimelineHorizontalScrollBar();
         return true;
     }
 
@@ -2919,11 +2916,10 @@ winrt::fire_and_forget MainWindow::renderTimelineAsync(){
         }
 
         updateTimelineCursorFromPlayback();
-        if(!renderDuringExport){
-            ensureCurrentTimelineCursorVisible();
-        }else{
-            syncTimelineHorizontalScrollBar();
+        if(!renderDuringExport && m_player && m_player.PlaybackSession().PlaybackState() == MediaPlaybackState::Playing){
+            ensureTimelineCursorVisible(Controls::Canvas::GetLeft(TimelineCursor()));
         }
+        syncTimelineHorizontalScrollBar();
 
         if(!renderDuringExport){
             wstring status{L"Loaded: "};

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1534,6 +1534,18 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         detachedPreview.HorizontalAlignment(HorizontalAlignment::Stretch);
         detachedPreview.VerticalAlignment(VerticalAlignment::Stretch);
         detachedPreview.SetMediaPlayer(m_player);
+
+        const auto weakSelf{get_weak()};
+        const auto detachedKeyHandler{[weakSelf](const auto&, const KRArgs& e){
+            if(const auto self{weakSelf.get()}){
+                self->onSeparatePreviewWindowKeyDown(e);
+            }
+        }};
+        detachedPreview.PreviewKeyDown(detachedKeyHandler);
+        detachedPreview.KeyDown(detachedKeyHandler);
+
+        root.PreviewKeyDown(detachedKeyHandler);
+        root.KeyDown(detachedKeyHandler);
         root.Children().Append(detachedPreview);
 
         previewWindow.Content(root);
@@ -1601,6 +1613,18 @@ void MainWindow::onSeparatePreviewWindowActivated(const Control&, const winrt::M
     if(mainHwnd){
         ::SetForegroundWindow(mainHwnd);
         ::SetFocus(mainHwnd);
+    }
+}
+
+void MainWindow::onSeparatePreviewWindowKeyDown(const KRArgs& args){
+    if(handleStorylineKeyDown(args)){
+        Activate();
+        const auto mainHwnd{getWindowHandle()};
+        if(mainHwnd){
+            ::SetForegroundWindow(mainHwnd);
+            ::SetFocus(mainHwnd);
+        }
+        tryFocusTimelineCanvas(FocusState::Programmatic);
     }
 }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -47,6 +47,7 @@
 #include <winrt/Windows.System.h>
 
 import llvc.Export;
+import llvc.Utils;
 
 #pragma comment(lib, "Shell32.lib")
 
@@ -76,6 +77,7 @@ using SCArgs = MainWindow::SCArgs;
 using KRArgs = MainWindow::KRArgs;
 using DEArgs = MainWindow::DEArgs;
 using WEArgs = MainWindow::WEArgs;
+using WAVArgs = MainWindow::WAVArgs;
 using MPSession = MainWindow::MPSession;
 using SFile = MainWindow::SFile;
 using FState = MainWindow::FState;
@@ -87,6 +89,40 @@ constexpr auto W_POS_L{L"WindowLeft"};
 namespace{
 
 constexpr int64_t HNS_PER_SECOND{10'000'000LL};
+
+
+template<typename T>
+std::optional<T> tryReadSetting(Windows::Foundation::Collections::IPropertySet& values, const wchar_t* key){
+    if(!values.HasKey(key)){
+        return std::nullopt;
+    }
+
+    try{
+        return unbox_value<T>(values.Lookup(key));
+    }catch(const winrt::hresult_error&){
+        values.Remove(key);
+        return std::nullopt;
+    }
+}
+
+std::optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IPropertySet& values, const wchar_t* key){
+    if(const auto asBool{tryReadSetting<bool>(values, key)}){
+        return asBool;
+    }
+    if(const auto asInt{tryReadSetting<int32_t>(values, key)}){
+        return *asInt != 0;
+    }
+    if(const auto asText{tryReadSetting<hstring>(values, key)}){
+        const auto text{trim(asText->c_str())};
+        if(_wcsicmp(text.c_str(), L"true") == 0 || _wcsicmp(text.c_str(), L"1") == 0){
+            return true;
+        }
+        if(_wcsicmp(text.c_str(), L"false") == 0 || _wcsicmp(text.c_str(), L"0") == 0){
+            return false;
+        }
+    }
+    return std::nullopt;
+}
 
 bool isAviPath(const wstring& filePath){
     if(filePath.size() < 4){
@@ -390,6 +426,13 @@ constexpr auto S_RECENT_PROJECTS{L"RecentProjects"};
 constexpr auto S_MAX_RECENT_VIDEOS{L"MaxRecentVideos"};
 constexpr auto S_MAX_RECENT_PROJECTS{L"MaxRecentProjects"};
 constexpr auto S_DEFAULT_MAX_RECENT{5};
+constexpr auto S_SEPARATE_PREVIEW_DETACHED{L"SeparatePreviewDetached"};
+constexpr auto S_SEPARATE_PREVIEW_L{L"SeparatePreviewLeft"};
+constexpr auto S_SEPARATE_PREVIEW_T{L"SeparatePreviewTop"};
+constexpr auto S_SEPARATE_PREVIEW_W{L"SeparatePreviewWidth"};
+constexpr auto S_SEPARATE_PREVIEW_H{L"SeparatePreviewHeight"};
+constexpr auto S_SEPARATE_PREVIEW_DPI{L"SeparatePreviewDpi"};
+constexpr auto S_SEPARATE_PREVIEW_FULLSCREEN{L"SeparatePreviewFullscreen"};
 
 constexpr auto P_FILE_PATH{L"file_path"};
 constexpr auto P_STORYLINE_ZOOM{L"storyline_zoom"};
@@ -529,10 +572,15 @@ MainWindow::MainWindow(){
     restoreWindowPlacement();
     loadAppSettings();
     Closed({this, &MainWindow::onClosed});
+    m_mainWindowActivatedRevoker = Activated(auto_revoke, {this, &MainWindow::onWindowActivated});
     refreshRecentVideosMenu();
     refreshRecentProjectsMenu();
     updateWindowTitle();
     refreshStatusInfoSection();
+
+    if(m_restorePreviewDetachedOnStartup){
+        (void)setSeparatePreviewWindowOpen(true);
+    }
 }
 
 HWND MainWindow::getWindowHandle() const{
@@ -543,83 +591,53 @@ HWND MainWindow::getWindowHandle() const{
 }
 
 
-auto pixelsToDips(int32_t pixelValue, uint32_t dpi){
-    return static_cast<int32_t>(lround((pixelValue * 96.0) / (dpi == 0 ? 96 : dpi)));
-}
-
-auto dipsToPixels(int32_t dipValue, uint32_t dpi){
-    return static_cast<int32_t>(lround((dipValue * (dpi == 0 ? 96U : dpi)) / 96));
-}
-
-bool MainWindow::isRectVisibleOnAnyMonitor(const RECT& rect){
-    const auto monitor{::MonitorFromRect(&rect, MONITOR_DEFAULTTONULL)};
-    if(!monitor){
-        return false;
-    }
-
-    MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
-    if(!::GetMonitorInfoW(monitor, &monitorInfo)){
-        return false;
-    }
-
-    RECT intersection{};
-    return ::IntersectRect(&intersection, &rect, &monitorInfo.rcWork) != FALSE;
-}
-
 void MainWindow::restoreWindowPlacement(){
     const auto localSettings{ApplicationData::Current().LocalSettings()};
-    const auto values{localSettings.Values()};
+    auto values{localSettings.Values()};
 
-    if(!values.HasKey(W_POS_L) || !values.HasKey(W_POS_T) || !values.HasKey(W_POS_W) || !values.HasKey(W_POS_H)){
+    const auto left{tryReadSetting<int32_t>(values, W_POS_L)};
+    const auto top{tryReadSetting<int32_t>(values, W_POS_T)};
+    const auto widthDips{tryReadSetting<int32_t>(values, W_POS_W)};
+    const auto heightDips{tryReadSetting<int32_t>(values, W_POS_H)};
+    if(!left || !top || !widthDips || !heightDips){
         return;
     }
 
-    const auto left{unbox_value<int32_t>(values.Lookup(W_POS_L))};
-    const auto top{unbox_value<int32_t>(values.Lookup(W_POS_T))};
+    ::llvc::WindowPlacementState state{};
+    state.left = *left;
+    state.top = *top;
+    state.widthDips = *widthDips;
+    state.heightDips = *heightDips;
+    state.dpi = tryReadSetting<int32_t>(values, W_POS_DPI).value_or(96);
 
     const auto hwnd{getWindowHandle()};
-
-    SetWindowPos(hwnd, nullptr, left, top, 0, 0, SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOSIZE);
-
-    const auto currentDpi{::GetDpiForWindow(hwnd)};
-    const auto hasDpiData{values.HasKey(W_POS_DPI)};
-    const auto storedWidth{unbox_value<int32_t>(values.Lookup(W_POS_W))};
-    const auto storedHeight{unbox_value<int32_t>(values.Lookup(W_POS_H))};
-    const auto width{hasDpiData ? dipsToPixels(storedWidth, currentDpi) : storedWidth};
-    const auto height{hasDpiData ? dipsToPixels(storedHeight, currentDpi) : storedHeight};
-
-    if(!isRectVisibleOnAnyMonitor(RECT{left, top, left + width, top + height})){
+    if(!applyWindowPlacement(hwnd, state, hwnd, false)){
         values.Remove(W_POS_L);
         values.Remove(W_POS_T);
         values.Remove(W_POS_W);
         values.Remove(W_POS_H);
         values.Remove(W_POS_DPI);
-        return;
     }
-
-    SetWindowPos(hwnd, nullptr, left, top, width, height, SWP_NOACTIVATE | SWP_NOZORDER);
 }
 
 void MainWindow::loadAppSettings(){
-    const auto values{ApplicationData::Current().LocalSettings().Values()};
+    auto values{ApplicationData::Current().LocalSettings().Values()};
 
     m_maxRecentVideos = S_DEFAULT_MAX_RECENT;
     m_maxRecentProjects = S_DEFAULT_MAX_RECENT;
 
-    if(values.HasKey(S_MAX_RECENT_VIDEOS)){
-        const auto parsed{unbox_value<int32_t>(values.Lookup(S_MAX_RECENT_VIDEOS))};
-        m_maxRecentVideos = static_cast<uint32_t>(clamp(parsed, 1, 20));
+    if(const auto parsed{tryReadSetting<int32_t>(values, S_MAX_RECENT_VIDEOS)}){
+        m_maxRecentVideos = static_cast<uint32_t>(clamp(*parsed, 1, 20));
     }
-    if(values.HasKey(S_MAX_RECENT_PROJECTS)){
-        const auto parsed{unbox_value<int32_t>(values.Lookup(S_MAX_RECENT_PROJECTS))};
-        m_maxRecentProjects = static_cast<uint32_t>(clamp(parsed, 1, 20));
+    if(const auto parsed{tryReadSetting<int32_t>(values, S_MAX_RECENT_PROJECTS)}){
+        m_maxRecentProjects = static_cast<uint32_t>(clamp(*parsed, 1, 20));
     }
 
-    if(values.HasKey(S_RECENT_VIDEOS)){
-        m_recentVideos = splitRecentItems(unbox_value<hstring>(values.Lookup(S_RECENT_VIDEOS)).c_str());
+    if(const auto recentVideosText{tryReadSetting<hstring>(values, S_RECENT_VIDEOS)}){
+        m_recentVideos = splitRecentItems(recentVideosText->c_str());
     }
-    if(values.HasKey(S_RECENT_PROJECTS)){
-        m_recentProjects = splitRecentItems(unbox_value<hstring>(values.Lookup(S_RECENT_PROJECTS)).c_str());
+    if(const auto recentProjectsText{tryReadSetting<hstring>(values, S_RECENT_PROJECTS)}){
+        m_recentProjects = splitRecentItems(recentProjectsText->c_str());
     }
     if(m_recentVideos.size() > m_maxRecentVideos){
         m_recentVideos.resize(m_maxRecentVideos);
@@ -627,37 +645,57 @@ void MainWindow::loadAppSettings(){
     if(m_recentProjects.size() > m_maxRecentProjects){
         m_recentProjects.resize(m_maxRecentProjects);
     }
+
+    m_restorePreviewDetachedOnStartup = tryReadBoolSetting(values, S_SEPARATE_PREVIEW_DETACHED).value_or(false);
+
+    const auto previewLeft{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_L)};
+    const auto previewTop{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_T)};
+    const auto previewWidthDips{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_W)};
+    const auto previewHeightDips{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_H)};
+    if(previewLeft && previewTop && previewWidthDips && previewHeightDips){
+        m_separatePreviewLeft = *previewLeft;
+        m_separatePreviewTop = *previewTop;
+        m_separatePreviewWidthDips = max<int32_t>(320, *previewWidthDips);
+        m_separatePreviewHeightDips = max<int32_t>(200, *previewHeightDips);
+        m_separatePreviewDpi = max<int32_t>(96, tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_DPI).value_or(96));
+        m_hasSeparatePreviewPlacement = true;
+    }
+
+    m_restorePreviewFullscreenOnStartup = tryReadBoolSetting(values, S_SEPARATE_PREVIEW_FULLSCREEN).value_or(false);
 }
 
 void MainWindow::saveAppSettings() const{
-    const auto values{ApplicationData::Current().LocalSettings().Values()};
+    auto values{ApplicationData::Current().LocalSettings().Values()};
     values.Insert(S_MAX_RECENT_VIDEOS, box_value(static_cast<int32_t>(m_maxRecentVideos)));
     values.Insert(S_MAX_RECENT_PROJECTS, box_value(static_cast<int32_t>(m_maxRecentProjects)));
     values.Insert(S_RECENT_VIDEOS, box_value(hstring(joinRecentItems(m_recentVideos))));
     values.Insert(S_RECENT_PROJECTS, box_value(hstring(joinRecentItems(m_recentProjects))));
+    values.Insert(S_SEPARATE_PREVIEW_DETACHED, box_value(m_restorePreviewDetachedOnStartup));
+    values.Insert(S_SEPARATE_PREVIEW_FULLSCREEN, box_value(m_restorePreviewFullscreenOnStartup));
+
+    if(m_hasSeparatePreviewPlacement){
+        values.Insert(S_SEPARATE_PREVIEW_L, box_value(m_separatePreviewLeft));
+        values.Insert(S_SEPARATE_PREVIEW_T, box_value(m_separatePreviewTop));
+        values.Insert(S_SEPARATE_PREVIEW_W, box_value(m_separatePreviewWidthDips));
+        values.Insert(S_SEPARATE_PREVIEW_H, box_value(m_separatePreviewHeightDips));
+        values.Insert(S_SEPARATE_PREVIEW_DPI, box_value(m_separatePreviewDpi));
+    }
 }
 
 void MainWindow::saveWindowPlacement() const{
     const auto hwnd{getWindowHandle()};
-
-    RECT bounds{};
-    if(!GetWindowRect(hwnd, &bounds)){
+    const auto captured{::llvc::captureWindowPlacement(hwnd)};
+    if(!captured){
         return;
     }
 
-    WINDOWPLACEMENT placement{.length = sizeof(placement)};
-    if(GetWindowPlacement(hwnd, &placement) && placement.showCmd == SW_SHOWMAXIMIZED){
-        bounds = placement.rcNormalPosition;
-    }
-
     const auto localSettings{ApplicationData::Current().LocalSettings()};
-    const auto values{localSettings.Values()};
-    const auto dpi{::GetDpiForWindow(hwnd)};
-    values.Insert(W_POS_L, box_value(static_cast<int32_t>(bounds.left)));
-    values.Insert(W_POS_T, box_value(static_cast<int32_t>(bounds.top)));
-    values.Insert(W_POS_W, box_value(pixelsToDips(static_cast<int32_t>(bounds.right - bounds.left), dpi)));
-    values.Insert(W_POS_H, box_value(pixelsToDips(static_cast<int32_t>(bounds.bottom - bounds.top), dpi)));
-    values.Insert(W_POS_DPI, box_value(static_cast<int32_t>(dpi)));
+    auto values{localSettings.Values()};
+    values.Insert(W_POS_L, box_value(captured->left));
+    values.Insert(W_POS_T, box_value(captured->top));
+    values.Insert(W_POS_W, box_value(captured->widthDips));
+    values.Insert(W_POS_H, box_value(captured->heightDips));
+    values.Insert(W_POS_DPI, box_value(captured->dpi));
 }
 
 void MainWindow::onClosed(const Control&, const WEArgs&){
@@ -668,8 +706,37 @@ void MainWindow::onClosed(const Control&, const WEArgs&){
     }
 
     m_naturalDurationChangedRevoker.revoke();
+    m_mainWindowActivatedRevoker.revoke();
+
+    m_restorePreviewDetachedOnStartup = m_isSeparatePreviewWindowOpen;
+    m_restorePreviewFullscreenOnStartup = m_isSeparatePreviewWindowOpen && m_isSeparatePreviewFullscreen;
+
+    if(m_separatePreviewWindow){
+        HWND previewHwnd{};
+        if(SUCCEEDED(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
+            saveSeparatePreviewPlacement(previewHwnd);
+        }
+
+        m_separatePreviewClosedRevoker.revoke();
+        m_separatePreviewWindow.Close();
+        m_separatePreviewWindow = nullptr;
+    }
+
     saveWindowPlacement();
     saveAppSettings();
+}
+
+void MainWindow::onWindowActivated(const Control&, const WAVArgs& args){
+    if(args.WindowActivationState() == WindowActivationState::Deactivated){
+        return;
+    }
+
+    const auto weakThis{get_weak()};
+    DispatcherQueue().TryEnqueue([weakThis]{
+        if(const auto self{weakThis.get()}){
+            self->tryFocusTimelineCanvas(FocusState::Programmatic);
+        }
+    });
 }
 
 void MainWindow::startButton_Click(const Control&, const REArgs&){
@@ -1445,6 +1512,21 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
             args.Handled(true);
             return true;
         }
+        if(args.Key() == VirtualKey::Add || args.Key() == static_cast<VirtualKey>(187)){
+            adjustTimelineZoomBy(1);
+            args.Handled(true);
+            return true;
+        }
+        if(args.Key() == VirtualKey::Subtract || args.Key() == static_cast<VirtualKey>(189)){
+            adjustTimelineZoomBy(-1);
+            args.Handled(true);
+            return true;
+        }
+        if(args.Key() == VirtualKey::R){
+            reevaluateClearCutMarkersButton_Click(nullptr, {});
+            args.Handled(true);
+            return true;
+        }
     }
 
     if(focusOnMenu || focusInDialog){
@@ -1489,6 +1571,10 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         (void)markSceneAtCursor(false);
         args.Handled(true);
         return true;
+    case VirtualKey::F11:
+        (void)toggleSeparatePreviewFullscreen();
+        args.Handled(true);
+        return true;
     default:
         return false;
     }
@@ -1500,6 +1586,246 @@ void MainWindow::window_PreviewKeyDown(const Control&, const KRArgs& args){
 
 void MainWindow::window_KeyDown(const Control&, const KRArgs& args){
     (void)handleStorylineKeyDown(args);
+}
+
+void MainWindow::separatePreviewWindowMenuItem_Click(const Control&, const REArgs&){
+    const auto targetOpen{!m_isSeparatePreviewWindowOpen};
+    if(!setSeparatePreviewWindowOpen(targetOpen)){
+    }
+}
+
+void MainWindow::toggleSeparatePreviewFullscreenMenuItem_Click(const Control&, const REArgs&){
+    (void)toggleSeparatePreviewFullscreen();
+}
+
+void MainWindow::zoomInTimelineMenuItem_Click(const Control&, const REArgs&){
+    adjustTimelineZoomBy(1);
+}
+
+void MainWindow::zoomOutTimelineMenuItem_Click(const Control&, const REArgs&){
+    adjustTimelineZoomBy(-1);
+}
+
+void MainWindow::adjustTimelineZoomBy(int delta){
+    auto slider{TimelineZoomSlider()};
+    if(!slider){
+        return;
+    }
+
+    const auto target{clamp(slider.Value() + delta, slider.Minimum(), slider.Maximum())};
+    slider.Value(target);
+}
+
+bool MainWindow::setSeparatePreviewWindowOpen(bool open){
+    if(open == m_isSeparatePreviewWindowOpen){
+        return true;
+    }
+
+    if(open){
+        auto previewWindow{Window()};
+        previewWindow.Title(L"llvc - Video preview");
+
+        Controls::Grid root{};
+        root.Background(Media::SolidColorBrush(Windows::UI::ColorHelper::FromArgb(0xFF, 0x08, 0x08, 0x08)));
+
+        Controls::MediaPlayerElement detachedPreview{};
+        detachedPreview.AreTransportControlsEnabled(true);
+        detachedPreview.HorizontalAlignment(HorizontalAlignment::Stretch);
+        detachedPreview.VerticalAlignment(VerticalAlignment::Stretch);
+        detachedPreview.SetMediaPlayer(m_player);
+
+        const auto weakSelf{get_weak()};
+        const auto detachedKeyHandler{[weakSelf](const auto&, const KRArgs& e){
+            if(const auto self{weakSelf.get()}){
+                self->onSeparatePreviewWindowKeyDown(e);
+            }
+        }};
+        detachedPreview.PreviewKeyDown(detachedKeyHandler);
+        detachedPreview.KeyDown(detachedKeyHandler);
+
+        root.IsTabStop(true);
+        root.PreviewKeyDown(detachedKeyHandler);
+        root.KeyDown(detachedKeyHandler);
+
+        root.Children().Append(detachedPreview);
+
+        previewWindow.Content(root);
+        previewWindow.Activate();
+        root.Focus(FocusState::Programmatic);
+
+        HWND previewHwnd{};
+        if(SUCCEEDED(previewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
+            restoreSeparatePreviewPlacement(previewHwnd);
+        }
+
+        Activate();
+        const auto weakThis{get_weak()};
+        DispatcherQueue().TryEnqueue([weakThis]{
+            if(const auto self{weakThis.get()}){
+                self->tryFocusTimelineCanvas(FocusState::Programmatic);
+            }
+        });
+
+        m_separatePreviewClosedRevoker = previewWindow.Closed(auto_revoke, {this, &MainWindow::onSeparatePreviewWindowClosed});
+        m_separatePreviewWindow = previewWindow;
+        m_isSeparatePreviewWindowOpen = true;
+        m_isSeparatePreviewFullscreen = false;
+        m_restorePreviewDetachedOnStartup = true;
+        PreviewPlayer().SetMediaPlayer(nullptr);
+
+        if(m_restorePreviewFullscreenOnStartup){
+            (void)toggleSeparatePreviewFullscreen();
+        }
+
+        setStatusMessage(L"Preview opened in separate window");
+        return true;
+    }
+
+    if(m_separatePreviewWindow){
+        HWND previewHwnd{};
+        if(SUCCEEDED(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
+            saveSeparatePreviewPlacement(previewHwnd);
+        }
+
+        m_separatePreviewClosedRevoker.revoke();
+        m_separatePreviewWindow.Close();
+        m_separatePreviewWindow = nullptr;
+    }
+
+    PreviewPlayer().SetMediaPlayer(m_player);
+    m_isSeparatePreviewWindowOpen = false;
+    m_isSeparatePreviewFullscreen = false;
+    m_restorePreviewDetachedOnStartup = false;
+    setStatusMessage(L"Preview restored to main window");
+    return true;
+}
+
+void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
+    if(m_separatePreviewWindow){
+        HWND previewHwnd{};
+        if(SUCCEEDED(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
+            saveSeparatePreviewPlacement(previewHwnd);
+        }
+    }
+
+    m_separatePreviewClosedRevoker.revoke();
+    m_separatePreviewWindow = nullptr;
+    m_isSeparatePreviewWindowOpen = false;
+    m_isSeparatePreviewFullscreen = false;
+    if(!m_isClosing){
+        m_restorePreviewDetachedOnStartup = false;
+    }
+    PreviewPlayer().SetMediaPlayer(m_player);
+    setStatusMessage(L"Preview restored to main window");
+}
+
+void MainWindow::onSeparatePreviewWindowKeyDown(const KRArgs& args){
+    (void)handleStorylineKeyDown(args);
+}
+
+void MainWindow::saveSeparatePreviewPlacement(HWND previewHwnd){
+    if(!previewHwnd){
+        return;
+    }
+
+    RECT bounds{};
+    if(!::GetWindowRect(previewHwnd, &bounds)){
+        return;
+    }
+
+    if(m_isSeparatePreviewFullscreen && (m_separatePreviewRestoreRect.right > m_separatePreviewRestoreRect.left) && (m_separatePreviewRestoreRect.bottom > m_separatePreviewRestoreRect.top)){
+        bounds = m_separatePreviewRestoreRect;
+    }
+
+    const auto dpi{::GetDpiForWindow(previewHwnd)};
+    m_separatePreviewLeft = static_cast<int32_t>(bounds.left);
+    m_separatePreviewTop = static_cast<int32_t>(bounds.top);
+    m_separatePreviewWidthDips = pixelsToDips(static_cast<int32_t>(bounds.right - bounds.left), dpi);
+    m_separatePreviewHeightDips = pixelsToDips(static_cast<int32_t>(bounds.bottom - bounds.top), dpi);
+    m_separatePreviewDpi = static_cast<int32_t>(dpi);
+    m_hasSeparatePreviewPlacement = true;
+}
+
+void MainWindow::restoreSeparatePreviewPlacement(HWND previewHwnd){
+    if(!previewHwnd || !m_hasSeparatePreviewPlacement){
+        return;
+    }
+
+    ::llvc::WindowPlacementState state{};
+    state.left = m_separatePreviewLeft;
+    state.top = m_separatePreviewTop;
+    state.widthDips = m_separatePreviewWidthDips;
+    state.heightDips = m_separatePreviewHeightDips;
+    state.dpi = m_separatePreviewDpi;
+
+    (void)applyWindowPlacement(previewHwnd, state, getWindowHandle(), false);
+
+}
+
+bool MainWindow::toggleSeparatePreviewFullscreen(){
+    if(!m_isSeparatePreviewWindowOpen || !m_separatePreviewWindow){
+        setStatusMessage(L"Open the separate preview window first");
+        return false;
+    }
+
+    HWND previewHwnd{};
+    check_hresult(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd));
+    if(!previewHwnd){
+        setErrorMessage(L"Could not resolve preview window handle");
+        return false;
+    }
+
+    if(!m_isSeparatePreviewFullscreen){
+        RECT currentRect{};
+        if(!::GetWindowRect(previewHwnd, &currentRect)){
+            setErrorMessage(L"Could not read preview window bounds");
+            return false;
+        }
+
+        m_separatePreviewRestoreRect = currentRect;
+        m_separatePreviewRestoreStyle = ::GetWindowLongPtrW(previewHwnd, GWL_STYLE);
+        m_separatePreviewRestoreExStyle = ::GetWindowLongPtrW(previewHwnd, GWL_EXSTYLE);
+
+        const auto fullscreenStyle{m_separatePreviewRestoreStyle & ~(WS_OVERLAPPEDWINDOW)};
+        ::SetWindowLongPtrW(previewHwnd, GWL_STYLE, fullscreenStyle);
+
+        MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
+        const auto monitor{::MonitorFromWindow(previewHwnd, MONITOR_DEFAULTTONEAREST)};
+        if(!monitor || !::GetMonitorInfoW(monitor, &monitorInfo)){
+            setErrorMessage(L"Could not resolve preview monitor bounds");
+            return false;
+        }
+
+        ::SetWindowPos(
+            previewHwnd,
+            HWND_TOP,
+            monitorInfo.rcMonitor.left,
+            monitorInfo.rcMonitor.top,
+            monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left,
+            monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top,
+            SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+
+        m_isSeparatePreviewFullscreen = true;
+        m_restorePreviewFullscreenOnStartup = true;
+        setStatusMessage(L"Separate preview: full-screen on");
+        return true;
+    }
+
+    ::SetWindowLongPtrW(previewHwnd, GWL_STYLE, m_separatePreviewRestoreStyle);
+    ::SetWindowLongPtrW(previewHwnd, GWL_EXSTYLE, m_separatePreviewRestoreExStyle);
+    ::SetWindowPos(
+        previewHwnd,
+        HWND_NOTOPMOST,
+        m_separatePreviewRestoreRect.left,
+        m_separatePreviewRestoreRect.top,
+        m_separatePreviewRestoreRect.right - m_separatePreviewRestoreRect.left,
+        m_separatePreviewRestoreRect.bottom - m_separatePreviewRestoreRect.top,
+        SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+
+    m_isSeparatePreviewFullscreen = false;
+    m_restorePreviewFullscreenOnStartup = false;
+    setStatusMessage(L"Separate preview: full-screen off");
+    return true;
 }
 
 void MainWindow::rootGrid_PointerReleased(const Control&, const PREArgs& args){
@@ -1720,6 +2046,7 @@ AAction MainWindow::manualMenuItem_Click(const Control& sender, const REArgs& ar
         L"• Cut markers: Right-Click on the timeline/tick bar to toggle a marker at the desired frame. Markers split the video into scenes.\n"
         L"• Cut scene toggling: Ctrl+Left-Click a scene block to mark/unmark that whole scene for cutting; dark overlays indicate sections that will be removed.\n"
         L"• Preview start/pause/stop skipping cut scenes.\n"
+        L"• Preview window: Tools → Preview in separate window opens a movable second window; use F11 to toggle full-screen.\n"
         L"• Audio controls: Keep/remove audio and configure cross-fade for segment transitions.\n"
         L"• Project files: Save and reopen .llvc projects with timeline state.\n"
         L"• Export: Render a lossless cut based on your selected ranges (auto-adjusting to proper cut points if necessary).\n\n"

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -113,7 +113,7 @@ std::optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IProper
         return *asInt != 0;
     }
     if(const auto asText{tryReadSetting<hstring>(values, key)}){
-        const auto text{to_hstring(trim(asText->c_str()))};
+        const auto text{trim(asText->c_str())};
         if(_wcsicmp(text.c_str(), L"true") == 0 || _wcsicmp(text.c_str(), L"1") == 0){
             return true;
         }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -47,7 +47,6 @@
 #include <winrt/Windows.System.h>
 
 import llvc.Export;
-import llvc.Utils;
 
 #pragma comment(lib, "Shell32.lib")
 
@@ -77,7 +76,6 @@ using SCArgs = MainWindow::SCArgs;
 using KRArgs = MainWindow::KRArgs;
 using DEArgs = MainWindow::DEArgs;
 using WEArgs = MainWindow::WEArgs;
-using WAVArgs = MainWindow::WAVArgs;
 using MPSession = MainWindow::MPSession;
 using SFile = MainWindow::SFile;
 using FState = MainWindow::FState;
@@ -89,40 +87,6 @@ constexpr auto W_POS_L{L"WindowLeft"};
 namespace{
 
 constexpr int64_t HNS_PER_SECOND{10'000'000LL};
-
-
-template<typename T>
-std::optional<T> tryReadSetting(Windows::Foundation::Collections::IPropertySet& values, const wchar_t* key){
-    if(!values.HasKey(key)){
-        return std::nullopt;
-    }
-
-    try{
-        return unbox_value<T>(values.Lookup(key));
-    }catch(const winrt::hresult_error&){
-        values.Remove(key);
-        return std::nullopt;
-    }
-}
-
-std::optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IPropertySet& values, const wchar_t* key){
-    if(const auto asBool{tryReadSetting<bool>(values, key)}){
-        return asBool;
-    }
-    if(const auto asInt{tryReadSetting<int32_t>(values, key)}){
-        return *asInt != 0;
-    }
-    if(const auto asText{tryReadSetting<hstring>(values, key)}){
-        const auto text{trim(asText->c_str())};
-        if(_wcsicmp(text.c_str(), L"true") == 0 || _wcsicmp(text.c_str(), L"1") == 0){
-            return true;
-        }
-        if(_wcsicmp(text.c_str(), L"false") == 0 || _wcsicmp(text.c_str(), L"0") == 0){
-            return false;
-        }
-    }
-    return std::nullopt;
-}
 
 bool isAviPath(const wstring& filePath){
     if(filePath.size() < 4){
@@ -426,13 +390,6 @@ constexpr auto S_RECENT_PROJECTS{L"RecentProjects"};
 constexpr auto S_MAX_RECENT_VIDEOS{L"MaxRecentVideos"};
 constexpr auto S_MAX_RECENT_PROJECTS{L"MaxRecentProjects"};
 constexpr auto S_DEFAULT_MAX_RECENT{5};
-constexpr auto S_SEPARATE_PREVIEW_DETACHED{L"SeparatePreviewDetached"};
-constexpr auto S_SEPARATE_PREVIEW_L{L"SeparatePreviewLeft"};
-constexpr auto S_SEPARATE_PREVIEW_T{L"SeparatePreviewTop"};
-constexpr auto S_SEPARATE_PREVIEW_W{L"SeparatePreviewWidth"};
-constexpr auto S_SEPARATE_PREVIEW_H{L"SeparatePreviewHeight"};
-constexpr auto S_SEPARATE_PREVIEW_DPI{L"SeparatePreviewDpi"};
-constexpr auto S_SEPARATE_PREVIEW_FULLSCREEN{L"SeparatePreviewFullscreen"};
 
 constexpr auto P_FILE_PATH{L"file_path"};
 constexpr auto P_STORYLINE_ZOOM{L"storyline_zoom"};
@@ -572,15 +529,10 @@ MainWindow::MainWindow(){
     restoreWindowPlacement();
     loadAppSettings();
     Closed({this, &MainWindow::onClosed});
-    m_mainWindowActivatedRevoker = Activated(auto_revoke, {this, &MainWindow::onWindowActivated});
     refreshRecentVideosMenu();
     refreshRecentProjectsMenu();
     updateWindowTitle();
     refreshStatusInfoSection();
-
-    if(m_restorePreviewDetachedOnStartup){
-        (void)setSeparatePreviewWindowOpen(true);
-    }
 }
 
 HWND MainWindow::getWindowHandle() const{
@@ -591,53 +543,83 @@ HWND MainWindow::getWindowHandle() const{
 }
 
 
+auto pixelsToDips(int32_t pixelValue, uint32_t dpi){
+    return static_cast<int32_t>(lround((pixelValue * 96.0) / (dpi == 0 ? 96 : dpi)));
+}
+
+auto dipsToPixels(int32_t dipValue, uint32_t dpi){
+    return static_cast<int32_t>(lround((dipValue * (dpi == 0 ? 96U : dpi)) / 96));
+}
+
+bool MainWindow::isRectVisibleOnAnyMonitor(const RECT& rect){
+    const auto monitor{::MonitorFromRect(&rect, MONITOR_DEFAULTTONULL)};
+    if(!monitor){
+        return false;
+    }
+
+    MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
+    if(!::GetMonitorInfoW(monitor, &monitorInfo)){
+        return false;
+    }
+
+    RECT intersection{};
+    return ::IntersectRect(&intersection, &rect, &monitorInfo.rcWork) != FALSE;
+}
+
 void MainWindow::restoreWindowPlacement(){
     const auto localSettings{ApplicationData::Current().LocalSettings()};
-    auto values{localSettings.Values()};
+    const auto values{localSettings.Values()};
 
-    const auto left{tryReadSetting<int32_t>(values, W_POS_L)};
-    const auto top{tryReadSetting<int32_t>(values, W_POS_T)};
-    const auto widthDips{tryReadSetting<int32_t>(values, W_POS_W)};
-    const auto heightDips{tryReadSetting<int32_t>(values, W_POS_H)};
-    if(!left || !top || !widthDips || !heightDips){
+    if(!values.HasKey(W_POS_L) || !values.HasKey(W_POS_T) || !values.HasKey(W_POS_W) || !values.HasKey(W_POS_H)){
         return;
     }
 
-    ::llvc::WindowPlacementState state{};
-    state.left = *left;
-    state.top = *top;
-    state.widthDips = *widthDips;
-    state.heightDips = *heightDips;
-    state.dpi = tryReadSetting<int32_t>(values, W_POS_DPI).value_or(96);
+    const auto left{unbox_value<int32_t>(values.Lookup(W_POS_L))};
+    const auto top{unbox_value<int32_t>(values.Lookup(W_POS_T))};
 
     const auto hwnd{getWindowHandle()};
-    if(!applyWindowPlacement(hwnd, state, hwnd, false)){
+
+    SetWindowPos(hwnd, nullptr, left, top, 0, 0, SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOSIZE);
+
+    const auto currentDpi{::GetDpiForWindow(hwnd)};
+    const auto hasDpiData{values.HasKey(W_POS_DPI)};
+    const auto storedWidth{unbox_value<int32_t>(values.Lookup(W_POS_W))};
+    const auto storedHeight{unbox_value<int32_t>(values.Lookup(W_POS_H))};
+    const auto width{hasDpiData ? dipsToPixels(storedWidth, currentDpi) : storedWidth};
+    const auto height{hasDpiData ? dipsToPixels(storedHeight, currentDpi) : storedHeight};
+
+    if(!isRectVisibleOnAnyMonitor(RECT{left, top, left + width, top + height})){
         values.Remove(W_POS_L);
         values.Remove(W_POS_T);
         values.Remove(W_POS_W);
         values.Remove(W_POS_H);
         values.Remove(W_POS_DPI);
+        return;
     }
+
+    SetWindowPos(hwnd, nullptr, left, top, width, height, SWP_NOACTIVATE | SWP_NOZORDER);
 }
 
 void MainWindow::loadAppSettings(){
-    auto values{ApplicationData::Current().LocalSettings().Values()};
+    const auto values{ApplicationData::Current().LocalSettings().Values()};
 
     m_maxRecentVideos = S_DEFAULT_MAX_RECENT;
     m_maxRecentProjects = S_DEFAULT_MAX_RECENT;
 
-    if(const auto parsed{tryReadSetting<int32_t>(values, S_MAX_RECENT_VIDEOS)}){
-        m_maxRecentVideos = static_cast<uint32_t>(clamp(*parsed, 1, 20));
+    if(values.HasKey(S_MAX_RECENT_VIDEOS)){
+        const auto parsed{unbox_value<int32_t>(values.Lookup(S_MAX_RECENT_VIDEOS))};
+        m_maxRecentVideos = static_cast<uint32_t>(clamp(parsed, 1, 20));
     }
-    if(const auto parsed{tryReadSetting<int32_t>(values, S_MAX_RECENT_PROJECTS)}){
-        m_maxRecentProjects = static_cast<uint32_t>(clamp(*parsed, 1, 20));
+    if(values.HasKey(S_MAX_RECENT_PROJECTS)){
+        const auto parsed{unbox_value<int32_t>(values.Lookup(S_MAX_RECENT_PROJECTS))};
+        m_maxRecentProjects = static_cast<uint32_t>(clamp(parsed, 1, 20));
     }
 
-    if(const auto recentVideosText{tryReadSetting<hstring>(values, S_RECENT_VIDEOS)}){
-        m_recentVideos = splitRecentItems(recentVideosText->c_str());
+    if(values.HasKey(S_RECENT_VIDEOS)){
+        m_recentVideos = splitRecentItems(unbox_value<hstring>(values.Lookup(S_RECENT_VIDEOS)).c_str());
     }
-    if(const auto recentProjectsText{tryReadSetting<hstring>(values, S_RECENT_PROJECTS)}){
-        m_recentProjects = splitRecentItems(recentProjectsText->c_str());
+    if(values.HasKey(S_RECENT_PROJECTS)){
+        m_recentProjects = splitRecentItems(unbox_value<hstring>(values.Lookup(S_RECENT_PROJECTS)).c_str());
     }
     if(m_recentVideos.size() > m_maxRecentVideos){
         m_recentVideos.resize(m_maxRecentVideos);
@@ -645,57 +627,37 @@ void MainWindow::loadAppSettings(){
     if(m_recentProjects.size() > m_maxRecentProjects){
         m_recentProjects.resize(m_maxRecentProjects);
     }
-
-    m_restorePreviewDetachedOnStartup = tryReadBoolSetting(values, S_SEPARATE_PREVIEW_DETACHED).value_or(false);
-
-    const auto previewLeft{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_L)};
-    const auto previewTop{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_T)};
-    const auto previewWidthDips{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_W)};
-    const auto previewHeightDips{tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_H)};
-    if(previewLeft && previewTop && previewWidthDips && previewHeightDips){
-        m_separatePreviewLeft = *previewLeft;
-        m_separatePreviewTop = *previewTop;
-        m_separatePreviewWidthDips = max<int32_t>(320, *previewWidthDips);
-        m_separatePreviewHeightDips = max<int32_t>(200, *previewHeightDips);
-        m_separatePreviewDpi = max<int32_t>(96, tryReadSetting<int32_t>(values, S_SEPARATE_PREVIEW_DPI).value_or(96));
-        m_hasSeparatePreviewPlacement = true;
-    }
-
-    m_restorePreviewFullscreenOnStartup = tryReadBoolSetting(values, S_SEPARATE_PREVIEW_FULLSCREEN).value_or(false);
 }
 
 void MainWindow::saveAppSettings() const{
-    auto values{ApplicationData::Current().LocalSettings().Values()};
+    const auto values{ApplicationData::Current().LocalSettings().Values()};
     values.Insert(S_MAX_RECENT_VIDEOS, box_value(static_cast<int32_t>(m_maxRecentVideos)));
     values.Insert(S_MAX_RECENT_PROJECTS, box_value(static_cast<int32_t>(m_maxRecentProjects)));
     values.Insert(S_RECENT_VIDEOS, box_value(hstring(joinRecentItems(m_recentVideos))));
     values.Insert(S_RECENT_PROJECTS, box_value(hstring(joinRecentItems(m_recentProjects))));
-    values.Insert(S_SEPARATE_PREVIEW_DETACHED, box_value(m_restorePreviewDetachedOnStartup));
-    values.Insert(S_SEPARATE_PREVIEW_FULLSCREEN, box_value(m_restorePreviewFullscreenOnStartup));
-
-    if(m_hasSeparatePreviewPlacement){
-        values.Insert(S_SEPARATE_PREVIEW_L, box_value(m_separatePreviewLeft));
-        values.Insert(S_SEPARATE_PREVIEW_T, box_value(m_separatePreviewTop));
-        values.Insert(S_SEPARATE_PREVIEW_W, box_value(m_separatePreviewWidthDips));
-        values.Insert(S_SEPARATE_PREVIEW_H, box_value(m_separatePreviewHeightDips));
-        values.Insert(S_SEPARATE_PREVIEW_DPI, box_value(m_separatePreviewDpi));
-    }
 }
 
 void MainWindow::saveWindowPlacement() const{
     const auto hwnd{getWindowHandle()};
-    const auto captured{::llvc::captureWindowPlacement(hwnd)};
-    if(!captured){
+
+    RECT bounds{};
+    if(!GetWindowRect(hwnd, &bounds)){
         return;
     }
 
+    WINDOWPLACEMENT placement{.length = sizeof(placement)};
+    if(GetWindowPlacement(hwnd, &placement) && placement.showCmd == SW_SHOWMAXIMIZED){
+        bounds = placement.rcNormalPosition;
+    }
+
     const auto localSettings{ApplicationData::Current().LocalSettings()};
-    auto values{localSettings.Values()};
-    values.Insert(W_POS_L, box_value(captured->left));
-    values.Insert(W_POS_T, box_value(captured->top));
-    values.Insert(W_POS_W, box_value(captured->widthDips));
-    values.Insert(W_POS_H, box_value(captured->heightDips));
-    values.Insert(W_POS_DPI, box_value(captured->dpi));
+    const auto values{localSettings.Values()};
+    const auto dpi{::GetDpiForWindow(hwnd)};
+    values.Insert(W_POS_L, box_value(static_cast<int32_t>(bounds.left)));
+    values.Insert(W_POS_T, box_value(static_cast<int32_t>(bounds.top)));
+    values.Insert(W_POS_W, box_value(pixelsToDips(static_cast<int32_t>(bounds.right - bounds.left), dpi)));
+    values.Insert(W_POS_H, box_value(pixelsToDips(static_cast<int32_t>(bounds.bottom - bounds.top), dpi)));
+    values.Insert(W_POS_DPI, box_value(static_cast<int32_t>(dpi)));
 }
 
 void MainWindow::onClosed(const Control&, const WEArgs&){
@@ -706,37 +668,8 @@ void MainWindow::onClosed(const Control&, const WEArgs&){
     }
 
     m_naturalDurationChangedRevoker.revoke();
-    m_mainWindowActivatedRevoker.revoke();
-
-    m_restorePreviewDetachedOnStartup = m_isSeparatePreviewWindowOpen;
-    m_restorePreviewFullscreenOnStartup = m_isSeparatePreviewWindowOpen && m_isSeparatePreviewFullscreen;
-
-    if(m_separatePreviewWindow){
-        HWND previewHwnd{};
-        if(SUCCEEDED(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
-            saveSeparatePreviewPlacement(previewHwnd);
-        }
-
-        m_separatePreviewClosedRevoker.revoke();
-        m_separatePreviewWindow.Close();
-        m_separatePreviewWindow = nullptr;
-    }
-
     saveWindowPlacement();
     saveAppSettings();
-}
-
-void MainWindow::onWindowActivated(const Control&, const WAVArgs& args){
-    if(args.WindowActivationState() == WindowActivationState::Deactivated){
-        return;
-    }
-
-    const auto weakThis{get_weak()};
-    DispatcherQueue().TryEnqueue([weakThis]{
-        if(const auto self{weakThis.get()}){
-            self->tryFocusTimelineCanvas(FocusState::Programmatic);
-        }
-    });
 }
 
 void MainWindow::startButton_Click(const Control&, const REArgs&){
@@ -1512,21 +1445,6 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
             args.Handled(true);
             return true;
         }
-        if(args.Key() == VirtualKey::Add || args.Key() == static_cast<VirtualKey>(187)){
-            adjustTimelineZoomBy(1);
-            args.Handled(true);
-            return true;
-        }
-        if(args.Key() == VirtualKey::Subtract || args.Key() == static_cast<VirtualKey>(189)){
-            adjustTimelineZoomBy(-1);
-            args.Handled(true);
-            return true;
-        }
-        if(args.Key() == VirtualKey::R){
-            reevaluateClearCutMarkersButton_Click(nullptr, {});
-            args.Handled(true);
-            return true;
-        }
     }
 
     if(focusOnMenu || focusInDialog){
@@ -1571,10 +1489,6 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         (void)markSceneAtCursor(false);
         args.Handled(true);
         return true;
-    case VirtualKey::F11:
-        (void)toggleSeparatePreviewFullscreen();
-        args.Handled(true);
-        return true;
     default:
         return false;
     }
@@ -1586,246 +1500,6 @@ void MainWindow::window_PreviewKeyDown(const Control&, const KRArgs& args){
 
 void MainWindow::window_KeyDown(const Control&, const KRArgs& args){
     (void)handleStorylineKeyDown(args);
-}
-
-void MainWindow::separatePreviewWindowMenuItem_Click(const Control&, const REArgs&){
-    const auto targetOpen{!m_isSeparatePreviewWindowOpen};
-    if(!setSeparatePreviewWindowOpen(targetOpen)){
-    }
-}
-
-void MainWindow::toggleSeparatePreviewFullscreenMenuItem_Click(const Control&, const REArgs&){
-    (void)toggleSeparatePreviewFullscreen();
-}
-
-void MainWindow::zoomInTimelineMenuItem_Click(const Control&, const REArgs&){
-    adjustTimelineZoomBy(1);
-}
-
-void MainWindow::zoomOutTimelineMenuItem_Click(const Control&, const REArgs&){
-    adjustTimelineZoomBy(-1);
-}
-
-void MainWindow::adjustTimelineZoomBy(int delta){
-    auto slider{TimelineZoomSlider()};
-    if(!slider){
-        return;
-    }
-
-    const auto target{clamp(slider.Value() + delta, slider.Minimum(), slider.Maximum())};
-    slider.Value(target);
-}
-
-bool MainWindow::setSeparatePreviewWindowOpen(bool open){
-    if(open == m_isSeparatePreviewWindowOpen){
-        return true;
-    }
-
-    if(open){
-        auto previewWindow{Window()};
-        previewWindow.Title(L"llvc - Video preview");
-
-        Controls::Grid root{};
-        root.Background(Media::SolidColorBrush(Windows::UI::ColorHelper::FromArgb(0xFF, 0x08, 0x08, 0x08)));
-
-        Controls::MediaPlayerElement detachedPreview{};
-        detachedPreview.AreTransportControlsEnabled(true);
-        detachedPreview.HorizontalAlignment(HorizontalAlignment::Stretch);
-        detachedPreview.VerticalAlignment(VerticalAlignment::Stretch);
-        detachedPreview.SetMediaPlayer(m_player);
-
-        const auto weakSelf{get_weak()};
-        const auto detachedKeyHandler{[weakSelf](const auto&, const KRArgs& e){
-            if(const auto self{weakSelf.get()}){
-                self->onSeparatePreviewWindowKeyDown(e);
-            }
-        }};
-        detachedPreview.PreviewKeyDown(detachedKeyHandler);
-        detachedPreview.KeyDown(detachedKeyHandler);
-
-        root.IsTabStop(true);
-        root.PreviewKeyDown(detachedKeyHandler);
-        root.KeyDown(detachedKeyHandler);
-
-        root.Children().Append(detachedPreview);
-
-        previewWindow.Content(root);
-        previewWindow.Activate();
-        root.Focus(FocusState::Programmatic);
-
-        HWND previewHwnd{};
-        if(SUCCEEDED(previewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
-            restoreSeparatePreviewPlacement(previewHwnd);
-        }
-
-        Activate();
-        const auto weakThis{get_weak()};
-        DispatcherQueue().TryEnqueue([weakThis]{
-            if(const auto self{weakThis.get()}){
-                self->tryFocusTimelineCanvas(FocusState::Programmatic);
-            }
-        });
-
-        m_separatePreviewClosedRevoker = previewWindow.Closed(auto_revoke, {this, &MainWindow::onSeparatePreviewWindowClosed});
-        m_separatePreviewWindow = previewWindow;
-        m_isSeparatePreviewWindowOpen = true;
-        m_isSeparatePreviewFullscreen = false;
-        m_restorePreviewDetachedOnStartup = true;
-        PreviewPlayer().SetMediaPlayer(nullptr);
-
-        if(m_restorePreviewFullscreenOnStartup){
-            (void)toggleSeparatePreviewFullscreen();
-        }
-
-        setStatusMessage(L"Preview opened in separate window");
-        return true;
-    }
-
-    if(m_separatePreviewWindow){
-        HWND previewHwnd{};
-        if(SUCCEEDED(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
-            saveSeparatePreviewPlacement(previewHwnd);
-        }
-
-        m_separatePreviewClosedRevoker.revoke();
-        m_separatePreviewWindow.Close();
-        m_separatePreviewWindow = nullptr;
-    }
-
-    PreviewPlayer().SetMediaPlayer(m_player);
-    m_isSeparatePreviewWindowOpen = false;
-    m_isSeparatePreviewFullscreen = false;
-    m_restorePreviewDetachedOnStartup = false;
-    setStatusMessage(L"Preview restored to main window");
-    return true;
-}
-
-void MainWindow::onSeparatePreviewWindowClosed(const Control&, const WEArgs&){
-    if(m_separatePreviewWindow){
-        HWND previewHwnd{};
-        if(SUCCEEDED(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd)) && previewHwnd){
-            saveSeparatePreviewPlacement(previewHwnd);
-        }
-    }
-
-    m_separatePreviewClosedRevoker.revoke();
-    m_separatePreviewWindow = nullptr;
-    m_isSeparatePreviewWindowOpen = false;
-    m_isSeparatePreviewFullscreen = false;
-    if(!m_isClosing){
-        m_restorePreviewDetachedOnStartup = false;
-    }
-    PreviewPlayer().SetMediaPlayer(m_player);
-    setStatusMessage(L"Preview restored to main window");
-}
-
-void MainWindow::onSeparatePreviewWindowKeyDown(const KRArgs& args){
-    (void)handleStorylineKeyDown(args);
-}
-
-void MainWindow::saveSeparatePreviewPlacement(HWND previewHwnd){
-    if(!previewHwnd){
-        return;
-    }
-
-    RECT bounds{};
-    if(!::GetWindowRect(previewHwnd, &bounds)){
-        return;
-    }
-
-    if(m_isSeparatePreviewFullscreen && (m_separatePreviewRestoreRect.right > m_separatePreviewRestoreRect.left) && (m_separatePreviewRestoreRect.bottom > m_separatePreviewRestoreRect.top)){
-        bounds = m_separatePreviewRestoreRect;
-    }
-
-    const auto dpi{::GetDpiForWindow(previewHwnd)};
-    m_separatePreviewLeft = static_cast<int32_t>(bounds.left);
-    m_separatePreviewTop = static_cast<int32_t>(bounds.top);
-    m_separatePreviewWidthDips = pixelsToDips(static_cast<int32_t>(bounds.right - bounds.left), dpi);
-    m_separatePreviewHeightDips = pixelsToDips(static_cast<int32_t>(bounds.bottom - bounds.top), dpi);
-    m_separatePreviewDpi = static_cast<int32_t>(dpi);
-    m_hasSeparatePreviewPlacement = true;
-}
-
-void MainWindow::restoreSeparatePreviewPlacement(HWND previewHwnd){
-    if(!previewHwnd || !m_hasSeparatePreviewPlacement){
-        return;
-    }
-
-    ::llvc::WindowPlacementState state{};
-    state.left = m_separatePreviewLeft;
-    state.top = m_separatePreviewTop;
-    state.widthDips = m_separatePreviewWidthDips;
-    state.heightDips = m_separatePreviewHeightDips;
-    state.dpi = m_separatePreviewDpi;
-
-    (void)applyWindowPlacement(previewHwnd, state, getWindowHandle(), false);
-
-}
-
-bool MainWindow::toggleSeparatePreviewFullscreen(){
-    if(!m_isSeparatePreviewWindowOpen || !m_separatePreviewWindow){
-        setStatusMessage(L"Open the separate preview window first");
-        return false;
-    }
-
-    HWND previewHwnd{};
-    check_hresult(m_separatePreviewWindow.as<::IWindowNative>()->get_WindowHandle(&previewHwnd));
-    if(!previewHwnd){
-        setErrorMessage(L"Could not resolve preview window handle");
-        return false;
-    }
-
-    if(!m_isSeparatePreviewFullscreen){
-        RECT currentRect{};
-        if(!::GetWindowRect(previewHwnd, &currentRect)){
-            setErrorMessage(L"Could not read preview window bounds");
-            return false;
-        }
-
-        m_separatePreviewRestoreRect = currentRect;
-        m_separatePreviewRestoreStyle = ::GetWindowLongPtrW(previewHwnd, GWL_STYLE);
-        m_separatePreviewRestoreExStyle = ::GetWindowLongPtrW(previewHwnd, GWL_EXSTYLE);
-
-        const auto fullscreenStyle{m_separatePreviewRestoreStyle & ~(WS_OVERLAPPEDWINDOW)};
-        ::SetWindowLongPtrW(previewHwnd, GWL_STYLE, fullscreenStyle);
-
-        MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
-        const auto monitor{::MonitorFromWindow(previewHwnd, MONITOR_DEFAULTTONEAREST)};
-        if(!monitor || !::GetMonitorInfoW(monitor, &monitorInfo)){
-            setErrorMessage(L"Could not resolve preview monitor bounds");
-            return false;
-        }
-
-        ::SetWindowPos(
-            previewHwnd,
-            HWND_TOP,
-            monitorInfo.rcMonitor.left,
-            monitorInfo.rcMonitor.top,
-            monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left,
-            monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top,
-            SWP_FRAMECHANGED | SWP_SHOWWINDOW);
-
-        m_isSeparatePreviewFullscreen = true;
-        m_restorePreviewFullscreenOnStartup = true;
-        setStatusMessage(L"Separate preview: full-screen on");
-        return true;
-    }
-
-    ::SetWindowLongPtrW(previewHwnd, GWL_STYLE, m_separatePreviewRestoreStyle);
-    ::SetWindowLongPtrW(previewHwnd, GWL_EXSTYLE, m_separatePreviewRestoreExStyle);
-    ::SetWindowPos(
-        previewHwnd,
-        HWND_NOTOPMOST,
-        m_separatePreviewRestoreRect.left,
-        m_separatePreviewRestoreRect.top,
-        m_separatePreviewRestoreRect.right - m_separatePreviewRestoreRect.left,
-        m_separatePreviewRestoreRect.bottom - m_separatePreviewRestoreRect.top,
-        SWP_FRAMECHANGED | SWP_SHOWWINDOW);
-
-    m_isSeparatePreviewFullscreen = false;
-    m_restorePreviewFullscreenOnStartup = false;
-    setStatusMessage(L"Separate preview: full-screen off");
-    return true;
 }
 
 void MainWindow::rootGrid_PointerReleased(const Control&, const PREArgs& args){
@@ -2046,7 +1720,6 @@ AAction MainWindow::manualMenuItem_Click(const Control& sender, const REArgs& ar
         L"• Cut markers: Right-Click on the timeline/tick bar to toggle a marker at the desired frame. Markers split the video into scenes.\n"
         L"• Cut scene toggling: Ctrl+Left-Click a scene block to mark/unmark that whole scene for cutting; dark overlays indicate sections that will be removed.\n"
         L"• Preview start/pause/stop skipping cut scenes.\n"
-        L"• Preview window: Tools → Preview in separate window opens a movable second window; use F11 to toggle full-screen.\n"
         L"• Audio controls: Keep/remove audio and configure cross-fade for segment transitions.\n"
         L"• Project files: Save and reopen .llvc projects with timeline state.\n"
         L"• Export: Render a lossless cut based on your selected ranges (auto-adjusting to proper cut points if necessary).\n\n"

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1547,11 +1547,9 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         root.PreviewKeyDown(detachedKeyHandler);
         root.KeyDown(detachedKeyHandler);
 
-        RoutedEventHandler tunnelKeys{[weakSelf](const IInspectable&, const RoutedEventArgs& e){
+        Input::KeyEventHandler tunnelKeys{[weakSelf](const IInspectable&, const KRArgs& e){
             if(const auto self{weakSelf.get()}){
-                if(const auto keyArgs{e.try_as<KRArgs>()}){
-                    self->onSeparatePreviewWindowKeyDown(keyArgs);
-                }
+                self->onSeparatePreviewWindowKeyDown(e);
             }
         }};
         root.AddHandler(UIElement::PreviewKeyDownEvent(), tunnelKeys, true);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1465,6 +1465,16 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
             args.Handled(true);
             return true;
         }
+        if(args.Key() == VirtualKey::Add || args.Key() == VirtualKey::OemPlus){
+            adjustTimelineZoomBy(1);
+            args.Handled(true);
+            return true;
+        }
+        if(args.Key() == VirtualKey::Subtract || args.Key() == VirtualKey::OemMinus){
+            adjustTimelineZoomBy(-1);
+            args.Handled(true);
+            return true;
+        }
         if(args.Key() == VirtualKey::R){
             reevaluateClearCutMarkersButton_Click(nullptr, {});
             args.Handled(true);
@@ -1540,6 +1550,24 @@ void MainWindow::separatePreviewWindowMenuItem_Click(const Control&, const REArg
 
 void MainWindow::toggleSeparatePreviewFullscreenMenuItem_Click(const Control&, const REArgs&){
     (void)toggleSeparatePreviewFullscreen();
+}
+
+void MainWindow::zoomInTimelineMenuItem_Click(const Control&, const REArgs&){
+    adjustTimelineZoomBy(1);
+}
+
+void MainWindow::zoomOutTimelineMenuItem_Click(const Control&, const REArgs&){
+    adjustTimelineZoomBy(-1);
+}
+
+void MainWindow::adjustTimelineZoomBy(int delta){
+    auto slider{TimelineZoomSlider()};
+    if(!slider){
+        return;
+    }
+
+    const auto target{clamp(slider.Value() + delta, slider.Minimum(), slider.Maximum())};
+    slider.Value(target);
 }
 
 bool MainWindow::setSeparatePreviewWindowOpen(bool open){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1547,11 +1547,11 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         root.PreviewKeyDown(detachedKeyHandler);
         root.KeyDown(detachedKeyHandler);
 
-        Input::KeyEventHandler tunnelKeys{[weakSelf](const IInspectable&, const KRArgs& e){
+        const IInspectable tunnelKeys{Input::KeyEventHandler{[weakSelf](const IInspectable&, const KRArgs& e){
             if(const auto self{weakSelf.get()}){
                 self->onSeparatePreviewWindowKeyDown(e);
             }
-        }};
+        }}};
         root.AddHandler(UIElement::PreviewKeyDownEvent(), tunnelKeys, true);
         root.AddHandler(UIElement::KeyDownEvent(), tunnelKeys, true);
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1543,12 +1543,25 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         detachedPreview.PreviewKeyDown(detachedKeyHandler);
         detachedPreview.KeyDown(detachedKeyHandler);
 
+        root.IsTabStop(true);
         root.PreviewKeyDown(detachedKeyHandler);
         root.KeyDown(detachedKeyHandler);
+
+        RoutedEventHandler tunnelKeys{[weakSelf](const IInspectable&, const RoutedEventArgs& e){
+            if(const auto self{weakSelf.get()}){
+                if(const auto keyArgs{e.try_as<KRArgs>()}){
+                    self->onSeparatePreviewWindowKeyDown(keyArgs);
+                }
+            }
+        }};
+        root.AddHandler(UIElement::PreviewKeyDownEvent(), tunnelKeys, true);
+        root.AddHandler(UIElement::KeyDownEvent(), tunnelKeys, true);
+
         root.Children().Append(detachedPreview);
 
         previewWindow.Content(root);
         previewWindow.Activate();
+        root.Focus(FocusState::Programmatic);
 
         m_separatePreviewClosedRevoker = previewWindow.Closed(auto_revoke, {this, &MainWindow::onSeparatePreviewWindowClosed});
         m_separatePreviewWindow = previewWindow;

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -47,6 +47,7 @@
 #include <winrt/Windows.System.h>
 
 import llvc.Export;
+import llvc.Utils;
 
 #pragma comment(lib, "Shell32.lib")
 
@@ -556,29 +557,6 @@ HWND MainWindow::getWindowHandle() const{
 }
 
 
-auto pixelsToDips(int32_t pixelValue, uint32_t dpi){
-    return static_cast<int32_t>(lround((pixelValue * 96.0) / (dpi == 0 ? 96 : dpi)));
-}
-
-auto dipsToPixels(int32_t dipValue, uint32_t dpi){
-    return static_cast<int32_t>(lround((dipValue * (dpi == 0 ? 96U : dpi)) / 96));
-}
-
-bool MainWindow::isRectVisibleOnAnyMonitor(const RECT& rect){
-    const auto monitor{::MonitorFromRect(&rect, MONITOR_DEFAULTTONULL)};
-    if(!monitor){
-        return false;
-    }
-
-    MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
-    if(!::GetMonitorInfoW(monitor, &monitorInfo)){
-        return false;
-    }
-
-    RECT intersection{};
-    return ::IntersectRect(&intersection, &rect, &monitorInfo.rcWork) != FALSE;
-}
-
 void MainWindow::restoreWindowPlacement(){
     const auto localSettings{ApplicationData::Current().LocalSettings()};
     const auto values{localSettings.Values()};
@@ -587,30 +565,21 @@ void MainWindow::restoreWindowPlacement(){
         return;
     }
 
-    const auto left{unbox_value<int32_t>(values.Lookup(W_POS_L))};
-    const auto top{unbox_value<int32_t>(values.Lookup(W_POS_T))};
+    ::llvc::WindowPlacementState state{};
+    state.left = unbox_value<int32_t>(values.Lookup(W_POS_L));
+    state.top = unbox_value<int32_t>(values.Lookup(W_POS_T));
+    state.widthDips = unbox_value<int32_t>(values.Lookup(W_POS_W));
+    state.heightDips = unbox_value<int32_t>(values.Lookup(W_POS_H));
+    state.dpi = values.HasKey(W_POS_DPI) ? unbox_value<int32_t>(values.Lookup(W_POS_DPI)) : 96;
 
     const auto hwnd{getWindowHandle()};
-
-    SetWindowPos(hwnd, nullptr, left, top, 0, 0, SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOSIZE);
-
-    const auto currentDpi{::GetDpiForWindow(hwnd)};
-    const auto hasDpiData{values.HasKey(W_POS_DPI)};
-    const auto storedWidth{unbox_value<int32_t>(values.Lookup(W_POS_W))};
-    const auto storedHeight{unbox_value<int32_t>(values.Lookup(W_POS_H))};
-    const auto width{hasDpiData ? dipsToPixels(storedWidth, currentDpi) : storedWidth};
-    const auto height{hasDpiData ? dipsToPixels(storedHeight, currentDpi) : storedHeight};
-
-    if(!isRectVisibleOnAnyMonitor(RECT{left, top, left + width, top + height})){
+    if(!applyWindowPlacement(hwnd, state, hwnd, false)){
         values.Remove(W_POS_L);
         values.Remove(W_POS_T);
         values.Remove(W_POS_W);
         values.Remove(W_POS_H);
         values.Remove(W_POS_DPI);
-        return;
     }
-
-    SetWindowPos(hwnd, nullptr, left, top, width, height, SWP_NOACTIVATE | SWP_NOZORDER);
 }
 
 void MainWindow::loadAppSettings(){
@@ -677,25 +646,18 @@ void MainWindow::saveAppSettings() const{
 
 void MainWindow::saveWindowPlacement() const{
     const auto hwnd{getWindowHandle()};
-
-    RECT bounds{};
-    if(!GetWindowRect(hwnd, &bounds)){
+    const auto captured{::llvc::captureWindowPlacement(hwnd)};
+    if(!captured){
         return;
-    }
-
-    WINDOWPLACEMENT placement{.length = sizeof(placement)};
-    if(GetWindowPlacement(hwnd, &placement) && placement.showCmd == SW_SHOWMAXIMIZED){
-        bounds = placement.rcNormalPosition;
     }
 
     const auto localSettings{ApplicationData::Current().LocalSettings()};
     const auto values{localSettings.Values()};
-    const auto dpi{::GetDpiForWindow(hwnd)};
-    values.Insert(W_POS_L, box_value(static_cast<int32_t>(bounds.left)));
-    values.Insert(W_POS_T, box_value(static_cast<int32_t>(bounds.top)));
-    values.Insert(W_POS_W, box_value(pixelsToDips(static_cast<int32_t>(bounds.right - bounds.left), dpi)));
-    values.Insert(W_POS_H, box_value(pixelsToDips(static_cast<int32_t>(bounds.bottom - bounds.top), dpi)));
-    values.Insert(W_POS_DPI, box_value(static_cast<int32_t>(dpi)));
+    values.Insert(W_POS_L, box_value(captured->left));
+    values.Insert(W_POS_T, box_value(captured->top));
+    values.Insert(W_POS_W, box_value(captured->widthDips));
+    values.Insert(W_POS_H, box_value(captured->heightDips));
+    values.Insert(W_POS_DPI, box_value(captured->dpi));
 }
 
 void MainWindow::onClosed(const Control&, const WEArgs&){
@@ -1719,32 +1681,14 @@ void MainWindow::restoreSeparatePreviewPlacement(HWND previewHwnd){
         return;
     }
 
-    const auto currentDpi{::GetDpiForWindow(previewHwnd)};
-    const auto width{dipsToPixels(m_separatePreviewWidthDips, currentDpi)};
-    const auto height{dipsToPixels(m_separatePreviewHeightDips, currentDpi)};
-    RECT desiredRect{m_separatePreviewLeft, m_separatePreviewTop, m_separatePreviewLeft + width, m_separatePreviewTop + height};
+    ::llvc::WindowPlacementState state{};
+    state.left = m_separatePreviewLeft;
+    state.top = m_separatePreviewTop;
+    state.widthDips = m_separatePreviewWidthDips;
+    state.heightDips = m_separatePreviewHeightDips;
+    state.dpi = m_separatePreviewDpi;
 
-    if(!isRectVisibleOnAnyMonitor(desiredRect)){
-        MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
-        const auto mainMonitor{::MonitorFromWindow(getWindowHandle(), MONITOR_DEFAULTTONEAREST)};
-        if(mainMonitor && ::GetMonitorInfoW(mainMonitor, &monitorInfo)){
-            const auto fallbackWidth{min(width, static_cast<int32_t>(monitorInfo.rcWork.right - monitorInfo.rcWork.left))};
-            const auto fallbackHeight{min(height, static_cast<int32_t>(monitorInfo.rcWork.bottom - monitorInfo.rcWork.top))};
-            desiredRect.left = monitorInfo.rcWork.left;
-            desiredRect.top = monitorInfo.rcWork.top;
-            desiredRect.right = desiredRect.left + fallbackWidth;
-            desiredRect.bottom = desiredRect.top + fallbackHeight;
-        }
-    }
-
-    ::SetWindowPos(
-        previewHwnd,
-        nullptr,
-        desiredRect.left,
-        desiredRect.top,
-        desiredRect.right - desiredRect.left,
-        desiredRect.bottom - desiredRect.top,
-        SWP_NOACTIVATE | SWP_NOZORDER);
+    (void)applyWindowPlacement(previewHwnd, state, getWindowHandle(), false);
 
 }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -76,6 +76,7 @@ using SCArgs = MainWindow::SCArgs;
 using KRArgs = MainWindow::KRArgs;
 using DEArgs = MainWindow::DEArgs;
 using WEArgs = MainWindow::WEArgs;
+using WAVArgs = MainWindow::WAVArgs;
 using MPSession = MainWindow::MPSession;
 using SFile = MainWindow::SFile;
 using FState = MainWindow::FState;
@@ -529,6 +530,7 @@ MainWindow::MainWindow(){
     restoreWindowPlacement();
     loadAppSettings();
     Closed({this, &MainWindow::onClosed});
+    m_mainWindowActivatedRevoker = Activated(auto_revoke, {this, &MainWindow::onWindowActivated});
     refreshRecentVideosMenu();
     refreshRecentProjectsMenu();
     updateWindowTitle();
@@ -668,6 +670,7 @@ void MainWindow::onClosed(const Control&, const WEArgs&){
     }
 
     m_naturalDurationChangedRevoker.revoke();
+    m_mainWindowActivatedRevoker.revoke();
 
     if(m_separatePreviewWindow){
         m_separatePreviewClosedRevoker.revoke();
@@ -677,6 +680,19 @@ void MainWindow::onClosed(const Control&, const WEArgs&){
 
     saveWindowPlacement();
     saveAppSettings();
+}
+
+void MainWindow::onWindowActivated(const Control&, const WAVArgs& args){
+    if(args.WindowActivationState() == WindowActivationState::Deactivated){
+        return;
+    }
+
+    const auto weakThis{get_weak()};
+    DispatcherQueue().TryEnqueue([weakThis]{
+        if(const auto self{weakThis.get()}){
+            self->tryFocusTimelineCanvas(FocusState::Programmatic);
+        }
+    });
 }
 
 void MainWindow::startButton_Click(const Control&, const REArgs&){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -92,20 +92,20 @@ constexpr int64_t HNS_PER_SECOND{10'000'000LL};
 
 
 template<typename T>
-std::optional<T> tryReadSetting(Windows::Foundation::Collections::IPropertySet& values, const wchar_t* key){
+optional<T> tryReadSetting(Windows::Foundation::Collections::IMap<hstring, IInspectable>& values, const wchar_t* key){
     if(!values.HasKey(key)){
-        return std::nullopt;
+        return nullopt;
     }
 
     try{
         return unbox_value<T>(values.Lookup(key));
     }catch(const winrt::hresult_error&){
         values.Remove(key);
-        return std::nullopt;
+        return nullopt;
     }
 }
 
-std::optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IPropertySet& values, const wchar_t* key){
+optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IMap<hstring, IInspectable>& values, const wchar_t* key){
     if(const auto asBool{tryReadSetting<bool>(values, key)}){
         return asBool;
     }
@@ -121,7 +121,7 @@ std::optional<bool> tryReadBoolSetting(Windows::Foundation::Collections::IProper
             return false;
         }
     }
-    return std::nullopt;
+    return nullopt;
 }
 
 bool isAviPath(const wstring& filePath){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1336,6 +1336,9 @@ void MainWindow::stepByFrame(int delta){
     const auto target {clamp(current + (direction * frameStep100ns), 0LL, duration100ns)};
     m_player.PlaybackSession().Position(TimeSpan{target});
     updateTimelineCursorFromPlayback();
+    const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
+    ensureTimelineCursorVisible(cursorLeft);
+    syncTimelineHorizontalScrollBar();
 }
 
 
@@ -1387,6 +1390,9 @@ bool MainWindow::moveCursorToMarker(int direction){
     if(m_player){
         m_player.PlaybackSession().Position(TimeSpan{target100ns});
         updateTimelineCursorFromPlayback();
+        const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
+        ensureTimelineCursorVisible(cursorLeft);
+        syncTimelineHorizontalScrollBar();
         return true;
     }
 

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -149,7 +149,6 @@ private:
     LONG_PTR m_separatePreviewRestoreExStyle{0};
     winrt::Microsoft::UI::Xaml::Window m_separatePreviewWindow{nullptr};
     winrt::Microsoft::UI::Xaml::Window::Closed_revoker m_separatePreviewClosedRevoker{};
-    winrt::Microsoft::UI::Xaml::Window::Activated_revoker m_separatePreviewActivatedRevoker{};
     ::llvc::Project m_prj{};
     ::llvc::Timeline m_tl{};
 
@@ -228,7 +227,6 @@ private:
     bool sourceHasAudio() const;
     bool setSeparatePreviewWindowOpen(bool open);
     void onSeparatePreviewWindowClosed(const Control& sender, const WEArgs& args);
-    void onSeparatePreviewWindowActivated(const Control& sender, const winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs& args);
     void onSeparatePreviewWindowKeyDown(const KRArgs& args);
     bool toggleSeparatePreviewFullscreen();
     static TS secondsToTimeSpan(double seconds);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -214,6 +214,7 @@ private:
     void stepByFrame(int delta);
     bool moveCursorToMarker(int direction);
     void ensureTimelineCursorVisible(double cursorLeft);
+    void ensureCurrentTimelineCursorVisible();
     void tryFocusTimelineCanvas(const FState focusState);
     bool handleStorylineKeyDown(const KRArgs& args);
     UndoRedoState captureUndoRedoState() const;

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -229,6 +229,7 @@ private:
     bool setSeparatePreviewWindowOpen(bool open);
     void onSeparatePreviewWindowClosed(const Control& sender, const WEArgs& args);
     void onSeparatePreviewWindowActivated(const Control& sender, const winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs& args);
+    void onSeparatePreviewWindowKeyDown(const KRArgs& args);
     bool toggleSeparatePreviewFullscreen();
     static TS secondsToTimeSpan(double seconds);
     static bool isRectVisibleOnAnyMonitor(const RECT& rect);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -214,7 +214,6 @@ private:
     void stepByFrame(int delta);
     bool moveCursorToMarker(int direction);
     void ensureTimelineCursorVisible(double cursorLeft);
-    void ensureCurrentTimelineCursorVisible();
     void tryFocusTimelineCanvas(const FState focusState);
     bool handleStorylineKeyDown(const KRArgs& args);
     UndoRedoState captureUndoRedoState() const;

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -144,6 +144,9 @@ private:
     bool m_isApplyingUndoRedoState{false};
     bool m_isSeparatePreviewWindowOpen{false};
     bool m_isSeparatePreviewFullscreen{false};
+    RECT m_separatePreviewRestoreRect{0, 0, 0, 0};
+    LONG_PTR m_separatePreviewRestoreStyle{0};
+    LONG_PTR m_separatePreviewRestoreExStyle{0};
     winrt::Microsoft::UI::Xaml::Window m_separatePreviewWindow{nullptr};
     winrt::Microsoft::UI::Xaml::Window::Closed_revoker m_separatePreviewClosedRevoker{};
     ::llvc::Project m_prj{};

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -59,7 +59,6 @@ struct MainWindow: MainWindowT<MainWindow>{
     using KRArgs = winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs;
     using DEArgs = winrt::Microsoft::UI::Xaml::DragEventArgs;
     using WEArgs = winrt::Microsoft::UI::Xaml::WindowEventArgs;
-    using WAVArgs = winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs;
     using MPSession = winrt::Windows::Media::Playback::MediaPlaybackSession;
     using MP = winrt::Windows::Media::Playback::MediaPlayer;
     using SFile = winrt::Windows::Storage::StorageFile;
@@ -111,17 +110,12 @@ struct MainWindow: MainWindowT<MainWindow>{
     AAction manualMenuItem_Click(const Control& sender, const REArgs& args);
     AAction aboutMenuItem_Click(const Control& sender, const REArgs& args);
     AAction optionsMenuItem_Click(const Control& sender, const REArgs& args);
-    void separatePreviewWindowMenuItem_Click(const Control& sender, const REArgs& args);
-    void toggleSeparatePreviewFullscreenMenuItem_Click(const Control& sender, const REArgs& args);
-    void zoomInTimelineMenuItem_Click(const Control& sender, const REArgs& args);
-    void zoomOutTimelineMenuItem_Click(const Control& sender, const REArgs& args);
     AAction toggleCutMarkerAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     AAction markSceneCutAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     AAction markSceneKeptAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     void window_DragOver(const Control& sender, const DEArgs& args);
     AAction window_Drop(const Control& sender, const DEArgs& args);
     void onClosed(const Control& sender, const WEArgs& args);
-    void onWindowActivated(const Control& sender, const WAVArgs& args);
     void onNaturalDurationChanged(const MPSession& sender, const Control& args);
     void onPositionTimerTick(const Control& sender, const Control& args);
 
@@ -146,22 +140,6 @@ private:
     double m_timelineDragStartX{0};
     double m_timelineDragStartOffset{0};
     bool m_isApplyingUndoRedoState{false};
-    winrt::Microsoft::UI::Xaml::Window::Activated_revoker m_mainWindowActivatedRevoker{};
-    bool m_isSeparatePreviewWindowOpen{false};
-    bool m_isSeparatePreviewFullscreen{false};
-    bool m_restorePreviewDetachedOnStartup{false};
-    bool m_hasSeparatePreviewPlacement{false};
-    bool m_restorePreviewFullscreenOnStartup{false};
-    int32_t m_separatePreviewLeft{0};
-    int32_t m_separatePreviewTop{0};
-    int32_t m_separatePreviewWidthDips{960};
-    int32_t m_separatePreviewHeightDips{540};
-    int32_t m_separatePreviewDpi{96};
-    RECT m_separatePreviewRestoreRect{0, 0, 0, 0};
-    LONG_PTR m_separatePreviewRestoreStyle{0};
-    LONG_PTR m_separatePreviewRestoreExStyle{0};
-    winrt::Microsoft::UI::Xaml::Window m_separatePreviewWindow{nullptr};
-    winrt::Microsoft::UI::Xaml::Window::Closed_revoker m_separatePreviewClosedRevoker{};
     ::llvc::Project m_prj{};
     ::llvc::Timeline m_tl{};
 
@@ -239,14 +217,8 @@ private:
     static wstring formatTimelineDurationText(int64_t duration100ns);
     static wstring formatDateTimeText(const winrt::Windows::Foundation::DateTime& value);
     bool sourceHasAudio() const;
-    bool setSeparatePreviewWindowOpen(bool open);
-    void onSeparatePreviewWindowClosed(const Control& sender, const WEArgs& args);
-    void onSeparatePreviewWindowKeyDown(const KRArgs& args);
-    bool toggleSeparatePreviewFullscreen();
-    void adjustTimelineZoomBy(int delta);
-    void saveSeparatePreviewPlacement(HWND previewHwnd);
-    void restoreSeparatePreviewPlacement(HWND previewHwnd);
     static TS secondsToTimeSpan(double seconds);
+    static bool isRectVisibleOnAnyMonitor(const RECT& rect);
 };
 
 }

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -59,6 +59,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     using KRArgs = winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs;
     using DEArgs = winrt::Microsoft::UI::Xaml::DragEventArgs;
     using WEArgs = winrt::Microsoft::UI::Xaml::WindowEventArgs;
+    using WAVArgs = winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs;
     using MPSession = winrt::Windows::Media::Playback::MediaPlaybackSession;
     using MP = winrt::Windows::Media::Playback::MediaPlayer;
     using SFile = winrt::Windows::Storage::StorageFile;
@@ -110,12 +111,17 @@ struct MainWindow: MainWindowT<MainWindow>{
     AAction manualMenuItem_Click(const Control& sender, const REArgs& args);
     AAction aboutMenuItem_Click(const Control& sender, const REArgs& args);
     AAction optionsMenuItem_Click(const Control& sender, const REArgs& args);
+    void separatePreviewWindowMenuItem_Click(const Control& sender, const REArgs& args);
+    void toggleSeparatePreviewFullscreenMenuItem_Click(const Control& sender, const REArgs& args);
+    void zoomInTimelineMenuItem_Click(const Control& sender, const REArgs& args);
+    void zoomOutTimelineMenuItem_Click(const Control& sender, const REArgs& args);
     AAction toggleCutMarkerAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     AAction markSceneCutAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     AAction markSceneKeptAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     void window_DragOver(const Control& sender, const DEArgs& args);
     AAction window_Drop(const Control& sender, const DEArgs& args);
     void onClosed(const Control& sender, const WEArgs& args);
+    void onWindowActivated(const Control& sender, const WAVArgs& args);
     void onNaturalDurationChanged(const MPSession& sender, const Control& args);
     void onPositionTimerTick(const Control& sender, const Control& args);
 
@@ -140,6 +146,22 @@ private:
     double m_timelineDragStartX{0};
     double m_timelineDragStartOffset{0};
     bool m_isApplyingUndoRedoState{false};
+    winrt::Microsoft::UI::Xaml::Window::Activated_revoker m_mainWindowActivatedRevoker{};
+    bool m_isSeparatePreviewWindowOpen{false};
+    bool m_isSeparatePreviewFullscreen{false};
+    bool m_restorePreviewDetachedOnStartup{false};
+    bool m_hasSeparatePreviewPlacement{false};
+    bool m_restorePreviewFullscreenOnStartup{false};
+    int32_t m_separatePreviewLeft{0};
+    int32_t m_separatePreviewTop{0};
+    int32_t m_separatePreviewWidthDips{960};
+    int32_t m_separatePreviewHeightDips{540};
+    int32_t m_separatePreviewDpi{96};
+    RECT m_separatePreviewRestoreRect{0, 0, 0, 0};
+    LONG_PTR m_separatePreviewRestoreStyle{0};
+    LONG_PTR m_separatePreviewRestoreExStyle{0};
+    winrt::Microsoft::UI::Xaml::Window m_separatePreviewWindow{nullptr};
+    winrt::Microsoft::UI::Xaml::Window::Closed_revoker m_separatePreviewClosedRevoker{};
     ::llvc::Project m_prj{};
     ::llvc::Timeline m_tl{};
 
@@ -217,8 +239,14 @@ private:
     static wstring formatTimelineDurationText(int64_t duration100ns);
     static wstring formatDateTimeText(const winrt::Windows::Foundation::DateTime& value);
     bool sourceHasAudio() const;
+    bool setSeparatePreviewWindowOpen(bool open);
+    void onSeparatePreviewWindowClosed(const Control& sender, const WEArgs& args);
+    void onSeparatePreviewWindowKeyDown(const KRArgs& args);
+    bool toggleSeparatePreviewFullscreen();
+    void adjustTimelineZoomBy(int delta);
+    void saveSeparatePreviewPlacement(HWND previewHwnd);
+    void restoreSeparatePreviewPlacement(HWND previewHwnd);
     static TS secondsToTimeSpan(double seconds);
-    static bool isRectVisibleOnAnyMonitor(const RECT& rect);
 };
 
 }

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -147,6 +147,14 @@ private:
     winrt::Microsoft::UI::Xaml::Window::Activated_revoker m_mainWindowActivatedRevoker{};
     bool m_isSeparatePreviewWindowOpen{false};
     bool m_isSeparatePreviewFullscreen{false};
+    bool m_restorePreviewDetachedOnStartup{false};
+    bool m_hasSeparatePreviewPlacement{false};
+    bool m_separatePreviewWasMaximized{false};
+    int32_t m_separatePreviewLeft{0};
+    int32_t m_separatePreviewTop{0};
+    int32_t m_separatePreviewWidthDips{960};
+    int32_t m_separatePreviewHeightDips{540};
+    int32_t m_separatePreviewDpi{96};
     RECT m_separatePreviewRestoreRect{0, 0, 0, 0};
     LONG_PTR m_separatePreviewRestoreStyle{0};
     LONG_PTR m_separatePreviewRestoreExStyle{0};
@@ -232,6 +240,8 @@ private:
     void onSeparatePreviewWindowClosed(const Control& sender, const WEArgs& args);
     void onSeparatePreviewWindowKeyDown(const KRArgs& args);
     bool toggleSeparatePreviewFullscreen();
+    void saveSeparatePreviewPlacement(HWND previewHwnd);
+    void restoreSeparatePreviewPlacement(HWND previewHwnd);
     static TS secondsToTimeSpan(double seconds);
     static bool isRectVisibleOnAnyMonitor(const RECT& rect);
 };

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -149,6 +149,7 @@ private:
     LONG_PTR m_separatePreviewRestoreExStyle{0};
     winrt::Microsoft::UI::Xaml::Window m_separatePreviewWindow{nullptr};
     winrt::Microsoft::UI::Xaml::Window::Closed_revoker m_separatePreviewClosedRevoker{};
+    winrt::Microsoft::UI::Xaml::Window::Activated_revoker m_separatePreviewActivatedRevoker{};
     ::llvc::Project m_prj{};
     ::llvc::Timeline m_tl{};
 
@@ -227,6 +228,7 @@ private:
     bool sourceHasAudio() const;
     bool setSeparatePreviewWindowOpen(bool open);
     void onSeparatePreviewWindowClosed(const Control& sender, const WEArgs& args);
+    void onSeparatePreviewWindowActivated(const winrt::Microsoft::UI::Xaml::Window& sender, const winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs& args);
     bool toggleSeparatePreviewFullscreen();
     static TS secondsToTimeSpan(double seconds);
     static bool isRectVisibleOnAnyMonitor(const RECT& rect);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -149,7 +149,7 @@ private:
     bool m_isSeparatePreviewFullscreen{false};
     bool m_restorePreviewDetachedOnStartup{false};
     bool m_hasSeparatePreviewPlacement{false};
-    bool m_separatePreviewWasMaximized{false};
+    bool m_restorePreviewFullscreenOnStartup{false};
     int32_t m_separatePreviewLeft{0};
     int32_t m_separatePreviewTop{0};
     int32_t m_separatePreviewWidthDips{960};

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -59,6 +59,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     using KRArgs = winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs;
     using DEArgs = winrt::Microsoft::UI::Xaml::DragEventArgs;
     using WEArgs = winrt::Microsoft::UI::Xaml::WindowEventArgs;
+    using WAVArgs = winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs;
     using MPSession = winrt::Windows::Media::Playback::MediaPlaybackSession;
     using MP = winrt::Windows::Media::Playback::MediaPlayer;
     using SFile = winrt::Windows::Storage::StorageFile;
@@ -118,6 +119,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     void window_DragOver(const Control& sender, const DEArgs& args);
     AAction window_Drop(const Control& sender, const DEArgs& args);
     void onClosed(const Control& sender, const WEArgs& args);
+    void onWindowActivated(const Control& sender, const WAVArgs& args);
     void onNaturalDurationChanged(const MPSession& sender, const Control& args);
     void onPositionTimerTick(const Control& sender, const Control& args);
 
@@ -142,6 +144,7 @@ private:
     double m_timelineDragStartX{0};
     double m_timelineDragStartOffset{0};
     bool m_isApplyingUndoRedoState{false};
+    winrt::Microsoft::UI::Xaml::Window::Activated_revoker m_mainWindowActivatedRevoker{};
     bool m_isSeparatePreviewWindowOpen{false};
     bool m_isSeparatePreviewFullscreen{false};
     RECT m_separatePreviewRestoreRect{0, 0, 0, 0};

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -228,7 +228,7 @@ private:
     bool sourceHasAudio() const;
     bool setSeparatePreviewWindowOpen(bool open);
     void onSeparatePreviewWindowClosed(const Control& sender, const WEArgs& args);
-    void onSeparatePreviewWindowActivated(const winrt::Microsoft::UI::Xaml::Window& sender, const winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs& args);
+    void onSeparatePreviewWindowActivated(const Control& sender, const winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs& args);
     bool toggleSeparatePreviewFullscreen();
     static TS secondsToTimeSpan(double seconds);
     static bool isRectVisibleOnAnyMonitor(const RECT& rect);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -243,7 +243,6 @@ private:
     void saveSeparatePreviewPlacement(HWND previewHwnd);
     void restoreSeparatePreviewPlacement(HWND previewHwnd);
     static TS secondsToTimeSpan(double seconds);
-    static bool isRectVisibleOnAnyMonitor(const RECT& rect);
 };
 
 }

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -113,6 +113,8 @@ struct MainWindow: MainWindowT<MainWindow>{
     AAction optionsMenuItem_Click(const Control& sender, const REArgs& args);
     void separatePreviewWindowMenuItem_Click(const Control& sender, const REArgs& args);
     void toggleSeparatePreviewFullscreenMenuItem_Click(const Control& sender, const REArgs& args);
+    void zoomInTimelineMenuItem_Click(const Control& sender, const REArgs& args);
+    void zoomOutTimelineMenuItem_Click(const Control& sender, const REArgs& args);
     AAction toggleCutMarkerAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     AAction markSceneCutAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     AAction markSceneKeptAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
@@ -240,6 +242,7 @@ private:
     void onSeparatePreviewWindowClosed(const Control& sender, const WEArgs& args);
     void onSeparatePreviewWindowKeyDown(const KRArgs& args);
     bool toggleSeparatePreviewFullscreen();
+    void adjustTimelineZoomBy(int delta);
     void saveSeparatePreviewPlacement(HWND previewHwnd);
     void restoreSeparatePreviewPlacement(HWND previewHwnd);
     static TS secondsToTimeSpan(double seconds);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -110,6 +110,8 @@ struct MainWindow: MainWindowT<MainWindow>{
     AAction manualMenuItem_Click(const Control& sender, const REArgs& args);
     AAction aboutMenuItem_Click(const Control& sender, const REArgs& args);
     AAction optionsMenuItem_Click(const Control& sender, const REArgs& args);
+    void separatePreviewWindowMenuItem_Click(const Control& sender, const REArgs& args);
+    void toggleSeparatePreviewFullscreenMenuItem_Click(const Control& sender, const REArgs& args);
     AAction toggleCutMarkerAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     AAction markSceneCutAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     AAction markSceneKeptAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
@@ -140,6 +142,10 @@ private:
     double m_timelineDragStartX{0};
     double m_timelineDragStartOffset{0};
     bool m_isApplyingUndoRedoState{false};
+    bool m_isSeparatePreviewWindowOpen{false};
+    bool m_isSeparatePreviewFullscreen{false};
+    winrt::Microsoft::UI::Xaml::Window m_separatePreviewWindow{nullptr};
+    winrt::Microsoft::UI::Xaml::Window::Closed_revoker m_separatePreviewClosedRevoker{};
     ::llvc::Project m_prj{};
     ::llvc::Timeline m_tl{};
 
@@ -216,6 +222,9 @@ private:
     static wstring formatTimelineDurationText(int64_t duration100ns);
     static wstring formatDateTimeText(const winrt::Windows::Foundation::DateTime& value);
     bool sourceHasAudio() const;
+    bool setSeparatePreviewWindowOpen(bool open);
+    void onSeparatePreviewWindowClosed(const Control& sender, const WEArgs& args);
+    bool toggleSeparatePreviewFullscreen();
     static TS secondsToTimeSpan(double seconds);
     static bool isRectVisibleOnAnyMonitor(const RECT& rect);
 };

--- a/Win/llvc/Utils.ixx
+++ b/Win/llvc/Utils.ixx
@@ -1,8 +1,4 @@
-﻿module;
-
-#include <Windows.h>
-
-export module llvc.Utils;
+﻿export module llvc.Utils;
 
 import std;
 
@@ -10,25 +6,11 @@ export namespace llvc{
 
 using namespace std;
 
-struct WindowPlacementState final{
-    int32_t left{};
-    int32_t top{};
-    int32_t widthDips{};
-    int32_t heightDips{};
-    int32_t dpi{96};
-    bool maximized{false};
-};
-
 wstring trim(wstring value);
 wstring serializeIndexList(const vector<uint32_t>& values);
 wstring serializeIndexPairs(const vector<pair<uint32_t, uint32_t>>& values);
 vector<uint32_t> parseIndexList(const wstring& text);
 vector<pair<uint32_t, uint32_t>> parseIndexPairs(const wstring& text);
-int32_t pixelsToDips(int32_t pixelValue, uint32_t dpi);
-int32_t dipsToPixels(int32_t dipValue, uint32_t dpi);
-bool isRectVisibleOnAnyMonitor(const RECT& rect);
-optional<WindowPlacementState> captureWindowPlacement(HWND hwnd);
-bool applyWindowPlacement(HWND hwnd, const WindowPlacementState& state, HWND fallbackWindow = nullptr, bool restoreMaximized = false);
 
 }
 
@@ -98,98 +80,6 @@ vector<pair<uint32_t, uint32_t>> parseIndexPairs(const wstring& text){
         start = sep + 1;
     }
     return pairs;
-}
-
-int32_t pixelsToDips(int32_t pixelValue, uint32_t dpi){
-    return static_cast<int32_t>(lround((pixelValue * 96.0) / (dpi == 0 ? 96 : dpi)));
-}
-
-int32_t dipsToPixels(int32_t dipValue, uint32_t dpi){
-    return static_cast<int32_t>(lround((dipValue * (dpi == 0 ? 96U : dpi)) / 96));
-}
-
-bool isRectVisibleOnAnyMonitor(const RECT& rect){
-    const auto monitor{::MonitorFromRect(&rect, MONITOR_DEFAULTTONULL)};
-    if(!monitor){
-        return false;
-    }
-
-    MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
-    if(!::GetMonitorInfoW(monitor, &monitorInfo)){
-        return false;
-    }
-
-    RECT intersection{};
-    return ::IntersectRect(&intersection, &rect, &monitorInfo.rcWork) != FALSE;
-}
-
-optional<WindowPlacementState> captureWindowPlacement(HWND hwnd){
-    if(!hwnd){
-        return nullopt;
-    }
-
-    RECT bounds{};
-    if(!::GetWindowRect(hwnd, &bounds)){
-        return nullopt;
-    }
-
-    WindowPlacementState state{};
-    WINDOWPLACEMENT placement{.length = sizeof(placement)};
-    if(::GetWindowPlacement(hwnd, &placement) && placement.showCmd == SW_SHOWMAXIMIZED){
-        state.maximized = true;
-        bounds = placement.rcNormalPosition;
-    }
-
-    const auto dpi{::GetDpiForWindow(hwnd)};
-    state.left = static_cast<int32_t>(bounds.left);
-    state.top = static_cast<int32_t>(bounds.top);
-    state.widthDips = pixelsToDips(static_cast<int32_t>(bounds.right - bounds.left), dpi);
-    state.heightDips = pixelsToDips(static_cast<int32_t>(bounds.bottom - bounds.top), dpi);
-    state.dpi = static_cast<int32_t>(dpi);
-    return state;
-}
-
-bool applyWindowPlacement(HWND hwnd, const WindowPlacementState& state, HWND fallbackWindow, bool restoreMaximized){
-    if(!hwnd){
-        return false;
-    }
-
-    const auto currentDpi{::GetDpiForWindow(hwnd)};
-    const auto width{dipsToPixels(state.widthDips, currentDpi)};
-    const auto height{dipsToPixels(state.heightDips, currentDpi)};
-    RECT targetRect{state.left, state.top, state.left + width, state.top + height};
-
-    if(!isRectVisibleOnAnyMonitor(targetRect) && fallbackWindow){
-        MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
-        const auto monitor{::MonitorFromWindow(fallbackWindow, MONITOR_DEFAULTTONEAREST)};
-        if(monitor && ::GetMonitorInfoW(monitor, &monitorInfo)){
-            const auto fallbackWidth{min(width, static_cast<int32_t>(monitorInfo.rcWork.right - monitorInfo.rcWork.left))};
-            const auto fallbackHeight{min(height, static_cast<int32_t>(monitorInfo.rcWork.bottom - monitorInfo.rcWork.top))};
-            targetRect.left = monitorInfo.rcWork.left;
-            targetRect.top = monitorInfo.rcWork.top;
-            targetRect.right = targetRect.left + fallbackWidth;
-            targetRect.bottom = targetRect.top + fallbackHeight;
-        }
-    }
-
-    if(!isRectVisibleOnAnyMonitor(targetRect)){
-        return false;
-    }
-
-    ::SetWindowPos(
-        hwnd,
-        nullptr,
-        targetRect.left,
-        targetRect.top,
-        targetRect.right - targetRect.left,
-        targetRect.bottom - targetRect.top,
-        SWP_NOACTIVATE | SWP_NOZORDER);
-
-    if(restoreMaximized && state.maximized){
-        ::ShowWindow(hwnd, SW_MAXIMIZE);
-    }
-
-    return true;
 }
 
 }

--- a/Win/llvc/Utils.ixx
+++ b/Win/llvc/Utils.ixx
@@ -1,4 +1,8 @@
-﻿export module llvc.Utils;
+﻿module;
+
+#include <Windows.h>
+
+export module llvc.Utils;
 
 import std;
 
@@ -6,11 +10,25 @@ export namespace llvc{
 
 using namespace std;
 
+struct WindowPlacementState final{
+    int32_t left{};
+    int32_t top{};
+    int32_t widthDips{};
+    int32_t heightDips{};
+    int32_t dpi{96};
+    bool maximized{false};
+};
+
 wstring trim(wstring value);
 wstring serializeIndexList(const vector<uint32_t>& values);
 wstring serializeIndexPairs(const vector<pair<uint32_t, uint32_t>>& values);
 vector<uint32_t> parseIndexList(const wstring& text);
 vector<pair<uint32_t, uint32_t>> parseIndexPairs(const wstring& text);
+int32_t pixelsToDips(int32_t pixelValue, uint32_t dpi);
+int32_t dipsToPixels(int32_t dipValue, uint32_t dpi);
+bool isRectVisibleOnAnyMonitor(const RECT& rect);
+optional<WindowPlacementState> captureWindowPlacement(HWND hwnd);
+bool applyWindowPlacement(HWND hwnd, const WindowPlacementState& state, HWND fallbackWindow = nullptr, bool restoreMaximized = false);
 
 }
 
@@ -80,6 +98,98 @@ vector<pair<uint32_t, uint32_t>> parseIndexPairs(const wstring& text){
         start = sep + 1;
     }
     return pairs;
+}
+
+int32_t pixelsToDips(int32_t pixelValue, uint32_t dpi){
+    return static_cast<int32_t>(lround((pixelValue * 96.0) / (dpi == 0 ? 96 : dpi)));
+}
+
+int32_t dipsToPixels(int32_t dipValue, uint32_t dpi){
+    return static_cast<int32_t>(lround((dipValue * (dpi == 0 ? 96U : dpi)) / 96));
+}
+
+bool isRectVisibleOnAnyMonitor(const RECT& rect){
+    const auto monitor{::MonitorFromRect(&rect, MONITOR_DEFAULTTONULL)};
+    if(!monitor){
+        return false;
+    }
+
+    MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
+    if(!::GetMonitorInfoW(monitor, &monitorInfo)){
+        return false;
+    }
+
+    RECT intersection{};
+    return ::IntersectRect(&intersection, &rect, &monitorInfo.rcWork) != FALSE;
+}
+
+optional<WindowPlacementState> captureWindowPlacement(HWND hwnd){
+    if(!hwnd){
+        return nullopt;
+    }
+
+    RECT bounds{};
+    if(!::GetWindowRect(hwnd, &bounds)){
+        return nullopt;
+    }
+
+    WindowPlacementState state{};
+    WINDOWPLACEMENT placement{.length = sizeof(placement)};
+    if(::GetWindowPlacement(hwnd, &placement) && placement.showCmd == SW_SHOWMAXIMIZED){
+        state.maximized = true;
+        bounds = placement.rcNormalPosition;
+    }
+
+    const auto dpi{::GetDpiForWindow(hwnd)};
+    state.left = static_cast<int32_t>(bounds.left);
+    state.top = static_cast<int32_t>(bounds.top);
+    state.widthDips = pixelsToDips(static_cast<int32_t>(bounds.right - bounds.left), dpi);
+    state.heightDips = pixelsToDips(static_cast<int32_t>(bounds.bottom - bounds.top), dpi);
+    state.dpi = static_cast<int32_t>(dpi);
+    return state;
+}
+
+bool applyWindowPlacement(HWND hwnd, const WindowPlacementState& state, HWND fallbackWindow, bool restoreMaximized){
+    if(!hwnd){
+        return false;
+    }
+
+    const auto currentDpi{::GetDpiForWindow(hwnd)};
+    const auto width{dipsToPixels(state.widthDips, currentDpi)};
+    const auto height{dipsToPixels(state.heightDips, currentDpi)};
+    RECT targetRect{state.left, state.top, state.left + width, state.top + height};
+
+    if(!isRectVisibleOnAnyMonitor(targetRect) && fallbackWindow){
+        MONITORINFO monitorInfo{.cbSize = sizeof(monitorInfo)};
+        const auto monitor{::MonitorFromWindow(fallbackWindow, MONITOR_DEFAULTTONEAREST)};
+        if(monitor && ::GetMonitorInfoW(monitor, &monitorInfo)){
+            const auto fallbackWidth{min(width, static_cast<int32_t>(monitorInfo.rcWork.right - monitorInfo.rcWork.left))};
+            const auto fallbackHeight{min(height, static_cast<int32_t>(monitorInfo.rcWork.bottom - monitorInfo.rcWork.top))};
+            targetRect.left = monitorInfo.rcWork.left;
+            targetRect.top = monitorInfo.rcWork.top;
+            targetRect.right = targetRect.left + fallbackWidth;
+            targetRect.bottom = targetRect.top + fallbackHeight;
+        }
+    }
+
+    if(!isRectVisibleOnAnyMonitor(targetRect)){
+        return false;
+    }
+
+    ::SetWindowPos(
+        hwnd,
+        nullptr,
+        targetRect.left,
+        targetRect.top,
+        targetRect.right - targetRect.left,
+        targetRect.bottom - targetRect.top,
+        SWP_NOACTIVATE | SWP_NOZORDER);
+
+    if(restoreMaximized && state.maximized){
+        ::ShowWindow(hwnd, SW_MAXIMIZE);
+    }
+
+    return true;
 }
 
 }


### PR DESCRIPTION
### Motivation
- Allow the video preview to be moved to another monitor and toggled to full-screen so users can review footage on a separate display.
- Provide a simple workflow to detach/reattach the preview from the main UI and control full-screen from the app or a hotkey.

### Description
- Added two new Tools menu entries in `MainWindow.xaml`: `SeparatePreviewWindowMenuItem` to open/close a detachable preview and a `Toggle preview full-screen` item (also bound to `F11`).
- Introduced state and handlers in `MainWindow.xaml.h` including `m_isSeparatePreviewWindowOpen`, `m_isSeparatePreviewFullscreen`, `m_separatePreviewWindow`, `m_separatePreviewClosedRevoker`, and declarations for `setSeparatePreviewWindowOpen`, `onSeparatePreviewWindowClosed`, and `toggleSeparatePreviewFullscreen`.
- Implemented detached preview lifecycle and UI in `MainWindow.xaml.cpp`: `setSeparatePreviewWindowOpen` creates a new `Window` with a `MediaPlayerElement` bound to the app `MediaPlayer`, `onSeparatePreviewWindowClosed` restores the preview to the main window, and `toggleSeparatePreviewFullscreen` toggles the `AppWindow` presenter to `FullScreen` using the preview window handle.
- Wired the `F11` key to call `toggleSeparatePreviewFullscreen` and updated the in-app manual text to document the new workflow.

### Testing
- Ran `git diff --check` to validate formatting and whitespace, which succeeded.
- Attempted to run a release build with `msbuild Win/trifles-win.sln /t:Build /p:Configuration=Release`, but `msbuild` is not available in the current environment so a full build/test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1bed5f4988333bd06d3d0cb4ce80d)