### PR TITLE
Handle .llvc/.mp4/.mov/.avi launch args at startup

### DIFF
--- a/Win/llvc/App.xaml.cpp
+++ b/Win/llvc/App.xaml.cpp
@@ -29,8 +29,8 @@ App::App(){
 /// Invoked when the application is launched.
 /// </summary>
 /// <param name="e">Details about the launch request and process.</param>
-void App::OnLaunched([[maybe_unused]] LaunchActivatedEventArgs const& e){
-    window = make<MainWindow>();
+void App::OnLaunched(LaunchActivatedEventArgs const& e){
+    window = make<MainWindow>(e.Arguments());
     window.Activate();
 }
 

--- a/Win/llvc/App.xaml.cpp
+++ b/Win/llvc/App.xaml.cpp
@@ -4,8 +4,22 @@
 
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
+using namespace Windows::ApplicationModel::Activation;
+using namespace Windows::Storage;
 
 namespace winrt::llvc::implementation{
+
+namespace{
+
+void showLaunchDebugPopup(const std::wstring& message){
+#if defined(_DEBUG)
+    ::MessageBoxW(nullptr, message.c_str(), L"llvc launch debug", MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
+#else
+    (void)message;
+#endif
+}
+
+}
 
 /// <summary>
 /// Initializes the singleton application object.  This is the first line of authored code
@@ -30,7 +44,23 @@ App::App(){
 /// </summary>
 /// <param name="e">Details about the launch request and process.</param>
 void App::OnLaunched(LaunchActivatedEventArgs const& e){
+    showLaunchDebugPopup(L"OnLaunched arguments: " + std::wstring(e.Arguments().c_str()));
+
     window = make<MainWindow>(e.Arguments());
+    window.Activate();
+}
+
+void App::OnFileActivated(FileActivatedEventArgs const& e){
+    std::wstring launchPath{};
+    if(e.Files().Size() > 0){
+        if(const auto file{e.Files().GetAt(0).try_as<StorageFile>()}){
+            launchPath = file.Path().c_str();
+        }
+    }
+
+    showLaunchDebugPopup(L"OnFileActivated path: " + launchPath);
+
+    window = make<MainWindow>(winrt::hstring(launchPath));
     window.Activate();
 }
 

--- a/Win/llvc/App.xaml.cpp
+++ b/Win/llvc/App.xaml.cpp
@@ -3,6 +3,7 @@
 #include "MainWindow.xaml.h"
 
 #include <winrt/Windows.Storage.h>
+#include <shellapi.h>
 
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
@@ -17,6 +18,25 @@ void showLaunchDebugPopup(const std::wstring& message){
 #else
     (void)message;
 #endif
+}
+
+hstring getLaunchTargetFromOnLaunched(Microsoft::UI::Xaml::LaunchActivatedEventArgs const& e){
+    if(!e.Arguments().empty()){
+        return e.Arguments();
+    }
+
+    int argc{};
+    wchar_t** argv{::CommandLineToArgvW(::GetCommandLineW(), &argc)};
+    if(argc <= 1 || !argv){
+        if(argv){
+            ::LocalFree(argv);
+        }
+        return {};
+    }
+
+    const hstring target{argv[1]};
+    ::LocalFree(argv);
+    return target;
 }
 
 }
@@ -44,9 +64,13 @@ App::App(){
 /// </summary>
 /// <param name="e">Details about the launch request and process.</param>
 void App::OnLaunched(Microsoft::UI::Xaml::LaunchActivatedEventArgs const& e){
-    showLaunchDebugPopup(L"OnLaunched arguments: " + std::wstring(e.Arguments().c_str()));
+    const auto launchTarget{getLaunchTargetFromOnLaunched(e)};
 
-    window = make<MainWindow>(e.Arguments());
+    showLaunchDebugPopup(
+        L"OnLaunched arguments: [" + std::wstring(e.Arguments().c_str()) +
+        L"]\nCommand line target fallback: [" + std::wstring(launchTarget.c_str()) + L"]");
+
+    window = make<MainWindow>(launchTarget);
     window.Activate();
 }
 

--- a/Win/llvc/App.xaml.cpp
+++ b/Win/llvc/App.xaml.cpp
@@ -2,10 +2,10 @@
 #include "App.xaml.h"
 #include "MainWindow.xaml.h"
 
+#include <winrt/Windows.Storage.h>
+
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
-using namespace Windows::ApplicationModel::Activation;
-using namespace Windows::Storage;
 
 namespace winrt::llvc::implementation{
 
@@ -43,17 +43,17 @@ App::App(){
 /// Invoked when the application is launched.
 /// </summary>
 /// <param name="e">Details about the launch request and process.</param>
-void App::OnLaunched(LaunchActivatedEventArgs const& e){
+void App::OnLaunched(Microsoft::UI::Xaml::LaunchActivatedEventArgs const& e){
     showLaunchDebugPopup(L"OnLaunched arguments: " + std::wstring(e.Arguments().c_str()));
 
     window = make<MainWindow>(e.Arguments());
     window.Activate();
 }
 
-void App::OnFileActivated(FileActivatedEventArgs const& e){
+void App::OnFileActivated(winrt::Windows::ApplicationModel::Activation::FileActivatedEventArgs const& e){
     std::wstring launchPath{};
     if(e.Files().Size() > 0){
-        if(const auto file{e.Files().GetAt(0).try_as<StorageFile>()}){
+        if(const auto file{e.Files().GetAt(0).try_as<winrt::Windows::Storage::StorageFile>()}){
             launchPath = file.Path().c_str();
         }
     }

--- a/Win/llvc/App.xaml.cpp
+++ b/Win/llvc/App.xaml.cpp
@@ -12,14 +12,6 @@ namespace winrt::llvc::implementation{
 
 namespace{
 
-void showLaunchDebugPopup(const std::wstring& message){
-#if defined(_DEBUG)
-    ::MessageBoxW(nullptr, message.c_str(), L"llvc launch debug", MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
-#else
-    (void)message;
-#endif
-}
-
 hstring getLaunchTargetFromOnLaunched(Microsoft::UI::Xaml::LaunchActivatedEventArgs const& e){
     if(!e.Arguments().empty()){
         return e.Arguments();
@@ -66,10 +58,6 @@ App::App(){
 void App::OnLaunched(Microsoft::UI::Xaml::LaunchActivatedEventArgs const& e){
     const auto launchTarget{getLaunchTargetFromOnLaunched(e)};
 
-    showLaunchDebugPopup(
-        L"OnLaunched arguments: [" + std::wstring(e.Arguments().c_str()) +
-        L"]\nCommand line target fallback: [" + std::wstring(launchTarget.c_str()) + L"]");
-
     window = make<MainWindow>(launchTarget);
     window.Activate();
 }
@@ -81,8 +69,6 @@ void App::OnFileActivated(winrt::Windows::ApplicationModel::Activation::FileActi
             launchPath = file.Path().c_str();
         }
     }
-
-    showLaunchDebugPopup(L"OnFileActivated path: " + launchPath);
 
     window = make<MainWindow>(winrt::hstring(launchPath));
     window.Activate();

--- a/Win/llvc/App.xaml.h
+++ b/Win/llvc/App.xaml.h
@@ -8,6 +8,7 @@ struct App: AppT<App>{
     App();
 
     void OnLaunched(Microsoft::UI::Xaml::LaunchActivatedEventArgs const&);
+    void OnFileActivated(winrt::Windows::ApplicationModel::Activation::FileActivatedEventArgs const&);
 
 private:
     winrt::Microsoft::UI::Xaml::Window window{ nullptr };

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1745,7 +1745,6 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
         root.IsTabStop(true);
         root.PreviewKeyDown(detachedKeyHandler);
         root.KeyDown(detachedKeyHandler);
-        root.DoubleTapped(detachedDoubleTapHandler);
 
         root.Children().Append(detachedPreview);
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -114,14 +114,6 @@ LRESULT CALLBACK MainWindowSubclassProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
 
 constexpr int64_t HNS_PER_SECOND{10'000'000LL};
 
-void showLaunchTracePopup(const std::wstring& message){
-#if defined(_DEBUG)
-    ::MessageBoxW(nullptr, message.c_str(), L"llvc launch trace", MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
-#else
-    (void)message;
-#endif
-}
-
 bool isAviPath(const wstring& filePath){
     if(filePath.size() < 4){
         return false;
@@ -603,17 +595,13 @@ MainWindow::MainWindow(const hstring& launchArguments){
 }
 
 AAction MainWindow::openFromLaunchArgumentsAsync(const hstring& arguments){
-    showLaunchTracePopup(L"MainWindow::openFromLaunchArgumentsAsync raw argument: " + std::wstring(arguments.c_str()));
-
     wstring launchPath{arguments.c_str()};
     if(launchPath.empty()){
-        showLaunchTracePopup(L"Launch argument is empty (nothing to open)");
         co_return;
     }
 
     const auto begin{launchPath.find_first_not_of(L" \t\r\n")};
     if(begin == wstring::npos){
-        showLaunchTracePopup(L"Launch argument only contained whitespace");
         co_return;
     }
     const auto end{launchPath.find_last_not_of(L" \t\r\n")};
@@ -623,15 +611,11 @@ AAction MainWindow::openFromLaunchArgumentsAsync(const hstring& arguments){
         launchPath = launchPath.substr(1, launchPath.size() - 2);
     }
 
-    showLaunchTracePopup(L"Normalized launch path: " + launchPath);
-
     wstring lowerExt{std::filesystem::path(launchPath).extension().wstring()};
     transform(lowerExt.begin(), lowerExt.end(), lowerExt.begin(), ::towlower);
-    showLaunchTracePopup(L"Detected extension: " + lowerExt);
 
     if(lowerExt != PROJECT_EXT && lowerExt != L".mp4" && lowerExt != L".mov" && lowerExt != L".avi"){
         setStatusMessage(L"Launch argument is not a supported media/project file");
-        showLaunchTracePopup(L"Extension not supported; aborting launch-open path");
         co_return;
     }
 
@@ -640,24 +624,17 @@ AAction MainWindow::openFromLaunchArgumentsAsync(const hstring& arguments){
         file = co_await SFile::GetFileFromPathAsync(launchPath);
     }catch(const winrt::hresult_error&){
         setStatusMessage(L"File from launch argument was not found");
-        showLaunchTracePopup(L"GetFileFromPathAsync failed for: " + launchPath);
         co_return;
     }
 
-    showLaunchTracePopup(L"StorageFile resolved: " + std::wstring(file.Path().c_str()));
-
     if(lowerExt == PROJECT_EXT){
-        showLaunchTracePopup(L"Detected .llvc project; calling openProjectFileAsync");
         co_await openProjectFileAsync(file);
-        showLaunchTracePopup(L"openProjectFileAsync finished");
         co_return;
     }
 
     m_prj.clearTimeline();
     clearUndoRedoHistory();
-    showLaunchTracePopup(L"Detected media file; calling loadVideoFileAsync");
     co_await loadVideoFileAsync(file);
-    showLaunchTracePopup(L"loadVideoFileAsync finished");
 }
 
 HWND MainWindow::getWindowHandle() const{

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1733,12 +1733,19 @@ bool MainWindow::setSeparatePreviewWindowOpen(bool open){
                 self->onSeparatePreviewWindowKeyDown(e);
             }
         }};
+        const auto detachedDoubleTapHandler{[weakSelf](const auto&, const auto&){
+            if(const auto self{weakSelf.get()}){
+                (void)self->toggleSeparatePreviewFullscreen();
+            }
+        }};
         detachedPreview.PreviewKeyDown(detachedKeyHandler);
         detachedPreview.KeyDown(detachedKeyHandler);
+        detachedPreview.DoubleTapped(detachedDoubleTapHandler);
 
         root.IsTabStop(true);
         root.PreviewKeyDown(detachedKeyHandler);
         root.KeyDown(detachedKeyHandler);
+        root.DoubleTapped(detachedDoubleTapHandler);
 
         root.Children().Append(detachedPreview);
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -114,6 +114,14 @@ LRESULT CALLBACK MainWindowSubclassProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
 
 constexpr int64_t HNS_PER_SECOND{10'000'000LL};
 
+void showLaunchTracePopup(const std::wstring& message){
+#if defined(_DEBUG)
+    ::MessageBoxW(nullptr, message.c_str(), L"llvc launch trace", MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
+#else
+    (void)message;
+#endif
+}
+
 bool isAviPath(const wstring& filePath){
     if(filePath.size() < 4){
         return false;
@@ -595,13 +603,17 @@ MainWindow::MainWindow(const hstring& launchArguments){
 }
 
 AAction MainWindow::openFromLaunchArgumentsAsync(const hstring& arguments){
+    showLaunchTracePopup(L"MainWindow::openFromLaunchArgumentsAsync raw argument: " + std::wstring(arguments.c_str()));
+
     wstring launchPath{arguments.c_str()};
     if(launchPath.empty()){
+        showLaunchTracePopup(L"Launch argument is empty (nothing to open)");
         co_return;
     }
 
     const auto begin{launchPath.find_first_not_of(L" \t\r\n")};
     if(begin == wstring::npos){
+        showLaunchTracePopup(L"Launch argument only contained whitespace");
         co_return;
     }
     const auto end{launchPath.find_last_not_of(L" \t\r\n")};
@@ -611,11 +623,15 @@ AAction MainWindow::openFromLaunchArgumentsAsync(const hstring& arguments){
         launchPath = launchPath.substr(1, launchPath.size() - 2);
     }
 
+    showLaunchTracePopup(L"Normalized launch path: " + launchPath);
+
     wstring lowerExt{std::filesystem::path(launchPath).extension().wstring()};
     transform(lowerExt.begin(), lowerExt.end(), lowerExt.begin(), ::towlower);
+    showLaunchTracePopup(L"Detected extension: " + lowerExt);
 
     if(lowerExt != PROJECT_EXT && lowerExt != L".mp4" && lowerExt != L".mov" && lowerExt != L".avi"){
         setStatusMessage(L"Launch argument is not a supported media/project file");
+        showLaunchTracePopup(L"Extension not supported; aborting launch-open path");
         co_return;
     }
 
@@ -624,17 +640,24 @@ AAction MainWindow::openFromLaunchArgumentsAsync(const hstring& arguments){
         file = co_await SFile::GetFileFromPathAsync(launchPath);
     }catch(const winrt::hresult_error&){
         setStatusMessage(L"File from launch argument was not found");
+        showLaunchTracePopup(L"GetFileFromPathAsync failed for: " + launchPath);
         co_return;
     }
 
+    showLaunchTracePopup(L"StorageFile resolved: " + std::wstring(file.Path().c_str()));
+
     if(lowerExt == PROJECT_EXT){
+        showLaunchTracePopup(L"Detected .llvc project; calling openProjectFileAsync");
         co_await openProjectFileAsync(file);
+        showLaunchTracePopup(L"openProjectFileAsync finished");
         co_return;
     }
 
     m_prj.clearTimeline();
     clearUndoRedoHistory();
+    showLaunchTracePopup(L"Detected media file; calling loadVideoFileAsync");
     co_await loadVideoFileAsync(file);
+    showLaunchTracePopup(L"loadVideoFileAsync finished");
 }
 
 HWND MainWindow::getWindowHandle() const{

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -556,7 +556,7 @@ bool MainWindow::redoLastEdit(){
     return applyUndoRedoState(next, false);
 }
 
-MainWindow::MainWindow(){
+MainWindow::MainWindow(const hstring& launchArguments){
     InitializeComponent();
 
     m_player = MediaPlayer();
@@ -588,6 +588,53 @@ MainWindow::MainWindow(){
     if(m_restorePreviewDetachedOnStartup){
         (void)setSeparatePreviewWindowOpen(true);
     }
+
+    if(!launchArguments.empty()){
+        (void)openFromLaunchArgumentsAsync(launchArguments);
+    }
+}
+
+AAction MainWindow::openFromLaunchArgumentsAsync(const hstring& arguments){
+    wstring launchPath{arguments.c_str()};
+    if(launchPath.empty()){
+        co_return;
+    }
+
+    const auto begin{launchPath.find_first_not_of(L" \t\r\n")};
+    if(begin == wstring::npos){
+        co_return;
+    }
+    const auto end{launchPath.find_last_not_of(L" \t\r\n")};
+    launchPath = launchPath.substr(begin, end - begin + 1);
+
+    if(launchPath.size() >= 2 && launchPath.front() == L'"' && launchPath.back() == L'"'){
+        launchPath = launchPath.substr(1, launchPath.size() - 2);
+    }
+
+    wstring lowerExt{std::filesystem::path(launchPath).extension().wstring()};
+    transform(lowerExt.begin(), lowerExt.end(), lowerExt.begin(), ::towlower);
+
+    if(lowerExt != PROJECT_EXT && lowerExt != L".mp4" && lowerExt != L".mov" && lowerExt != L".avi"){
+        setStatusMessage(L"Launch argument is not a supported media/project file");
+        co_return;
+    }
+
+    SFile file{nullptr};
+    try{
+        file = co_await SFile::GetFileFromPathAsync(launchPath);
+    }catch(const winrt::hresult_error&){
+        setStatusMessage(L"File from launch argument was not found");
+        co_return;
+    }
+
+    if(lowerExt == PROJECT_EXT){
+        co_await openProjectFileAsync(file);
+        co_return;
+    }
+
+    m_prj.clearTimeline();
+    clearUndoRedoHistory();
+    co_await loadVideoFileAsync(file);
 }
 
 HWND MainWindow::getWindowHandle() const{

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -69,7 +69,7 @@ struct MainWindow: MainWindowT<MainWindow>{
     using TS = winrt::Windows::Foundation::TimeSpan;
     using FState = winrt::Microsoft::UI::Xaml::FocusState;
 
-    MainWindow();
+    MainWindow(const hstring& launchArguments = {});
 
     void startButton_Click(const Control& sender, const REArgs& args);
     void pauseButton_Click(const Control& sender, const REArgs& args);
@@ -193,6 +193,7 @@ private:
     void addRecentVideo(const hstring& path);
     void addRecentProject(const hstring& path);
     AAction showInfoDialogAsync(const hstring& title, const hstring& message);
+    AAction openFromLaunchArgumentsAsync(const hstring& arguments);
     AAction showPropertiesDialogAsync();
     AAction showOptionsDialogAsync();
     AAction openProjectFileAsync(const SFile& file);


### PR DESCRIPTION
### Motivation
- Clicking a `.llvc` project file launched the app but did not load the project because startup did not consume shell launch arguments. 
- The change makes the app react to file-open launch arguments so projects or media open automatically on shell-open. 
- Provide user-visible status messaging for unsupported or missing launch targets instead of silently doing nothing.

### Description
- Pass `LaunchActivatedEventArgs::Arguments()` from `App::OnLaunched` into `MainWindow` construction and add an optional `MainWindow(const hstring& launchArguments = {})` constructor. 
- Add `MainWindow::openFromLaunchArgumentsAsync(const hstring& arguments)` which trims/normalizes the argument, validates extension (`.llvc`, `.mp4`, `.mov`, `.avi`), resolves a `StorageFile` via `GetFileFromPathAsync`, and then invokes `openProjectFileAsync` for `.llvc` or clears timeline and calls `loadVideoFileAsync` for media. 
- Surface status messages for unsupported or missing files and preserve existing undo/timeline reset behavior when loading a video; updated declarations in `Win/llvc/MainWindow.xaml.h` and implementations in `Win/llvc/MainWindow.xaml.cpp` and `Win/llvc/App.xaml.cpp`.

### Testing
- Verified repository changes with `git diff -- Win/llvc/App.xaml.cpp Win/llvc/MainWindow.xaml.h Win/llvc/MainWindow.xaml.cpp` which showed the intended edits and additions, and the check succeeded. 
- Confirmed working tree and staged changes with `git status --short` which reported the modified files, and a commit was created successfully. 
- No Windows UI build/runtime tests were executed in this environment, so recommend building and running the app on Windows to validate shell-open behavior and file-loading end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a24f48efe48333ba33ea5ced42e64e)