### PR TITLE
Fix audio crossfade semantics, stream audio export memory, and stream‑copy codec validation

### DIFF
--- a/Win/llvc/Export.ixx
+++ b/Win/llvc/Export.ixx
@@ -56,7 +56,7 @@ vector<float> decodeAudioRangeToFloat(const com_ptr<IMFSourceReader>& reader, DW
 wstring pickExportOutputPath(const std::filesystem::path& sourceFsPath, const wchar_t* defaultExt, int64_t outputDuration100ns, HWND ownerWindow, bool mp4Only);
 void appendCrossfadedAudioSegment(vector<float>& mixedAudio, const vector<float>& segmentAudio, uint32_t audioChannels, size_t fadeFrames);
 void writePcmAudioFramesToWriter(const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, const vector<float>& audioFrames, uint32_t audioChannels, uint32_t audioSampleRate, uint64_t& writtenFrames);
-void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs, const function<bool()>& shouldCancel = {});
+void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs, float gain, const function<bool()>& shouldCancel = {});
 VideoWriteStats writeVideoSamplesForExport(const com_ptr<IMFSourceReader>& reader, DWORD videoStreamIndex, const com_ptr<IMFSinkWriter>& writer, DWORD writerVideoStreamIndex, const vector<pair<int64_t, int64_t>>& effectiveCutRanges100ns, GUID videoSubtype, uint32_t nalLengthFieldSize, int64_t sourceDuration100ns, const function<void(double)>& progressCallback, const function<bool()>& shouldCancel = {});
 void applyExportFileMetadata(const std::wstring& sourcePath, const std::wstring& outputPath, const std::wstring& exportComment);
 
@@ -490,8 +490,9 @@ void writePcmAudioFramesToWriter(const com_ptr<IMFSinkWriter>& writer, DWORD wri
     writtenFrames += framesToWrite;
 }
 
-void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs, const function<bool()>& shouldCancel){
+void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs, float gain, const function<bool()>& shouldCancel){
     const auto fadeFrames{crossfadeMs <= 0 ? size_t{0} : static_cast<size_t>((static_cast<int64_t>(audioSampleRate) * crossfadeMs) / 1000)};
+    const auto applyGain{max(0.0f, gain)};
     vector<float> tailBuffer;
     tailBuffer.reserve(fadeFrames * audioChannels);
     uint64_t writtenFrames{};
@@ -601,6 +602,11 @@ void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, D
                 const auto* src{reinterpret_cast<const float*>(bytes)};
                 const auto* begin{src + (trimStartFrames * audioChannels)};
                 vector<float> chunkAudio(begin, begin + (keepFrames * audioChannels));
+                if(applyGain != 1.0f){
+                    for(auto& sampleValue : chunkAudio){
+                        sampleValue *= applyGain;
+                    }
+                }
 
                 if(boundaryCrossfadePending){
                     boundaryBuffer.insert(boundaryBuffer.end(), chunkAudio.begin(), chunkAudio.end());

--- a/Win/llvc/Export.ixx
+++ b/Win/llvc/Export.ixx
@@ -48,14 +48,15 @@ uint32_t getNalLengthFieldSize(const com_ptr<IMFMediaType>& mediaType, const GUI
 bool isTrueRandomAccessPointSample(const com_ptr<IMFSample>& sample, const GUID& subtype, uint32_t nalLengthFieldSize, bool allowInconclusive);
 bool isContainerSyncSample(const com_ptr<IMFSample>& sample);
 com_ptr<IMFMediaType> chooseBestNativeVideoMediaType(const com_ptr<IMFSourceReader>& reader, DWORD streamIndex);
+com_ptr<IMFMediaType> chooseBestNativeVideoMediaTypeForSubtypes(const com_ptr<IMFSourceReader>& reader, DWORD streamIndex, const vector<GUID>& allowedSubtypes);
 com_ptr<IMFMediaType> createPcmFloatAudioType(uint32_t sampleRate, uint32_t channels);
 com_ptr<IMFMediaType> createAacOutputType(uint32_t sampleRate, uint32_t channels);
 vector<float> decodeAudioRangeToFloat(const com_ptr<IMFSourceReader>& reader, DWORD audioStreamIndex, int64_t rangeStart100ns, int64_t rangeEnd100ns, uint32_t channels, uint32_t sampleRate);
 
 wstring pickExportOutputPath(const std::filesystem::path& sourceFsPath, const wchar_t* defaultExt, int64_t outputDuration100ns, HWND ownerWindow, bool mp4Only);
 void appendCrossfadedAudioSegment(vector<float>& mixedAudio, const vector<float>& segmentAudio, uint32_t audioChannels, size_t fadeFrames);
-vector<float> buildMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs);
-void writePcmAudioToWriter(const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, const vector<float>& mixedAudio, uint32_t audioChannels, uint32_t audioSampleRate);
+void writePcmAudioFramesToWriter(const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, const vector<float>& audioFrames, uint32_t audioChannels, uint32_t audioSampleRate, uint64_t& writtenFrames);
+void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs);
 VideoWriteStats writeVideoSamplesForExport(const com_ptr<IMFSourceReader>& reader, DWORD videoStreamIndex, const com_ptr<IMFSinkWriter>& writer, DWORD writerVideoStreamIndex, const vector<pair<int64_t, int64_t>>& effectiveCutRanges100ns, GUID videoSubtype, uint32_t nalLengthFieldSize, int64_t sourceDuration100ns, const function<void(double)>& progressCallback);
 void applyExportFileMetadata(const std::wstring& sourcePath, const std::wstring& outputPath, const std::wstring& exportComment);
 
@@ -215,6 +216,10 @@ bool isContainerSyncSample(const com_ptr<IMFSample>& sample){
 }
 
 com_ptr<IMFMediaType> chooseBestNativeVideoMediaType(const com_ptr<IMFSourceReader>& reader, DWORD streamIndex){
+    return chooseBestNativeVideoMediaTypeForSubtypes(reader, streamIndex, {});
+}
+
+com_ptr<IMFMediaType> chooseBestNativeVideoMediaTypeForSubtypes(const com_ptr<IMFSourceReader>& reader, DWORD streamIndex, const vector<GUID>& allowedSubtypes){
     com_ptr<IMFMediaType> bestType;
     double bestFps{};
     uint32_t bestWidth{};
@@ -229,8 +234,13 @@ com_ptr<IMFMediaType> chooseBestNativeVideoMediaType(const com_ptr<IMFSourceRead
         check_hresult(hr);
 
         GUID major{GUID_NULL};
+        GUID subtype{GUID_NULL};
         check_hresult(type->GetGUID(MF_MT_MAJOR_TYPE, &major));
+        check_hresult(type->GetGUID(MF_MT_SUBTYPE, &subtype));
         if(major != MFMediaType_Video){
+            continue;
+        }
+        if(!allowedSubtypes.empty() && ranges::find(allowedSubtypes, subtype) == allowedSubtypes.end()){
             continue;
         }
 
@@ -429,8 +439,16 @@ void appendCrossfadedAudioSegment(vector<float>& mixedAudio, const vector<float>
     }
 
     for(size_t frame{0}; frame < overlapFrames; ++frame){
-        const auto fadeOut{static_cast<float>(overlapFrames - frame) / static_cast<float>(overlapFrames)};
-        const auto fadeIn{static_cast<float>(frame + 1) / static_cast<float>(overlapFrames)};
+        float fadeOut{};
+        float fadeIn{};
+        if(overlapFrames == 1){
+            fadeOut = 0.0f;
+            fadeIn = 1.0f;
+        }else{
+            const auto t{static_cast<float>(frame) / static_cast<float>(overlapFrames - 1)};
+            fadeOut = cosf(t * static_cast<float>(numbers::pi_v<double> * 0.5));
+            fadeIn = sinf(t * static_cast<float>(numbers::pi_v<double> * 0.5));
+        }
         for(uint32_t ch{0}; ch < audioChannels; ++ch){
             const auto dstIndex{(mixedFrames - overlapFrames + frame) * audioChannels + ch};
             const auto srcIndex{frame * audioChannels + ch};
@@ -441,49 +459,139 @@ void appendCrossfadedAudioSegment(vector<float>& mixedAudio, const vector<float>
     mixedAudio.insert(mixedAudio.end(), segmentAudio.begin() + static_cast<std::ptrdiff_t>(overlapFrames * audioChannels), segmentAudio.end());
 }
 
-vector<float> buildMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs){
-    vector<float> mixedAudio;
-    const auto fadeMs{crossfadeMs > 0 ? crossfadeMs : 100};
-    const auto fadeFrames{static_cast<size_t>((static_cast<int64_t>(audioSampleRate) * fadeMs) / 1000)};
-
-    for(const auto& [keepStart, keepEnd] : keepRanges100ns){
-        auto segmentAudio{decodeAudioRangeToFloat(audioReader, audioStreamIndex, keepStart, keepEnd, audioChannels, audioSampleRate)};
-        appendCrossfadedAudioSegment(mixedAudio, segmentAudio, audioChannels, fadeFrames);
+void writePcmAudioFramesToWriter(const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, const vector<float>& audioFrames, uint32_t audioChannels, uint32_t audioSampleRate, uint64_t& writtenFrames){
+    if(audioFrames.empty()){
+        return;
     }
 
-    return mixedAudio;
+    const auto framesToWrite{audioFrames.size() / audioChannels};
+    const auto bytesToWrite{static_cast<DWORD>(audioFrames.size() * sizeof(float))};
+
+    com_ptr<IMFSample> audioSample;
+    check_hresult(MFCreateSample(audioSample.put()));
+    com_ptr<IMFMediaBuffer> audioBuffer;
+    check_hresult(MFCreateMemoryBuffer(bytesToWrite, audioBuffer.put()));
+
+    BYTE* audioBytes{};
+    DWORD audioMaxLen{};
+    DWORD audioCurLen{};
+    check_hresult(audioBuffer->Lock(&audioBytes, &audioMaxLen, &audioCurLen));
+    memcpy(audioBytes, audioFrames.data(), bytesToWrite);
+    check_hresult(audioBuffer->Unlock());
+    check_hresult(audioBuffer->SetCurrentLength(bytesToWrite));
+    check_hresult(audioSample->AddBuffer(audioBuffer.get()));
+
+    const auto sampleTime100ns{static_cast<LONGLONG>((writtenFrames * 10'000'000ULL) / audioSampleRate)};
+    const auto sampleDuration100ns{static_cast<LONGLONG>((framesToWrite * 10'000'000ULL) / audioSampleRate)};
+    check_hresult(audioSample->SetSampleTime(sampleTime100ns));
+    check_hresult(audioSample->SetSampleDuration(sampleDuration100ns));
+    check_hresult(writer->WriteSample(writerAudioStreamIndex, audioSample.get()));
+
+    writtenFrames += framesToWrite;
 }
 
-void writePcmAudioToWriter(const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, const vector<float>& mixedAudio, uint32_t audioChannels, uint32_t audioSampleRate){
-    const size_t chunkFrames{1024};
-    size_t frameOffset{};
-    const auto totalFrames{mixedAudio.size() / audioChannels};
-    while(frameOffset < totalFrames){
-        const auto framesToWrite{min(chunkFrames, totalFrames - frameOffset)};
-        const auto bytesToWrite{static_cast<DWORD>(framesToWrite * audioChannels * sizeof(float))};
+void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs){
+    const auto fadeFrames{crossfadeMs <= 0 ? size_t{0} : static_cast<size_t>((static_cast<int64_t>(audioSampleRate) * crossfadeMs) / 1000)};
+    vector<float> tailBuffer;
+    tailBuffer.reserve(fadeFrames * audioChannels);
+    uint64_t writtenFrames{};
 
-        com_ptr<IMFSample> audioSample;
-        check_hresult(MFCreateSample(audioSample.put()));
-        com_ptr<IMFMediaBuffer> audioBuffer;
-        check_hresult(MFCreateMemoryBuffer(bytesToWrite, audioBuffer.put()));
+    auto appendChunk = [&](vector<float>& chunkAudio){
+        if(chunkAudio.empty()){
+            return;
+        }
 
-        BYTE* audioBytes{};
-        DWORD audioMaxLen{};
-        DWORD audioCurLen{};
-        check_hresult(audioBuffer->Lock(&audioBytes, &audioMaxLen, &audioCurLen));
-        memcpy(audioBytes, mixedAudio.data() + (frameOffset * audioChannels), bytesToWrite);
-        check_hresult(audioBuffer->Unlock());
-        check_hresult(audioBuffer->SetCurrentLength(bytesToWrite));
-        check_hresult(audioSample->AddBuffer(audioBuffer.get()));
+        if(!tailBuffer.empty()){
+            appendCrossfadedAudioSegment(tailBuffer, chunkAudio, audioChannels, fadeFrames);
+        }else{
+            tailBuffer = move(chunkAudio);
+        }
 
-        const auto sampleTime100ns{static_cast<LONGLONG>((frameOffset * 10'000'000LL) / audioSampleRate)};
-        const auto sampleDuration100ns{static_cast<LONGLONG>((framesToWrite * 10'000'000LL) / audioSampleRate)};
-        check_hresult(audioSample->SetSampleTime(sampleTime100ns));
-        check_hresult(audioSample->SetSampleDuration(sampleDuration100ns));
-        check_hresult(writer->WriteSample(writerAudioStreamIndex, audioSample.get()));
+        if(fadeFrames == 0){
+            writePcmAudioFramesToWriter(writer, writerAudioStreamIndex, tailBuffer, audioChannels, audioSampleRate, writtenFrames);
+            tailBuffer.clear();
+            return;
+        }
 
-        frameOffset += framesToWrite;
+        const auto tailFrames{tailBuffer.size() / audioChannels};
+        if(tailFrames > fadeFrames){
+            const auto flushFrames{tailFrames - fadeFrames};
+            vector<float> flushAudio;
+            flushAudio.reserve(flushFrames * audioChannels);
+            flushAudio.insert(flushAudio.end(), tailBuffer.begin(), tailBuffer.begin() + static_cast<std::ptrdiff_t>(flushFrames * audioChannels));
+            writePcmAudioFramesToWriter(writer, writerAudioStreamIndex, flushAudio, audioChannels, audioSampleRate, writtenFrames);
+            tailBuffer.erase(tailBuffer.begin(), tailBuffer.begin() + static_cast<std::ptrdiff_t>(flushFrames * audioChannels));
+        }
+    };
+
+    for(const auto& [keepStart, keepEnd] : keepRanges100ns){
+        if(keepEnd <= keepStart){
+            continue;
+        }
+
+        PROPVARIANT pos{.vt = VT_I8, .hVal = {.QuadPart = keepStart}};
+        check_hresult(audioReader->SetCurrentPosition(GUID_NULL, pos));
+        PropVariantClear(&pos);
+
+        for(;;){
+            DWORD actualStream{};
+            DWORD flags{};
+            LONGLONG timestamp{};
+            com_ptr<IMFSample> sample;
+            check_hresult(audioReader->ReadSample(audioStreamIndex, 0, &actualStream, &flags, &timestamp, sample.put()));
+            if((flags & MF_SOURCE_READERF_STREAMTICK) && timestamp >= keepEnd){
+                break;
+            }
+            if(flags & MF_SOURCE_READERF_ENDOFSTREAM){
+                break;
+            }
+            if(!sample){
+                continue;
+            }
+
+            LONGLONG sampleStart100ns{};
+            if(FAILED(sample->GetSampleTime(&sampleStart100ns))){
+                sampleStart100ns = timestamp;
+            }
+            LONGLONG sampleDuration100ns{};
+            if(FAILED(sample->GetSampleDuration(&sampleDuration100ns)) || sampleDuration100ns <= 0){
+                continue;
+            }
+
+            const auto sampleEnd100ns{sampleStart100ns + sampleDuration100ns};
+            if(sampleEnd100ns <= keepStart){
+                continue;
+            }
+            if(sampleStart100ns >= keepEnd){
+                break;
+            }
+
+            com_ptr<IMFMediaBuffer> contiguous;
+            check_hresult(sample->ConvertToContiguousBuffer(contiguous.put()));
+            BYTE* bytes{};
+            DWORD maxLen{};
+            DWORD curLen{};
+            check_hresult(contiguous->Lock(&bytes, &maxLen, &curLen));
+
+            const auto totalFrames{static_cast<int64_t>(curLen / (audioChannels * sizeof(float)))};
+            const auto trimStart100ns{max<int64_t>(0, keepStart - sampleStart100ns)};
+            const auto trimEnd100ns{max<int64_t>(0, sampleEnd100ns - keepEnd)};
+            const auto trimStartFrames{min<int64_t>(totalFrames, (trimStart100ns * audioSampleRate) / 10'000'000)};
+            const auto trimEndFrames{min<int64_t>(totalFrames - trimStartFrames, (trimEnd100ns * audioSampleRate) / 10'000'000)};
+            const auto keepFrames{max<int64_t>(0, totalFrames - trimStartFrames - trimEndFrames)};
+
+            if(keepFrames > 0){
+                const auto* src{reinterpret_cast<const float*>(bytes)};
+                const auto* begin{src + (trimStartFrames * audioChannels)};
+                vector<float> chunkAudio(begin, begin + (keepFrames * audioChannels));
+                appendChunk(chunkAudio);
+            }
+
+            contiguous->Unlock();
+        }
     }
+
+    writePcmAudioFramesToWriter(writer, writerAudioStreamIndex, tailBuffer, audioChannels, audioSampleRate, writtenFrames);
 }
 
 VideoWriteStats writeVideoSamplesForExport(const com_ptr<IMFSourceReader>& reader, DWORD videoStreamIndex, const com_ptr<IMFSinkWriter>& writer, DWORD writerVideoStreamIndex, const vector<pair<int64_t, int64_t>>& effectiveCutRanges100ns, GUID videoSubtype, uint32_t nalLengthFieldSize, int64_t sourceDuration100ns, const function<void(double)>& progressCallback){

--- a/Win/llvc/Export.ixx
+++ b/Win/llvc/Export.ixx
@@ -56,8 +56,8 @@ vector<float> decodeAudioRangeToFloat(const com_ptr<IMFSourceReader>& reader, DW
 wstring pickExportOutputPath(const std::filesystem::path& sourceFsPath, const wchar_t* defaultExt, int64_t outputDuration100ns, HWND ownerWindow, bool mp4Only);
 void appendCrossfadedAudioSegment(vector<float>& mixedAudio, const vector<float>& segmentAudio, uint32_t audioChannels, size_t fadeFrames);
 void writePcmAudioFramesToWriter(const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, const vector<float>& audioFrames, uint32_t audioChannels, uint32_t audioSampleRate, uint64_t& writtenFrames);
-void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs);
-VideoWriteStats writeVideoSamplesForExport(const com_ptr<IMFSourceReader>& reader, DWORD videoStreamIndex, const com_ptr<IMFSinkWriter>& writer, DWORD writerVideoStreamIndex, const vector<pair<int64_t, int64_t>>& effectiveCutRanges100ns, GUID videoSubtype, uint32_t nalLengthFieldSize, int64_t sourceDuration100ns, const function<void(double)>& progressCallback);
+void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs, const function<bool()>& shouldCancel = {});
+VideoWriteStats writeVideoSamplesForExport(const com_ptr<IMFSourceReader>& reader, DWORD videoStreamIndex, const com_ptr<IMFSinkWriter>& writer, DWORD writerVideoStreamIndex, const vector<pair<int64_t, int64_t>>& effectiveCutRanges100ns, GUID videoSubtype, uint32_t nalLengthFieldSize, int64_t sourceDuration100ns, const function<void(double)>& progressCallback, const function<bool()>& shouldCancel = {});
 void applyExportFileMetadata(const std::wstring& sourcePath, const std::wstring& outputPath, const std::wstring& exportComment);
 
 }
@@ -490,7 +490,7 @@ void writePcmAudioFramesToWriter(const com_ptr<IMFSinkWriter>& writer, DWORD wri
     writtenFrames += framesToWrite;
 }
 
-void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs){
+void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, DWORD audioStreamIndex, const vector<pair<int64_t, int64_t>>& keepRanges100ns, const com_ptr<IMFSinkWriter>& writer, DWORD writerAudioStreamIndex, uint32_t audioChannels, uint32_t audioSampleRate, int crossfadeMs, const function<bool()>& shouldCancel){
     const auto fadeFrames{crossfadeMs <= 0 ? size_t{0} : static_cast<size_t>((static_cast<int64_t>(audioSampleRate) * crossfadeMs) / 1000)};
     vector<float> tailBuffer;
     tailBuffer.reserve(fadeFrames * audioChannels);
@@ -529,6 +529,9 @@ void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, D
     };
 
     for(const auto& [keepStart, keepEnd] : keepRanges100ns){
+        if(shouldCancel && shouldCancel()){
+            throw hresult_error(HRESULT_FROM_WIN32(ERROR_CANCELLED), L"Export canceled.");
+        }
         if(keepEnd <= keepStart){
             continue;
         }
@@ -545,6 +548,9 @@ void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, D
         PropVariantClear(&pos);
 
         for(;;){
+            if(shouldCancel && shouldCancel()){
+                throw hresult_error(HRESULT_FROM_WIN32(ERROR_CANCELLED), L"Export canceled.");
+            }
             DWORD actualStream{};
             DWORD flags{};
             LONGLONG timestamp{};
@@ -622,7 +628,7 @@ void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, D
     writePcmAudioFramesToWriter(writer, writerAudioStreamIndex, tailBuffer, audioChannels, audioSampleRate, writtenFrames);
 }
 
-VideoWriteStats writeVideoSamplesForExport(const com_ptr<IMFSourceReader>& reader, DWORD videoStreamIndex, const com_ptr<IMFSinkWriter>& writer, DWORD writerVideoStreamIndex, const vector<pair<int64_t, int64_t>>& effectiveCutRanges100ns, GUID videoSubtype, uint32_t nalLengthFieldSize, int64_t sourceDuration100ns, const function<void(double)>& progressCallback){
+VideoWriteStats writeVideoSamplesForExport(const com_ptr<IMFSourceReader>& reader, DWORD videoStreamIndex, const com_ptr<IMFSinkWriter>& writer, DWORD writerVideoStreamIndex, const vector<pair<int64_t, int64_t>>& effectiveCutRanges100ns, GUID videoSubtype, uint32_t nalLengthFieldSize, int64_t sourceDuration100ns, const function<void(double)>& progressCallback, const function<bool()>& shouldCancel){
     auto waitingForCleanPoint{false};
     auto markDiscontinuityOnNextWrittenSample{false};
     auto dtsPtsShift100ns{static_cast<int64_t>(0)};
@@ -635,6 +641,9 @@ VideoWriteStats writeVideoSamplesForExport(const com_ptr<IMFSourceReader>& reade
     }
 
     for(;;){
+        if(shouldCancel && shouldCancel()){
+            throw hresult_error(HRESULT_FROM_WIN32(ERROR_CANCELLED), L"Export canceled.");
+        }
         DWORD actualStream{};
         DWORD flags{};
         LONGLONG timestamp{};

--- a/Win/llvc/Export.ixx
+++ b/Win/llvc/Export.ixx
@@ -496,19 +496,7 @@ void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, D
     tailBuffer.reserve(fadeFrames * audioChannels);
     uint64_t writtenFrames{};
 
-    auto appendChunk = [&](vector<float>& chunkAudio, bool crossfadeAtBoundary){
-        if(chunkAudio.empty()){
-            return;
-        }
-
-        if(!tailBuffer.empty() && crossfadeAtBoundary && fadeFrames > 0){
-            appendCrossfadedAudioSegment(tailBuffer, chunkAudio, audioChannels, fadeFrames);
-        }else if(!tailBuffer.empty()){
-            tailBuffer.insert(tailBuffer.end(), chunkAudio.begin(), chunkAudio.end());
-        }else{
-            tailBuffer = move(chunkAudio);
-        }
-
+    auto flushTailIfNeeded = [&](){
         if(fadeFrames == 0){
             writePcmAudioFramesToWriter(writer, writerAudioStreamIndex, tailBuffer, audioChannels, audioSampleRate, writtenFrames);
             tailBuffer.clear();
@@ -526,12 +514,31 @@ void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, D
         }
     };
 
+    auto appendChunk = [&](vector<float>& chunkAudio){
+        if(chunkAudio.empty()){
+            return;
+        }
+
+        if(!tailBuffer.empty()){
+            tailBuffer.insert(tailBuffer.end(), chunkAudio.begin(), chunkAudio.end());
+        }else{
+            tailBuffer = move(chunkAudio);
+        }
+
+        flushTailIfNeeded();
+    };
+
     for(const auto& [keepStart, keepEnd] : keepRanges100ns){
         if(keepEnd <= keepStart){
             continue;
         }
 
-        auto firstChunkInKeepRange{true};
+        const auto boundaryNeedsCrossfade{!tailBuffer.empty() && fadeFrames > 0};
+        vector<float> boundaryBuffer;
+        if(boundaryNeedsCrossfade){
+            boundaryBuffer.reserve(fadeFrames * audioChannels);
+        }
+        auto boundaryCrossfadePending{boundaryNeedsCrossfade};
 
         PROPVARIANT pos{.vt = VT_I8, .hVal = {.QuadPart = keepStart}};
         check_hresult(audioReader->SetCurrentPosition(GUID_NULL, pos));
@@ -588,11 +595,27 @@ void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, D
                 const auto* src{reinterpret_cast<const float*>(bytes)};
                 const auto* begin{src + (trimStartFrames * audioChannels)};
                 vector<float> chunkAudio(begin, begin + (keepFrames * audioChannels));
-                appendChunk(chunkAudio, firstChunkInKeepRange);
-                firstChunkInKeepRange = false;
+
+                if(boundaryCrossfadePending){
+                    boundaryBuffer.insert(boundaryBuffer.end(), chunkAudio.begin(), chunkAudio.end());
+                    const auto boundaryFrames{boundaryBuffer.size() / audioChannels};
+                    if(boundaryFrames >= fadeFrames){
+                        appendCrossfadedAudioSegment(tailBuffer, boundaryBuffer, audioChannels, fadeFrames);
+                        boundaryBuffer.clear();
+                        boundaryCrossfadePending = false;
+                        flushTailIfNeeded();
+                    }
+                }else{
+                    appendChunk(chunkAudio);
+                }
             }
 
             contiguous->Unlock();
+        }
+
+        if(boundaryCrossfadePending && !boundaryBuffer.empty()){
+            appendCrossfadedAudioSegment(tailBuffer, boundaryBuffer, audioChannels, fadeFrames);
+            flushTailIfNeeded();
         }
     }
 

--- a/Win/llvc/Export.ixx
+++ b/Win/llvc/Export.ixx
@@ -496,13 +496,15 @@ void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, D
     tailBuffer.reserve(fadeFrames * audioChannels);
     uint64_t writtenFrames{};
 
-    auto appendChunk = [&](vector<float>& chunkAudio){
+    auto appendChunk = [&](vector<float>& chunkAudio, bool crossfadeAtBoundary){
         if(chunkAudio.empty()){
             return;
         }
 
-        if(!tailBuffer.empty()){
+        if(!tailBuffer.empty() && crossfadeAtBoundary && fadeFrames > 0){
             appendCrossfadedAudioSegment(tailBuffer, chunkAudio, audioChannels, fadeFrames);
+        }else if(!tailBuffer.empty()){
+            tailBuffer.insert(tailBuffer.end(), chunkAudio.begin(), chunkAudio.end());
         }else{
             tailBuffer = move(chunkAudio);
         }
@@ -528,6 +530,8 @@ void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, D
         if(keepEnd <= keepStart){
             continue;
         }
+
+        auto firstChunkInKeepRange{true};
 
         PROPVARIANT pos{.vt = VT_I8, .hVal = {.QuadPart = keepStart}};
         check_hresult(audioReader->SetCurrentPosition(GUID_NULL, pos));
@@ -584,7 +588,8 @@ void writeMixedAudioForKeepRanges(const com_ptr<IMFSourceReader>& audioReader, D
                 const auto* src{reinterpret_cast<const float*>(bytes)};
                 const auto* begin{src + (trimStartFrames * audioChannels)};
                 vector<float> chunkAudio(begin, begin + (keepFrames * audioChannels));
-                appendChunk(chunkAudio);
+                appendChunk(chunkAudio, firstChunkInKeepRange);
+                firstChunkInKeepRange = false;
             }
 
             contiguous->Unlock();

--- a/Win/llvc/MainWindow.Export.cpp
+++ b/Win/llvc/MainWindow.Export.cpp
@@ -68,8 +68,9 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
     const auto sourceIsAvi{isAviSourcePath(sourcePath)};
     const auto defaultExt{sourceIsAvi ? L".mp4" : (_wcsicmp(sourceExt.c_str(), L".mov") == 0 ? L".mov" : L".mp4")};
 
-    const auto cutBlockCount{m_prj.cutRanges100ns().size()};
-    const auto keptBlockCount{invertCutRanges100ns(m_prj.cutRanges100ns(), sourceDuration100ns).size()};
+    const auto summaryCutRanges100ns{m_prj.buildCutRanges100ns()};
+    const auto cutBlockCount{summaryCutRanges100ns.size()};
+    const auto keptBlockCount{invertCutRanges100ns(summaryCutRanges100ns, sourceDuration100ns).size()};
     const auto keepAudioRequested{m_prj.keepAudio() && sourceHasAudio() && !m_mediaInfo.audioDisabledForThisSource};
     const auto crossfadeSummary{keepAudioRequested ? (to_wstring(m_prj.audioXfadeMs()) + L" ms") : wstring{L"n/a (audio removed)"}};
     const auto containerSummary{sourceIsAvi ? L"MP4" : (_wcsicmp(defaultExt, L".mov") == 0 ? L"MOV" : L"MP4")};

--- a/Win/llvc/MainWindow.Export.cpp
+++ b/Win/llvc/MainWindow.Export.cpp
@@ -120,7 +120,8 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
         check_hresult(reader->SetStreamSelection(static_cast<DWORD>(MF_SOURCE_READER_ALL_STREAMS), FALSE));
         check_hresult(reader->SetStreamSelection(videoStreamIndex, TRUE));
 
-        auto sourceVideoType{chooseBestNativeVideoMediaType(reader, videoStreamIndex)};
+        const vector<GUID> streamCopySubtypes{MFVideoFormat_H264, MFVideoFormat_HEVC, MFVideoFormat_H265};
+        auto sourceVideoType{chooseBestNativeVideoMediaTypeForSubtypes(reader, videoStreamIndex, streamCopySubtypes)};
         if(sourceIsAvi){
             sourceVideoType = nullptr;
             for(DWORD mediaTypeIndex{};; ++mediaTypeIndex){
@@ -142,7 +143,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
             }
         }
         if(!sourceVideoType){
-            throw hresult_error(MF_E_INVALIDMEDIATYPE, L"No native video media type found");
+            throw hresult_error(MF_E_INVALIDMEDIATYPE, L"No stream-copy video media type found (require H.264 or HEVC)");
         }
         check_hresult(reader->SetCurrentMediaType(videoStreamIndex, nullptr, sourceVideoType.get()));
 
@@ -163,7 +164,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
                     ? sourceVideoType->GetBlob(MF_MT_MPEG_SEQUENCE_HEADER, sequenceHeader.data(), sequenceHeaderSize, &bytesWritten)
                     : E_FAIL};
             if(FAILED(seqReadHr) || bytesWritten == 0){
-                throw hresult_error(MF_E_INVALIDMEDIATYPE, L"This AVI cannot be stream-copied to MP4 on this system (missing H.264 mux support)");
+                throw hresult_error(MF_E_INVALIDMEDIATYPE, L"AVI H.264 stream lacks codec configuration (SPS/PPS). Convert to MP4 first.");
             }
         }
 
@@ -280,7 +281,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
         const auto writerConfigHr{configureWriter()};
         if(FAILED(writerConfigHr)){
             if(sourceIsAvi){
-                throw hresult_error(writerConfigHr, L"This AVI cannot be stream-copied to MP4 on this system (missing H.264 mux support).");
+                throw hresult_error(writerConfigHr, L"System cannot mux H.264 into MP4 via Media Foundation.");
             }
             check_hresult(writerConfigHr);
         }
@@ -315,8 +316,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
             check_hresult(audioReader->SetCurrentMediaType(audioStreamIndex, nullptr, audioPcmType.get()));
 
             const auto keepRanges100ns{invertCutRanges100ns(effectiveCutRanges100ns, sourceDuration100ns)};
-            const auto mixedAudio{buildMixedAudioForKeepRanges(audioReader, audioStreamIndex, keepRanges100ns, audioChannels, audioSampleRate, m_prj.audioXfadeMs())};
-            writePcmAudioToWriter(writer, writerAudioStreamIndex, mixedAudio, audioChannels, audioSampleRate);
+            writeMixedAudioForKeepRanges(audioReader, audioStreamIndex, keepRanges100ns, writer, writerAudioStreamIndex, audioChannels, audioSampleRate, m_prj.audioXfadeMs());
         }
 
         check_hresult(writer->Finalize());

--- a/Win/llvc/MainWindow.Export.cpp
+++ b/Win/llvc/MainWindow.Export.cpp
@@ -73,6 +73,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
     const auto keptBlockCount{invertCutRanges100ns(summaryCutRanges100ns, sourceDuration100ns).size()};
     const auto keepAudioRequested{m_prj.keepAudio() && sourceHasAudio() && !m_mediaInfo.audioDisabledForThisSource};
     const auto crossfadeSummary{keepAudioRequested ? (to_wstring(m_prj.audioXfadeMs()) + L" ms") : wstring{L"n/a (audio removed)"}};
+    const auto volumeSummary{keepAudioRequested ? (to_wstring(m_prj.audioVolumePct()) + L"%") : wstring{L"n/a (audio removed)"}};
     const auto containerSummary{sourceIsAvi ? L"MP4" : (_wcsicmp(defaultExt, L".mov") == 0 ? L"MOV" : L"MP4")};
 
     Controls::ContentDialog exportSummaryDialog{};
@@ -84,6 +85,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
         L"\nKept blocks: " + to_wstring(keptBlockCount) +
         L"\nAudio: " + wstring{keepAudioRequested ? L"kept" : L"removed"} +
         L"\nCrossfade: " + crossfadeSummary +
+        L"\nVolume: " + volumeSummary +
         L"\nOutput container: " + containerSummary));
     exportSummaryDialog.PrimaryButtonText(L"Continue");
     exportSummaryDialog.CloseButtonText(L"Cancel");
@@ -348,7 +350,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
             check_hresult(audioReader->SetCurrentMediaType(audioStreamIndex, nullptr, audioPcmType.get()));
 
             const auto keepRanges100ns{invertCutRanges100ns(effectiveCutRanges100ns, sourceDuration100ns)};
-            writeMixedAudioForKeepRanges(audioReader, audioStreamIndex, keepRanges100ns, writer, writerAudioStreamIndex, audioChannels, audioSampleRate, m_prj.audioXfadeMs(), [self = get_weak()](){
+            writeMixedAudioForKeepRanges(audioReader, audioStreamIndex, keepRanges100ns, writer, writerAudioStreamIndex, audioChannels, audioSampleRate, m_prj.audioXfadeMs(), m_prj.audioVolumePct() / 100.0f, [self = get_weak()](){
                 if(const auto strong = self.get()){
                     return strong->m_cancelExportRequested.load();
                 }

--- a/Win/llvc/MainWindow.Export.cpp
+++ b/Win/llvc/MainWindow.Export.cpp
@@ -24,6 +24,7 @@ namespace winrt::llvc::implementation{
 using namespace std;
 using namespace winrt;
 using namespace ::llvc;
+namespace Controls = winrt::Microsoft::UI::Xaml::Controls;
 
 using Control = MainWindow::Control;
 using REArgs = MainWindow::REArgs;
@@ -67,12 +68,35 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
     const auto sourceIsAvi{isAviSourcePath(sourcePath)};
     const auto defaultExt{sourceIsAvi ? L".mp4" : (_wcsicmp(sourceExt.c_str(), L".mov") == 0 ? L".mov" : L".mp4")};
 
+    const auto cutBlockCount{m_prj.cutRanges100ns().size()};
+    const auto keptBlockCount{invertCutRanges100ns(m_prj.cutRanges100ns(), sourceDuration100ns).size()};
+    const auto keepAudioRequested{m_prj.keepAudio() && sourceHasAudio() && !m_mediaInfo.audioDisabledForThisSource};
+    const auto crossfadeSummary{keepAudioRequested ? (to_wstring(m_prj.audioXfadeMs()) + L" ms") : wstring{L"n/a (audio removed)"}};
+    const auto containerSummary{sourceIsAvi ? L"MP4" : (_wcsicmp(defaultExt, L".mov") == 0 ? L"MOV" : L"MP4")};
+
+    Controls::ContentDialog exportSummaryDialog{};
+    exportSummaryDialog.XamlRoot(Content().XamlRoot());
+    exportSummaryDialog.Title(box_value(L"Confirm export settings"));
+    exportSummaryDialog.Content(box_value(
+        L"Output duration: " + formatTimelineDurationText(outputDuration100ns) +
+        L"\nCut blocks: " + to_wstring(cutBlockCount) +
+        L"\nKept blocks: " + to_wstring(keptBlockCount) +
+        L"\nAudio: " + wstring{keepAudioRequested ? L"kept" : L"removed"} +
+        L"\nCrossfade: " + crossfadeSummary +
+        L"\nOutput container: " + containerSummary));
+    exportSummaryDialog.PrimaryButtonText(L"Continue");
+    exportSummaryDialog.CloseButtonText(L"Cancel");
+    if((co_await exportSummaryDialog.ShowAsync()) != Controls::ContentDialogResult::Primary){
+        co_return;
+    }
+
     const auto outputPath{pickExportOutputPath(sourceFsPath, defaultExt, outputDuration100ns, getWindowHandle(), sourceIsAvi)};
     if(outputPath.empty()){
         co_return;
     }
 
     m_isExportInProgress = true;
+    m_cancelExportRequested = false;
     m_resumeTimelineRenderAfterExport = m_prj.videoFile() && m_timelineDurationSeconds > 0;
     ++m_timelineRenderVersion;
 
@@ -82,6 +106,7 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
 
     winrt::hstring exportErrorMessage{};
     auto exportSucceeded{false};
+    auto exportCanceled{false};
     const auto exportComment{makeExportComment(sourceFsPath)};
 
     winrt::apartment_context uiThread;
@@ -305,6 +330,12 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
                         }
                     });
                 }
+            },
+            [self = get_weak()](){
+                if(const auto strong = self.get()){
+                    return strong->m_cancelExportRequested.load();
+                }
+                return false;
             })};
         (void)videoStats;
 
@@ -316,14 +347,29 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
             check_hresult(audioReader->SetCurrentMediaType(audioStreamIndex, nullptr, audioPcmType.get()));
 
             const auto keepRanges100ns{invertCutRanges100ns(effectiveCutRanges100ns, sourceDuration100ns)};
-            writeMixedAudioForKeepRanges(audioReader, audioStreamIndex, keepRanges100ns, writer, writerAudioStreamIndex, audioChannels, audioSampleRate, m_prj.audioXfadeMs());
+            writeMixedAudioForKeepRanges(audioReader, audioStreamIndex, keepRanges100ns, writer, writerAudioStreamIndex, audioChannels, audioSampleRate, m_prj.audioXfadeMs(), [self = get_weak()](){
+                if(const auto strong = self.get()){
+                    return strong->m_cancelExportRequested.load();
+                }
+                return false;
+            });
+        }
+
+        if(m_cancelExportRequested){
+            throw hresult_error(HRESULT_FROM_WIN32(ERROR_CANCELLED), L"Export canceled.");
         }
 
         check_hresult(writer->Finalize());
         applyExportFileMetadata(sourcePath, outputPath, exportComment);
         exportSucceeded = true;
     }catch(const hresult_error& ex){
-        exportErrorMessage = ex.message();
+        if(ex.code() == HRESULT_FROM_WIN32(ERROR_CANCELLED)){
+            exportCanceled = true;
+            std::error_code ec;
+            filesystem::remove(outputPath, ec);
+        }else{
+            exportErrorMessage = ex.message();
+        }
     }
 
     co_await uiThread;
@@ -338,6 +384,9 @@ AAction MainWindow::exportVideoMenuItem_Click(const Control&, const REArgs&){
         setStatusMessage(L"Export completed");
         clearErrorMessage();
         refreshStatusInfoSection();
+    }else if(exportCanceled){
+        setStatusMessage(L"Export canceled");
+        clearErrorMessage();
     }else{
         setStatusMessage(L"Export failed");
         setErrorMessage(exportErrorMessage.c_str());

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -20,9 +20,9 @@
 
         <controls:MenuBar x:Name="MainMenuBar" Grid.Row="0" IsTabStop="False">
             <controls:MenuBarItem Title="File">
-                <MenuFlyoutItem Text="New project	Ctrl+N" Click="newProjectMenuItem_Click"/>
+                <MenuFlyoutItem Text="New project (Ctrl+N)" Click="newProjectMenuItem_Click"/>
                 <MenuFlyoutItem Text="Open project..." Click="openProjectMenuItem_Click"/>
-                <MenuFlyoutItem Text="Save project	Ctrl+S" Click="saveProjectMenuItem_Click"/>
+                <MenuFlyoutItem Text="Save project (Ctrl+S)" Click="saveProjectMenuItem_Click"/>
                 <MenuFlyoutItem Text="Save project as..." Click="saveProjectAsMenuItem_Click"/>
                 <MenuFlyoutItem Text="Close project" Click="closeProjectMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
@@ -38,21 +38,21 @@
             </controls:MenuBarItem>
 
             <controls:MenuBarItem Title="Edit">
-                <MenuFlyoutItem Text="Undo	Ctrl+Z" Click="undoMenuItem_Click"/>
-                <MenuFlyoutItem Text="Redo	Ctrl+Y" Click="redoMenuItem_Click"/>
+                <MenuFlyoutItem Text="Undo (Ctrl+Z)" Click="undoMenuItem_Click"/>
+                <MenuFlyoutItem Text="Redo (Ctrl+Y)" Click="redoMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Reevaluate clear cut markers	Ctrl+R" Click="reevaluateClearCutMarkersButton_Click"/>
+                <MenuFlyoutItem Text="Reevaluate clear cut markers (Ctrl+R)" Click="reevaluateClearCutMarkersButton_Click"/>
                 <MenuFlyoutSeparator/>
-                <MenuFlyoutItem Text="Toggle cut mark	Ctrl+M" Click="toggleCutMarkerAtCursorMenuItem_Click"/>
-                <MenuFlyoutItem Text="Mark scene cut	Delete" Click="markSceneCutAtCursorMenuItem_Click"/>
-                <MenuFlyoutItem Text="Mark scene kept	Insert" Click="markSceneKeptAtCursorMenuItem_Click"/>
+                <MenuFlyoutItem Text="Toggle cut mark (Ctrl+M)" Click="toggleCutMarkerAtCursorMenuItem_Click"/>
+                <MenuFlyoutItem Text="Mark scene cut (Delete)" Click="markSceneCutAtCursorMenuItem_Click"/>
+                <MenuFlyoutItem Text="Mark scene kept (Insert)" Click="markSceneKeptAtCursorMenuItem_Click"/>
             </controls:MenuBarItem>
             <controls:MenuBarItem Title="View">
-                <MenuFlyoutItem Text="Zoom in timeline	Ctrl++" Click="zoomInTimelineMenuItem_Click"/>
-                <MenuFlyoutItem Text="Zoom out timeline	Ctrl+-" Click="zoomOutTimelineMenuItem_Click"/>
+                <MenuFlyoutItem Text="Zoom in timeline (Ctrl++)" Click="zoomInTimelineMenuItem_Click"/>
+                <MenuFlyoutItem Text="Zoom out timeline (Ctrl+-)" Click="zoomOutTimelineMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
                 <ToggleMenuFlyoutItem x:Name="SeparatePreviewWindowMenuItem" Text="Preview in separate window" Click="separatePreviewWindowMenuItem_Click"/>
-                <MenuFlyoutItem Text="Toggle preview full-screen	F11" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
+                <MenuFlyoutItem Text="Toggle preview full-screen (F11)" Click="toggleSeparatePreviewFullscreenMenuItem_Click"/>
             </controls:MenuBarItem>
 
             <controls:MenuBarItem Title="Tools">

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -148,7 +148,7 @@
                         <ComboBoxItem Content="5 s" Tag="5000"/>
                     </ComboBox>
                     <TextBlock x:Name="AudioVolumeIconText" Text="🔉" VerticalAlignment="Center"/>
-                    <Slider x:Name="AudioVolumeSlider" Width="120" IsEnabled="False" Minimum="0" Maximum="175" SmallChange="5" LargeChange="5" StepFrequency="5" Value="100" ValueChanged="audioVolumeSlider_ValueChanged"/>
+                    <Slider x:Name="AudioVolumeSlider" Width="120" IsEnabled="False" Minimum="0" Maximum="250" SmallChange="5" LargeChange="5" StepFrequency="5" Value="100" ValueChanged="audioVolumeSlider_ValueChanged"/>
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right" VerticalAlignment="Center">

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -137,7 +137,7 @@
                     <CheckBox x:Name="KeepAudioCheckBox" Content="Keep audio" IsEnabled="False" VerticalAlignment="Center" Checked="keepAudioCheckBox_Changed" Unchecked="keepAudioCheckBox_Changed"/>
                     <TextBlock Text="Audio cross-fade:" VerticalAlignment="Center"/>
                     <ComboBox x:Name="AudioCrossfadeComboBox" Width="120" IsEnabled="False" SelectionChanged="audioCrossfadeComboBox_SelectionChanged">
-                        <ComboBoxItem Content="0 ms" Tag="0"/>
+                        <ComboBoxItem Content="None (0 ms)" Tag="0"/>
                         <ComboBoxItem Content="50 ms" Tag="50"/>
                         <ComboBoxItem Content="100 ms" Tag="100"/>
                         <ComboBoxItem Content="250 ms" Tag="250"/>
@@ -193,6 +193,7 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
                 <Grid Grid.Column="0" RowSpacing="2" VerticalAlignment="Center">
@@ -207,6 +208,7 @@
 
                 <TextBlock x:Name="InfoText" Grid.Column="1" Margin="0,0,10,0" Text="Estimated output: --:--.---" VerticalAlignment="Center" HorizontalAlignment="Right" TextTrimming="CharacterEllipsis"/>
                 <ProgressBar x:Name="OperationProgressBar" Grid.Column="2" Width="170" Height="16" Minimum="0" Maximum="100" Value="0" Visibility="Collapsed" HorizontalAlignment="Right"/>
+                <Button x:Name="CancelExportButton" Grid.Column="3" Margin="8,0,0,0" Content="Cancel" Click="cancelExportButton_Click" Visibility="Collapsed" IsEnabled="False"/>
             </Grid>
         </Border>
     </Grid>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -144,6 +144,8 @@
                         <ComboBoxItem Content="500 ms" Tag="500"/>
                         <ComboBoxItem Content="750 ms" Tag="750"/>
                         <ComboBoxItem Content="1 s" Tag="1000"/>
+                        <ComboBoxItem Content="2 s" Tag="2000"/>
+                        <ComboBoxItem Content="5 s" Tag="5000"/>
                     </ComboBox>
                 </StackPanel>
 

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -147,6 +147,8 @@
                         <ComboBoxItem Content="2 s" Tag="2000"/>
                         <ComboBoxItem Content="5 s" Tag="5000"/>
                     </ComboBox>
+                    <TextBlock x:Name="AudioVolumeIconText" Text="🔉" VerticalAlignment="Center"/>
+                    <Slider x:Name="AudioVolumeSlider" Width="120" IsEnabled="False" Minimum="0" Maximum="150" SmallChange="5" LargeChange="5" StepFrequency="5" Value="100" ValueChanged="audioVolumeSlider_ValueChanged"/>
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right" VerticalAlignment="Center">

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -27,7 +27,7 @@
                 <MenuFlyoutItem Text="Close project" Click="closeProjectMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="Load video..." Click="loadVideoMenuItem_Click"/>
-                <MenuFlyoutItem Text="Export video...\tF7" Click="exportVideoMenuItem_Click"/>
+                <MenuFlyoutItem Text="Export video... (F7)" Click="exportVideoMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
                 <MenuFlyoutSubItem x:Name="RecentProjectsMenu" Text="Recent projects"/>
                 <MenuFlyoutSubItem x:Name="RecentVideosMenu" Text="Recent videos"/>
@@ -110,6 +110,7 @@
                             <TextBlock Text="Ctrl+-: zoom out timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete: cut scene" TextWrapping="Wrap"/>
                             <TextBlock Text="Insert: keep scene" TextWrapping="Wrap"/>
+                            <TextBlock Text="F7: export video" TextWrapping="Wrap"/>
                             <TextBlock Text=""/>
                             <TextBlock Text="Timeline click: set cursor"/>
                             <TextBlock Text="Right-click: toggle mark"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -148,7 +148,7 @@
                         <ComboBoxItem Content="5 s" Tag="5000"/>
                     </ComboBox>
                     <TextBlock x:Name="AudioVolumeIconText" Text="🔉" VerticalAlignment="Center"/>
-                    <Slider x:Name="AudioVolumeSlider" Width="120" IsEnabled="False" Minimum="0" Maximum="250" SmallChange="5" LargeChange="5" StepFrequency="5" Value="100" ValueChanged="audioVolumeSlider_ValueChanged"/>
+                    <Slider x:Name="AudioVolumeSlider" Width="120" IsEnabled="False" Minimum="0" Maximum="250" SmallChange="5" LargeChange="5" StepFrequency="5" Value="100" ValueChanged="audioVolumeSlider_ValueChanged" ToolTipService.ToolTip="Preview uses MediaPlayer volume (max 100%); export applies full boost."/>
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right" VerticalAlignment="Center">

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -27,7 +27,7 @@
                 <MenuFlyoutItem Text="Close project" Click="closeProjectMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="Load video..." Click="loadVideoMenuItem_Click"/>
-                <MenuFlyoutItem Text="Export video..." Click="exportVideoMenuItem_Click"/>
+                <MenuFlyoutItem Text="Export video...\tF7" Click="exportVideoMenuItem_Click"/>
                 <MenuFlyoutSeparator/>
                 <MenuFlyoutSubItem x:Name="RecentProjectsMenu" Text="Recent projects"/>
                 <MenuFlyoutSubItem x:Name="RecentVideosMenu" Text="Recent videos"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -148,7 +148,7 @@
                         <ComboBoxItem Content="5 s" Tag="5000"/>
                     </ComboBox>
                     <TextBlock x:Name="AudioVolumeIconText" Text="🔉" VerticalAlignment="Center"/>
-                    <Slider x:Name="AudioVolumeSlider" Width="120" IsEnabled="False" Minimum="0" Maximum="150" SmallChange="5" LargeChange="5" StepFrequency="5" Value="100" ValueChanged="audioVolumeSlider_ValueChanged"/>
+                    <Slider x:Name="AudioVolumeSlider" Width="120" IsEnabled="False" Minimum="0" Maximum="175" SmallChange="5" LargeChange="5" StepFrequency="5" Value="100" ValueChanged="audioVolumeSlider_ValueChanged"/>
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right" VerticalAlignment="Center">

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1537,6 +1537,10 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         (void)toggleSeparatePreviewFullscreen();
         args.Handled(true);
         return true;
+    case VirtualKey::F7:
+        (void)exportVideoMenuItem_Click(Control{}, REArgs{});
+        args.Handled(true);
+        return true;
     default:
         return false;
     }
@@ -2016,14 +2020,14 @@ AAction MainWindow::manualMenuItem_Click(const Control& sender, const REArgs& ar
         L"• Preview window: Tools → Preview in separate window opens a movable second window; use F11 to toggle full-screen.\n"
         L"• Audio controls: Keep/remove audio and configure cross-fade for segment transitions.\n"
         L"• Project files: Save and reopen .llvc projects with timeline state.\n"
-        L"• Export: Render a lossless cut based on your selected ranges (auto-adjusting to proper cut points if necessary).\n\n"
+        L"• Export: Render a lossless cut based on your selected ranges (auto-adjusting to proper cut points if necessary). Use F7 as a shortcut.\n\n"
         L"Usage workflow:\n"
         L"1) File → Load video (or drag and drop a supported file).\n"
         L"2) Right-click to place boundary markers around scenes you may want to remove.\n"
         L"3) Reevaluate cut markers to land on proper RAP frames.\n"
         L"4) Ctrl+Left-Click scene blocks to toggle which scenes are cut (dark = cut, clear = kept).\n"
         L"5) Optionally adjust Keep audio and Audio cross-fade settings, then preview playback.\n"
-        L"6) Use File → Save project, then File → Export video to generate the final cut.");
+        L"6) Use File → Save project, then File → Export video (or press F7) to generate the final cut.");
 }
 
 AAction MainWindow::aboutMenuItem_Click(const Control&, const REArgs&){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -2465,6 +2465,10 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
     uint32_t allSamplesIndependent{};
     uint32_t maxKeyFrameSpacing{};
     const auto sourceIsAvi{isAviPath(filePath)};
+    wstring lowerPath{filePath};
+    transform(lowerPath.begin(), lowerPath.end(), lowerPath.begin(), ::towlower);
+    const auto sourceIsMp4{lowerPath.size() >= 4 && lowerPath.substr(lowerPath.size() - 4) == L".mp4"};
+    const auto sourceIsMov{lowerPath.size() >= 4 && lowerPath.substr(lowerPath.size() - 4) == L".mov"};
 
     for(DWORD streamIndex{0};; ++streamIndex){
         com_ptr<IMFMediaType> type;
@@ -2534,13 +2538,17 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
     }
 
     if(videoStreamIndex != invalidStreamIndex){
-        if(auto bestVideoType{chooseBestNativeVideoMediaType(reader, videoStreamIndex)}){
-            if(sourceIsAvi){
-                bestVideoType = aviNativeH264Type;
-            }
+        vector<GUID> allowedVideoSubtypes;
+        if(sourceIsMp4 || sourceIsMov){
+            allowedVideoSubtypes = {MFVideoFormat_H264, MFVideoFormat_HEVC, MFVideoFormat_H265};
+        }
+
+        if(auto bestVideoType{sourceIsAvi ? aviNativeH264Type : chooseBestNativeVideoMediaTypeForSubtypes(reader, videoStreamIndex, allowedVideoSubtypes)}){
             (void)reader->SetCurrentMediaType(videoStreamIndex, nullptr, bestVideoType.get());
 
             MFGetAttributeSize(bestVideoType.get(), MF_MT_FRAME_SIZE, &width, &height);
+
+            check_hresult(bestVideoType->GetGUID(MF_MT_SUBTYPE, &videoSubtype));
             MFGetAttributeRatio(bestVideoType.get(), MF_MT_FRAME_RATE, &fpsNum, &fpsDen);
             (void)bestVideoType->GetUINT32(MF_MT_AVG_BITRATE, &videoBitrate);
             if(SUCCEEDED(bestVideoType->GetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, &allSamplesIndependent))){
@@ -2549,6 +2557,9 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
             if(SUCCEEDED(bestVideoType->GetUINT32(MF_MT_MAX_KEYFRAME_SPACING, &maxKeyFrameSpacing))){
                 result.maxKeyFrameSpacing = to_wstring(maxKeyFrameSpacing) + L" frames";
             }
+        }else if(sourceIsMp4 || sourceIsMov){
+            result.errorMessage = L"No stream-copy video media type found. Require H.264 or HEVC in MP4/MOV.";
+            return result;
         }
     }
 
@@ -2569,13 +2580,11 @@ MediaInspectionResult MainWindow::inspectMediaFile(const wstring& filePath){
         return result;
     }
 
-    wstring lowerPath{filePath};
-    transform(lowerPath.begin(), lowerPath.end(), lowerPath.begin(), ::towlower);
-    if(lowerPath.size() >= 4 && lowerPath.substr(lowerPath.size() - 4) == L".mp4"){
+    if(sourceIsMp4){
         result.container = L"MP4";
-    }else if(lowerPath.size() >= 4 && lowerPath.substr(lowerPath.size() - 4) == L".mov"){
+    }else if(sourceIsMov){
         result.container = L"MOV";
-    }else if(lowerPath.size() >= 4 && lowerPath.substr(lowerPath.size() - 4) == L".avi"){
+    }else if(sourceIsAvi){
         result.container = L"AVI";
     }else{
         result.errorMessage = L"Container not supported. Only MP4, MOV, and AVI (H.264 only) are allowed";

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -865,7 +865,7 @@ void MainWindow::timelineZoomSlider_ValueChanged(const Control&, const RBVArgs&)
     if(m_prj.videoFile() && m_timelineDurationSeconds > 0){
         renderTimelineAsync();
     }
-    //ensureCurrentTimelineCursorVisible(); XXX: for some reason this line causes a terminating exception
+    ensureCurrentTimelineCursorVisible();
     updateWindowTitle();
     tryFocusTimelineCanvas(FocusState::Programmatic);
 }
@@ -1185,6 +1185,10 @@ void MainWindow::seekTimelineToCanvasX(double pointerX){
 
 void MainWindow::ensureTimelineCursorVisible(double cursorLeft){
     const auto scrollViewer{TimelineScrollViewer()};
+    if(!scrollViewer || !TimelineCanvas()){
+        return;
+    }
+
     const auto currentOffset{scrollViewer.HorizontalOffset()};
     const auto viewportWidth{scrollViewer.ViewportWidth()};
 
@@ -1207,6 +1211,10 @@ void MainWindow::ensureTimelineCursorVisible(double cursorLeft){
 }
 
 void MainWindow::ensureCurrentTimelineCursorVisible(){
+    if(!TimelineCursor() || !TimelineScrollViewer() || !TimelineCanvas()){
+        return;
+    }
+
     const auto cursorLeft{Controls::Canvas::GetLeft(TimelineCursor())};
     ensureTimelineCursorVisible(cursorLeft);
     syncTimelineHorizontalScrollBar();

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -920,6 +920,10 @@ void MainWindow::audioCrossfadeComboBox_SelectionChanged(const Control&, const C
 }
 
 void MainWindow::audioVolumeSlider_ValueChanged(const Control&, const RBVArgs& args){
+    if(!m_player){
+        return;
+    }
+
     if(m_isApplyingUndoRedoState){
         return;
     }
@@ -2407,6 +2411,10 @@ void MainWindow::clearErrorMessage(){
 }
 
 void MainWindow::refreshStatusInfoSection(){
+    if(!InfoText()){
+        return;
+    }
+
     const auto outputDuration100ns{m_prj.outputDuration100ns()};
     wstring text{L"Estimated output: "};
     text += formatTimelineDurationText(outputDuration100ns);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -2873,7 +2873,7 @@ void MainWindow::applyAudioSettingsToPlayer(){
 
     const auto allowAudio{sourceHasAudio() && m_prj.keepAudio()};
     m_player.IsMuted(!allowAudio);
-    m_player.Volume(allowAudio ? clamp(m_prj.audioVolumePct() / 100.0, 0.0, 1.0) : 0.0);
+    m_player.Volume(allowAudio ? clamp(m_prj.audioVolumePct() / 100.0, 0.0, 2.5) : 0.0);
 }
 
 void MainWindow::updateAudioUiAndPlaybackState(){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -2873,7 +2873,9 @@ void MainWindow::applyAudioSettingsToPlayer(){
 
     const auto allowAudio{sourceHasAudio() && m_prj.keepAudio()};
     m_player.IsMuted(!allowAudio);
-    m_player.Volume(allowAudio ? clamp(m_prj.audioVolumePct() / 100.0, 0.0, 2.5) : 0.0);
+    // WinRT MediaPlayer preview volume is 0..1, so preview boost is capped at 100%.
+    // Export path still applies full configured gain above 100%.
+    m_player.Volume(allowAudio ? clamp(m_prj.audioVolumePct() / 100.0, 0.0, 1.0) : 0.0);
 }
 
 void MainWindow::updateAudioUiAndPlaybackState(){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -723,6 +723,8 @@ bool MainWindow::isExportInProgressForClosePrompt() const{
 
 void MainWindow::requestExportCancel(){
     m_cancelExportRequested = true;
+    setStatusMessage(L"Canceling export...");
+    setOperationInProgress(false);
 }
 
 void MainWindow::onWindowActivated(const Control&, const WAVArgs& args){
@@ -2410,6 +2412,7 @@ void MainWindow::cancelExportButton_Click(const Control&, const REArgs&){
 
     m_cancelExportRequested = true;
     setStatusMessage(L"Canceling export...");
+    setOperationInProgress(false);
 }
 
 AAction MainWindow::showOptionsDialogAsync(){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -444,8 +444,21 @@ bool isControlModifierActive(VirtualKeyModifiers modifiers){
     return (ctrlState & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down;
 }
 
+wstring audioVolumeGlyph(bool keepAudio, int32_t volumePct){
+    if(!keepAudio || volumePct <= 0){
+        return L"\xD83D\xDD07"; // U+1F507
+    }
+    if(volumePct < 75){
+        return L"\xD83D\xDD08"; // U+1F508
+    }
+    if(volumePct > 100){
+        return L"\xD83D\xDD0A"; // U+1F50A
+    }
+    return L"\xD83D\xDD09"; // U+1F509
+}
+
 bool MainWindow::isSameUndoRedoState(const UndoRedoState& a, const UndoRedoState& b) const{
-    if(a.keepAudio != b.keepAudio || a.audioCrossfadeMs != b.audioCrossfadeMs || a.cutScenes != b.cutScenes || a.frameIndex.size() != b.frameIndex.size()){
+    if(a.keepAudio != b.keepAudio || a.audioCrossfadeMs != b.audioCrossfadeMs || a.audioVolumePct != b.audioVolumePct || a.cutScenes != b.cutScenes || a.frameIndex.size() != b.frameIndex.size()){
         return false;
     }
 
@@ -466,6 +479,7 @@ MainWindow::UndoRedoState MainWindow::captureUndoRedoState() const{
         .cutScenes = m_prj.cutScenes(),
         .keepAudio = m_prj.keepAudio(),
         .audioCrossfadeMs = m_prj.audioXfadeMs(),
+        .audioVolumePct = m_prj.audioVolumePct(),
     };
 }
 
@@ -502,6 +516,7 @@ bool MainWindow::applyUndoRedoState(const UndoRedoState& state, bool fromUndo){
     m_prj.cutScenes(state.cutScenes);
     m_prj.keepAudio(state.keepAudio);
     m_prj.audioXfadeMs(state.audioCrossfadeMs);
+    m_prj.audioVolumePct(state.audioVolumePct);
 
     syncAudioCrossfadeComboSelection();
     updateAudioUiAndPlaybackState();
@@ -900,6 +915,18 @@ void MainWindow::audioCrossfadeComboBox_SelectionChanged(const Control&, const C
     }
 
     syncAudioCrossfadeComboSelection();
+    updateWindowTitle();
+    refreshStatusInfoSection();
+}
+
+void MainWindow::audioVolumeSlider_ValueChanged(const Control&, const RBVArgs& args){
+    if(m_isApplyingUndoRedoState){
+        return;
+    }
+
+    (void)pushUndoStateIfChanged();
+    m_prj.audioVolumePct(static_cast<int32_t>(lround(args.NewValue())));
+    updateAudioUiAndPlaybackState();
     updateWindowTitle();
     refreshStatusInfoSection();
 }
@@ -2838,6 +2865,7 @@ void MainWindow::applyAudioSettingsToPlayer(){
 
     const auto allowAudio{sourceHasAudio() && m_prj.keepAudio()};
     m_player.IsMuted(!allowAudio);
+    m_player.Volume(allowAudio ? clamp(m_prj.audioVolumePct() / 100.0, 0.0, 1.0) : 0.0);
 }
 
 void MainWindow::updateAudioUiAndPlaybackState(){
@@ -2858,6 +2886,9 @@ void MainWindow::updateAudioUiAndPlaybackState(){
     KeepAudioCheckBox().IsEnabled(hasAudio && !audioHardDisabled);
     KeepAudioCheckBox().IsChecked(box_value(hasAudio && !audioHardDisabled && m_prj.keepAudio()).as<IReference<bool>>());
     AudioCrossfadeComboBox().IsEnabled(hasAudio && !audioHardDisabled && m_prj.keepAudio());
+    AudioVolumeSlider().IsEnabled(hasAudio && !audioHardDisabled && m_prj.keepAudio());
+    AudioVolumeSlider().Value(static_cast<double>(m_prj.audioVolumePct()));
+    AudioVolumeIconText().Text(audioVolumeGlyph(hasAudio && !audioHardDisabled && m_prj.keepAudio(), m_prj.audioVolumePct()));
     m_isApplyingUndoRedoState = previousGuard;
     applyAudioSettingsToPlayer();
 }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -26,6 +26,8 @@
 #include <mfobjects.h>
 #include <mfreadwrite.h>
 
+#include <commctrl.h>
+
 #include <microsoft.ui.xaml.window.h>
 #include <propkey.h>
 #include <propsys.h>
@@ -50,6 +52,7 @@ import llvc.Export;
 import llvc.Utils;
 
 #pragma comment(lib, "Shell32.lib")
+#pragma comment(lib, "Comctl32.lib")
 
 using namespace std;
 using namespace winrt;
@@ -87,6 +90,27 @@ using TS = MainWindow::TS;
 constexpr auto W_POS_L{L"WindowLeft"};
 
 namespace{
+
+LRESULT CALLBACK MainWindowSubclassProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, UINT_PTR, DWORD_PTR refData){
+    auto* self{reinterpret_cast<MainWindow*>(refData)};
+    if(!self){
+        return DefSubclassProc(hwnd, msg, wParam, lParam);
+    }
+
+    if(msg == WM_CLOSE && self->isExportInProgressForClosePrompt()){
+        const auto choice{MessageBoxW(hwnd,
+            L"An export is still in progress. Cancel export and close the app?",
+            L"Export in progress",
+            MB_ICONWARNING | MB_YESNO | MB_DEFBUTTON2)};
+        if(choice != IDYES){
+            return 0;
+        }
+
+        self->requestExportCancel();
+    }
+
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
+}
 
 constexpr int64_t HNS_PER_SECOND{10'000'000LL};
 
@@ -536,6 +560,8 @@ MainWindow::MainWindow(){
     setVideoDetailsPanelExpanded(false);
 
     restoreWindowPlacement();
+    const auto hwnd{getWindowHandle()};
+    SetWindowSubclass(hwnd, MainWindowSubclassProc, 1, reinterpret_cast<DWORD_PTR>(this));
     loadAppSettings();
     Closed({this, &MainWindow::onClosed});
     m_mainWindowActivatedRevoker = Activated(auto_revoke, {this, &MainWindow::onWindowActivated});
@@ -663,6 +689,9 @@ void MainWindow::saveWindowPlacement() const{
 void MainWindow::onClosed(const Control&, const WEArgs&){
     m_isClosing = true;
 
+    const auto hwnd{getWindowHandle()};
+    RemoveWindowSubclass(hwnd, MainWindowSubclassProc, 1);
+
     if(m_positionTimer){
         m_positionTimer.Stop();
     }
@@ -686,6 +715,14 @@ void MainWindow::onClosed(const Control&, const WEArgs&){
 
     saveWindowPlacement();
     saveAppSettings();
+}
+
+bool MainWindow::isExportInProgressForClosePrompt() const{
+    return m_isExportInProgress;
+}
+
+void MainWindow::requestExportCancel(){
+    m_cancelExportRequested = true;
 }
 
 void MainWindow::onWindowActivated(const Control&, const WAVArgs& args){
@@ -2357,11 +2394,22 @@ void MainWindow::setOperationInProgress(bool active, bool indeterminate){
         OperationProgressBar().IsIndeterminate(false);
     }
     OperationProgressBar().Visibility(active ? Visibility::Visible : Visibility::Collapsed);
+    CancelExportButton().Visibility((active && m_isExportInProgress) ? Visibility::Visible : Visibility::Collapsed);
+    CancelExportButton().IsEnabled(active && m_isExportInProgress);
 }
 
 void MainWindow::setOperationProgress(double percent){
     OperationProgressBar().IsIndeterminate(false);
     OperationProgressBar().Value(clamp(percent, 0.0, 100.0));
+}
+
+void MainWindow::cancelExportButton_Click(const Control&, const REArgs&){
+    if(!m_isExportInProgress){
+        return;
+    }
+
+    m_cancelExportRequested = true;
+    setStatusMessage(L"Canceling export...");
 }
 
 AAction MainWindow::showOptionsDialogAsync(){

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -3,6 +3,7 @@
 #include "MainWindow.g.h"
 
 #include <cstdint>
+#include <atomic>
 #include <functional>
 #include <optional>
 #include <string>
@@ -124,6 +125,9 @@ struct MainWindow: MainWindowT<MainWindow>{
     void onWindowActivated(const Control& sender, const WAVArgs& args);
     void onNaturalDurationChanged(const MPSession& sender, const Control& args);
     void onPositionTimerTick(const Control& sender, const Control& args);
+    void cancelExportButton_Click(const Control& sender, const REArgs& args);
+    bool isExportInProgressForClosePrompt() const;
+    void requestExportCancel();
 
 private:
     MP m_player{nullptr};
@@ -139,6 +143,7 @@ private:
     hstring m_projectPath{};
     bool m_isClosing{false};
     bool m_isExportInProgress{false};
+    std::atomic_bool m_cancelExportRequested{false};
     bool m_resumeTimelineRenderAfterExport{false};
     bool m_isTimelineDragging{false};
     bool m_timelineDragMoved{false};

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -79,6 +79,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     void timelineZoomSlider_PointerWheelChanged(const Control& sender, const PREArgs& args);
     void keepAudioCheckBox_Changed(const Control& sender, const REArgs& args);
     void audioCrossfadeComboBox_SelectionChanged(const Control& sender, const Control& args);
+    void audioVolumeSlider_ValueChanged(const Control& sender, const RBVArgs& args);
     void timelineHorizontalScrollBar_ValueChanged(const Control& sender, const RBVArgs& args);
     void timelineScrollViewer_ViewChanged(const Control& sender, const SVVCArgs& args);
     void timelineScrollViewer_SizeChanged(const Control& sender, const SCArgs& args);
@@ -175,6 +176,7 @@ private:
         vector<uint32_t> cutScenes{};
         bool keepAudio{true};
         int32_t audioCrossfadeMs{0};
+        int32_t audioVolumePct{100};
     };
     vector<UndoRedoState> m_undoStack{};
     vector<UndoRedoState> m_redoStack{};

--- a/Win/llvc/Project.ixx
+++ b/Win/llvc/Project.ixx
@@ -226,7 +226,7 @@ void Project::audioXfadeMs(int32_t valueMs){
 }
 
 void Project::audioVolumePct(int32_t valuePct){
-    const auto clamped{clamp(valuePct, 0, 175)};
+    const auto clamped{clamp(valuePct, 0, 250)};
     const auto rounded{(clamped / 5) * 5};
     m_isDirty = (m_isDirty || m_audioVolumePct != rounded);
     m_audioVolumePct = rounded;

--- a/Win/llvc/Project.ixx
+++ b/Win/llvc/Project.ixx
@@ -226,7 +226,7 @@ void Project::audioXfadeMs(int32_t valueMs){
 }
 
 void Project::audioVolumePct(int32_t valuePct){
-    const auto clamped{clamp(valuePct, 0, 150)};
+    const auto clamped{clamp(valuePct, 0, 175)};
     const auto rounded{(clamped / 5) * 5};
     m_isDirty = (m_isDirty || m_audioVolumePct != rounded);
     m_audioVolumePct = rounded;

--- a/Win/llvc/Project.ixx
+++ b/Win/llvc/Project.ixx
@@ -35,6 +35,7 @@ struct Project final{
     void setZoom(double v);
     void keepAudio(bool v);
     void audioXfadeMs(int32_t valueMs);
+    void audioVolumePct(int32_t valuePct);
     void frameIndex(const vector<IndexedFrameSample>& v);
     void cutScenes(const vector<uint32_t>& v);
 
@@ -42,6 +43,7 @@ struct Project final{
     inline auto  zoom()         const{ return m_zoom; }
     inline bool  keepAudio()    const{ return m_keepAudio; }
     inline auto  audioXfadeMs() const{ return m_audioCrossfadeMs; }
+    inline auto  audioVolumePct() const{ return m_audioVolumePct; }
     inline auto& frameIndex()   const{ return m_frameIndex; }
     inline auto& selKeyFrames() const{ return m_selectedKeyFrames; }
     inline auto& cutScenes()    const{ return m_cutScenes; }
@@ -72,6 +74,7 @@ private:
     double m_zoom{4};
     bool m_keepAudio{true};
     int32_t m_audioCrossfadeMs{0};
+    int32_t m_audioVolumePct{100};
     vector<IndexedFrameSample> m_frameIndex{};
     vector<uint32_t> m_selectedKeyFrames{};
     vector<uint32_t> m_cutScenes{};
@@ -94,6 +97,7 @@ constexpr auto P_FILE_PATH{L"file_path"};
 constexpr auto P_STORYLINE_ZOOM{L"storyline_zoom"};
 constexpr auto P_KEEP_AUDIO{L"keep_audio"};
 constexpr auto P_AUDIO_CROSSFADE_MS{L"audio_crossfade_ms"};
+constexpr auto P_AUDIO_VOLUME_PCT{L"audio_volume_pct"};
 constexpr auto P_CUT_MARKERS{L"cut_markers"};
 constexpr auto P_CUT_SCENES{L"cut_scenes"};
 
@@ -102,6 +106,7 @@ struct LoadedProjectData{
     wstring zoomLevel;
     wstring keepAudio;
     wstring audioXfadeMs;
+    wstring audioVolumePct;
     wstring markers;
     wstring cutScenes;
 };
@@ -130,6 +135,7 @@ LoadedProjectData _parseProjectLines(const Windows::Foundation::Collections::IVe
         if(key == P_CUT_SCENES)         { data.cutScenes      = value; } else
         if(key == P_KEEP_AUDIO)         { data.keepAudio      = value; } else
         if(key == P_AUDIO_CROSSFADE_MS) { data.audioXfadeMs   = value; }
+        if(key == P_AUDIO_VOLUME_PCT)   { data.audioVolumePct = value; }
     }
 
     return data;
@@ -149,6 +155,7 @@ Project::AAction Project::open(const SFile& file){
     m_loadedFile = co_await StorageFile::GetFileFromPathAsync(projectData.loadedFilePath);
     m_keepAudio = projectData.keepAudio != L"0";
     try{ audioXfadeMs(stoi(projectData.audioXfadeMs)); } catch(...){}
+    try{ audioVolumePct(stoi(projectData.audioVolumePct)); } catch(...){}
     try{ m_zoom = stod(projectData.zoomLevel); } catch(...){}
 
     m_frameIndex = std::move(_parseKeyframeVector(projectData.markers));
@@ -177,6 +184,7 @@ Project::AAction Project::save(const SFile& file){
     lines.emplace_back(wstring(P_STORYLINE_ZOOM) + L"=" + to_wstring(m_zoom));
     lines.emplace_back(wstring(P_KEEP_AUDIO) + L"=" + wstring(m_keepAudio ? L"1" : L"0"));
     lines.emplace_back(wstring(P_AUDIO_CROSSFADE_MS) + L"=" + to_wstring(m_audioCrossfadeMs));
+    lines.emplace_back(wstring(P_AUDIO_VOLUME_PCT) + L"=" + to_wstring(m_audioVolumePct));
     lines.emplace_back(wstring(P_CUT_MARKERS) + L"=" + _serializeCutMarkers());
     lines.emplace_back(wstring(P_CUT_SCENES) + L"=" + serializeIndexList(m_cutScenes));
 
@@ -206,7 +214,7 @@ void Project::keepAudio(bool v){
     m_keepAudio = v;
 }
 
-constexpr array<int32_t, 8> AUDIO_CROSSFADE_PRESETS_MS{{0, 50, 100, 250, 500, 750, 1000}};
+constexpr array<int32_t, 10> AUDIO_CROSSFADE_PRESETS_MS{{0, 50, 100, 250, 500, 750, 1000, 2000, 5000}};
 
 void Project::audioXfadeMs(int32_t valueMs){
     const auto nearest{min_element(AUDIO_CROSSFADE_PRESETS_MS.begin(), AUDIO_CROSSFADE_PRESETS_MS.end(), [valueMs](auto a, auto b){
@@ -215,6 +223,13 @@ void Project::audioXfadeMs(int32_t valueMs){
     const auto v{nearest == AUDIO_CROSSFADE_PRESETS_MS.end() ? 0 : *nearest};
     m_isDirty = (m_isDirty || m_audioCrossfadeMs != v);
     m_audioCrossfadeMs = v;
+}
+
+void Project::audioVolumePct(int32_t valuePct){
+    const auto clamped{clamp(valuePct, 0, 150)};
+    const auto rounded{(clamped / 5) * 5};
+    m_isDirty = (m_isDirty || m_audioVolumePct != rounded);
+    m_audioVolumePct = rounded;
 }
 
 void Project::frameIndex(const vector<IndexedFrameSample>& v){
@@ -549,13 +564,15 @@ std::optional<size_t> Project::_sceneIndexAtTime100ns(int64_t time100ns) const{
 
 wstring Project::_buildProjectSnapshot() const{
     const auto snapshot{std::format(
-        L"{}={:.15g}\n{}={}\n{}={}\n{}={}\n{}={}\n",
+        L"{}={:.15g}\n{}={}\n{}={}\n{}={}\n{}={}\n{}={}\n",
         P_STORYLINE_ZOOM,
         m_zoom,
         P_KEEP_AUDIO,
         m_keepAudio ? 1 : 0,
         P_AUDIO_CROSSFADE_MS,
         m_audioCrossfadeMs,
+        P_AUDIO_VOLUME_PCT,
+        m_audioVolumePct,
         P_CUT_MARKERS,
         _serializeCutMarkers(),
         P_CUT_SCENES,


### PR DESCRIPTION
### Motivation
- Ensure a user-selected `0 ms` crossfade actually disables overlap instead of defaulting to 100 ms and remove the perceptual dip caused by the previous linear fade math.
- Prevent O(file-length) RAM usage when exporting audio by avoiding accumulation of the entire mixed PCM in memory.
- Make stream-copy decisions for MP4/MOV explicitly require supported subtypes (H.264/HEVC) and provide clearer AVI H.264 failure messages.

### Description
- Replace the implicit 100 ms fallback with explicit handling so `crossfadeMs <= 0` yields `fadeFrames = 0` and overlap mixing is skipped. (New logic in `writeMixedAudioForKeepRanges` / fadeFrames calculation.)
- Update overlap weighting to deterministic endpoints and equal-power blending by using `t = frame/(overlapFrames-1)` and `fadeOut = cos(t * π/2), fadeIn = sin(t * π/2)`, with a deterministic branch for `overlapFrames == 1`. (In `appendCrossfadedAudioSegment`.)
- Stream audio to the sink writer instead of building a full `vector<float>` for the entire output: introduce `writePcmAudioFramesToWriter` and `writeMixedAudioForKeepRanges` which keep only a rolling tail buffer for fades and immediately write flushed PCM to the `IMFSinkWriter`. (Replaced `buildMixedAudioForKeepRanges` + `writePcmAudioToWriter` callsites.)
- Add `chooseBestNativeVideoMediaTypeForSubtypes` to restrict native media type selection to an allowed set of subtypes and use it for MP4/MOV stream-copy code paths (H.264/HEVC only) to fail early and clearly when no suitable stream-copy type is available. (Changes in `Export.ixx`, `MainWindow.Export.cpp`, and `MainWindow.xaml.cpp`.)
- Improve AVI H.264 failure messaging by splitting the cases into: missing codec configuration (SPS/PPS) in source (asking user to convert to MP4) and system mux capability failure when configuring the writer (different error text). (In `MainWindow.Export.cpp`.)

### Testing
- Ran `git diff --check` to ensure no whitespace/diff issues; it passed. (success)
- Used `rg`/search to verify the old full-buffer mixing symbols (`buildMixedAudioForKeepRanges`, `writePcmAudioToWriter`) were removed from active callsites and the new streaming functions are used; verification succeeded. (success)
- Committed the changes locally; commit completed successfully. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1efe992888333bf55b659389ddb3c)