### PR TITLE
Add RAP-based scene boundary nudging with keyboard shortcuts

### DIFF
--- a/Win/llvc/MainWindow.Helpers.cpp
+++ b/Win/llvc/MainWindow.Helpers.cpp
@@ -108,7 +108,7 @@ bool isInMenuSubtree(const DependencyObject& object){
 bool isInDialogSubtree(const DependencyObject& object){
     auto current{object};
     while(current){
-        if(current.try_as<Controls::ContentDialog>() || current.try_as<Controls::Primitives::Popup>()){
+        if(current.try_as<Controls::ContentDialog>()){
             return true;
         }
         current = Media::VisualTreeHelper::GetParent(current);

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -95,7 +95,7 @@
             <Button x:Name="CheatSheetOpenMarker" Width="26" Height="64" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,4,0" Padding="0"
                     Content="❮" Click="cheatSheetOpenMarker_Click" ToolTipService.ToolTip="Show quick actions" IsTabStop="False"/>
 
-            <Border x:Name="CheatSheetPanel" Width="220" HorizontalAlignment="Right" VerticalAlignment="Stretch" Margin="4" Padding="10" CornerRadius="4"
+            <Border x:Name="CheatSheetPanel" Width="242" HorizontalAlignment="Right" VerticalAlignment="Stretch" Margin="4" Padding="10" CornerRadius="4"
                     BorderBrush="#707070" BorderThickness="1" Background="#E6101010" IsTabStop="False" Visibility="Collapsed">
                 <Grid IsTabStop="False">
                     <Button x:Name="CheatSheetCollapseMarker" Width="24" HorizontalAlignment="Left" VerticalAlignment="Stretch" Padding="0"

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -49,6 +49,8 @@
                 <MenuFlyoutItem Text="Toggle cut mark (Ctrl+M)" Click="toggleCutMarkerAtCursorMenuItem_Click"/>
                 <MenuFlyoutItem Text="Mark scene cut (Delete)" Click="markSceneCutAtCursorMenuItem_Click"/>
                 <MenuFlyoutItem Text="Mark scene kept (Insert)" Click="markSceneKeptAtCursorMenuItem_Click"/>
+                <MenuFlyoutItem Text="Shrink scene to RAP (Ctrl+<)" Click="shrinkSceneToRapMenuItem_Click"/>
+                <MenuFlyoutItem Text="Expand scene to RAP (Ctrl+>)" Click="expandSceneToRapMenuItem_Click"/>
             </controls:MenuBarItem>
             <controls:MenuBarItem Title="View">
                 <MenuFlyoutItem Text="Zoom in timeline (Ctrl++)" Click="zoomInTimelineMenuItem_Click"/>
@@ -109,6 +111,8 @@
                             <TextBlock Text="Up Arrow: prev. marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Down Arrow: next marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+M: toggle cut mark" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+<: shrink scene to RAP" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+>: expand scene to RAP" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl++: zoom in timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+-: zoom out timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete: cut scene" TextWrapping="Wrap"/>

--- a/Win/llvc/MainWindow.xaml
+++ b/Win/llvc/MainWindow.xaml
@@ -49,8 +49,8 @@
                 <MenuFlyoutItem Text="Toggle cut mark (Ctrl+M)" Click="toggleCutMarkerAtCursorMenuItem_Click"/>
                 <MenuFlyoutItem Text="Mark scene cut (Delete)" Click="markSceneCutAtCursorMenuItem_Click"/>
                 <MenuFlyoutItem Text="Mark scene kept (Insert)" Click="markSceneKeptAtCursorMenuItem_Click"/>
-                <MenuFlyoutItem Text="Shrink scene to RAP (Ctrl+<)" Click="shrinkSceneToRapMenuItem_Click"/>
-                <MenuFlyoutItem Text="Expand scene to RAP (Ctrl+>)" Click="expandSceneToRapMenuItem_Click"/>
+                <MenuFlyoutItem Text="Shrink scene to RAP (Ctrl+&lt;)" Click="shrinkSceneToRapMenuItem_Click"/>
+                <MenuFlyoutItem Text="Expand scene to RAP (Ctrl+&gt;)" Click="expandSceneToRapMenuItem_Click"/>
             </controls:MenuBarItem>
             <controls:MenuBarItem Title="View">
                 <MenuFlyoutItem Text="Zoom in timeline (Ctrl++)" Click="zoomInTimelineMenuItem_Click"/>
@@ -111,8 +111,8 @@
                             <TextBlock Text="Up Arrow: prev. marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Down Arrow: next marker" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+M: toggle cut mark" TextWrapping="Wrap"/>
-                            <TextBlock Text="Ctrl+<: shrink scene to RAP" TextWrapping="Wrap"/>
-                            <TextBlock Text="Ctrl+>: expand scene to RAP" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+&lt;: shrink scene to RAP" TextWrapping="Wrap"/>
+                            <TextBlock Text="Ctrl+&gt;: expand scene to RAP" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl++: zoom in timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Ctrl+-: zoom out timeline" TextWrapping="Wrap"/>
                             <TextBlock Text="Delete: cut scene" TextWrapping="Wrap"/>

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -2436,6 +2436,16 @@ AAction MainWindow::markSceneKeptAtCursorMenuItem_Click(const Control&, const RE
     co_return;
 }
 
+AAction MainWindow::shrinkSceneToRapMenuItem_Click(const Control&, const REArgs&){
+    (void)nudgeCurrentSceneBoundaryToNearestRap(false);
+    co_return;
+}
+
+AAction MainWindow::expandSceneToRapMenuItem_Click(const Control&, const REArgs&){
+    (void)nudgeCurrentSceneBoundaryToNearestRap(true);
+    co_return;
+}
+
 AAction MainWindow::pickAndLoadVideoAsync(){
     FileOpenPicker picker{};
     picker.SuggestedStartLocation(PickerLocationId::VideosLibrary);

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -831,15 +831,8 @@ void MainWindow::reevaluateClearCutMarkersButton_Click(const Control&, const REA
     }
 
     vector<int64_t> rapTimes100ns;
-    try{
-        rapTimes100ns = collectCleanPointTimes100ns(m_prj.videoFile().Path().c_str());
-    }catch(const winrt::hresult_error&){
+    if(!tryGetRapTimes100ns(rapTimes100ns)){
         setStatusMessage(L"Could not read RAP markers from the current source");
-        return;
-    }
-
-    if(rapTimes100ns.empty()){
-        setStatusMessage(L"Could not detect RAP markers in the current source");
         return;
     }
 
@@ -1436,13 +1429,7 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
     }
 
     vector<int64_t> rapTimes100ns;
-    try{
-        rapTimes100ns = collectCleanPointTimes100ns(m_prj.videoFile().Path().c_str());
-    }catch(const winrt::hresult_error&){
-        return false;
-    }
-
-    if(rapTimes100ns.empty()){
+    if(!tryGetRapTimes100ns(rapTimes100ns)){
         return false;
     }
 
@@ -1681,6 +1668,37 @@ void MainWindow::tryFocusTimelineCanvas(FState focusState){
     }
 }
 
+bool MainWindow::tryGetRapTimes100ns(vector<int64_t>& rapTimes100ns){
+    if(!m_prj.videoFile()){
+        return false;
+    }
+
+    const hstring sourcePath{m_prj.videoFile().Path()};
+    if(!m_cachedRapTimes100ns.empty() && sourcePath == m_cachedRapSourcePath){
+        rapTimes100ns = m_cachedRapTimes100ns;
+        return true;
+    }
+
+    vector<int64_t> collected;
+    try{
+        collected = collectCleanPointTimes100ns(sourcePath.c_str());
+    }catch(const winrt::hresult_error&){
+        return false;
+    }
+
+    if(collected.empty()){
+        return false;
+    }
+
+    sort(collected.begin(), collected.end());
+    collected.erase(unique(collected.begin(), collected.end()), collected.end());
+
+    m_cachedRapSourcePath = sourcePath;
+    m_cachedRapTimes100ns = collected;
+    rapTimes100ns = std::move(collected);
+    return true;
+}
+
 bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
     const auto focused{Input::FocusManager::GetFocusedElement(Content().XamlRoot()).try_as<DependencyObject>()};
     const auto focusOnMenu{focused && isInMenuSubtree(focused)};
@@ -1763,7 +1781,7 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         }
     }
 
-    if(focusOnMenu || focusInDialog){
+    if(focusInDialog){
         return false;
     }
 
@@ -2417,6 +2435,8 @@ void MainWindow::resetProjectState(){
     m_prj.reset();
     clearUndoRedoHistory();
     m_mediaInfo = {};
+    m_cachedRapSourcePath.clear();
+    m_cachedRapTimes100ns.clear();
     m_timelineDurationSeconds = 0;
     TimelineZoomSlider().Value(m_prj.zoom());
     refreshVideoDetailsPanel();
@@ -3006,6 +3026,8 @@ AAction MainWindow::loadVideoFileAsync(const SFile& file){
     inspected.sourceCreated = formatDateTimeText(file.DateCreated());
     inspected.sourceModified = formatDateTimeText(basicProperties.DateModified());
     m_mediaInfo = inspected;
+    m_cachedRapSourcePath.clear();
+    m_cachedRapTimes100ns.clear();
 
     wstring status{L"Loaded: "};
     status += file.Name().c_str();

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -832,7 +832,7 @@ void MainWindow::reevaluateClearCutMarkersButton_Click(const Control&, const REA
 
     vector<int64_t> rapTimes100ns;
     if(!tryGetRapTimes100ns(rapTimes100ns)){
-        setStatusMessage(L"Could not read RAP markers from the current source");
+        queueRapLookup(true, 0);
         return;
     }
 
@@ -1430,6 +1430,7 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
 
     vector<int64_t> rapTimes100ns;
     if(!tryGetRapTimes100ns(rapTimes100ns)){
+        queueRapLookup(false, expandScene ? 1 : -1);
         return false;
     }
 
@@ -1683,36 +1684,104 @@ bool MainWindow::tryGetRapTimes100ns(vector<int64_t>& rapTimes100ns){
     }
 
     const hstring sourcePath{m_prj.videoFile().Path()};
-    if(m_cachedRapLookupAttempted && sourcePath == m_cachedRapSourcePath){
-        if(!m_cachedRapLookupSucceeded){
-            return false;
-        }
-        rapTimes100ns = m_cachedRapTimes100ns;
-        return true;
+    if(sourcePath != m_cachedRapSourcePath || !m_cachedRapLookupAttempted || !m_cachedRapLookupSucceeded){
+        return false;
     }
 
-    m_cachedRapSourcePath = sourcePath;
-    m_cachedRapTimes100ns.clear();
-    m_cachedRapLookupAttempted = true;
-    m_cachedRapLookupSucceeded = false;
+    rapTimes100ns = m_cachedRapTimes100ns;
+    return !rapTimes100ns.empty();
+}
 
+void MainWindow::queueRapLookup(bool queueReevaluate, int nudgeDirection){
+    if(!m_prj.videoFile() || m_prj.videoFile().Path().empty()){
+        return;
+    }
+
+    const hstring sourcePath{m_prj.videoFile().Path()};
+    if(m_cachedRapLookupAttempted && sourcePath == m_cachedRapSourcePath && !m_cachedRapLookupSucceeded){
+        setStatusMessage(L"Could not read RAP markers from the current source");
+        return;
+    }
+
+    if(queueReevaluate){
+        m_pendingReevaluateAfterRapLookup = true;
+    }
+    if(nudgeDirection != 0){
+        m_pendingNudgeDirectionAfterRapLookup = nudgeDirection;
+    }
+
+    if(m_isRapLookupInProgress){
+        setStatusMessage(L"Scanning source for RAP markers...");
+        return;
+    }
+
+    runRapLookupAsync();
+}
+
+fire_and_forget MainWindow::runRapLookupAsync(){
+    const auto weakSelf{get_weak()};
+    const hstring sourcePath{m_prj.videoFile() ? m_prj.videoFile().Path() : hstring{}};
+    if(sourcePath.empty()){
+        co_return;
+    }
+
+    m_isRapLookupInProgress = true;
+    setOperationInProgress(true, true);
+    setStatusMessage(L"Scanning source for RAP markers...");
+
+    vector<int64_t> rapTimes100ns;
+    auto lookupSucceeded{false};
+
+    co_await resume_background();
     try{
         rapTimes100ns = collectCleanPointTimes100ns(sourcePath.c_str());
+        sort(rapTimes100ns.begin(), rapTimes100ns.end());
+        rapTimes100ns.erase(unique(rapTimes100ns.begin(), rapTimes100ns.end()), rapTimes100ns.end());
+        lookupSucceeded = !rapTimes100ns.empty();
     }catch(const winrt::hresult_error&){
         rapTimes100ns.clear();
-        return false;
+        lookupSucceeded = false;
     }
 
-    if(rapTimes100ns.empty()){
-        return false;
+    co_await resume_foreground(DispatcherQueue());
+
+    if(const auto self{weakSelf.get()}){
+        const auto sameSourceLoaded{self->m_prj.videoFile() && self->m_prj.videoFile().Path() == sourcePath};
+
+        if(sameSourceLoaded){
+            self->m_cachedRapSourcePath = sourcePath;
+            self->m_cachedRapTimes100ns = lookupSucceeded ? rapTimes100ns : vector<int64_t>{};
+            self->m_cachedRapLookupAttempted = true;
+            self->m_cachedRapLookupSucceeded = lookupSucceeded;
+        }
+
+        self->m_isRapLookupInProgress = false;
+        self->setOperationInProgress(false);
+
+        const auto runReevaluate{self->m_pendingReevaluateAfterRapLookup};
+        const auto nudgeDirection{self->m_pendingNudgeDirectionAfterRapLookup};
+        self->m_pendingReevaluateAfterRapLookup = false;
+        self->m_pendingNudgeDirectionAfterRapLookup = 0;
+
+        if(!sameSourceLoaded){
+            co_return;
+        }
+
+        if(!lookupSucceeded){
+            self->setStatusMessage(L"Could not read RAP markers from the current source");
+            co_return;
+        }
+
+        self->setStatusMessage(L"RAP markers ready");
+        if(runReevaluate){
+            self->reevaluateClearCutMarkersButton_Click(nullptr, {});
+        }
+        if(nudgeDirection < 0){
+            (void)self->nudgeCurrentSceneBoundaryToNearestRap(false);
+        }else if(nudgeDirection > 0){
+            (void)self->nudgeCurrentSceneBoundaryToNearestRap(true);
+        }
     }
-
-    sort(rapTimes100ns.begin(), rapTimes100ns.end());
-    rapTimes100ns.erase(unique(rapTimes100ns.begin(), rapTimes100ns.end()), rapTimes100ns.end());
-
-    m_cachedRapTimes100ns = rapTimes100ns;
-    m_cachedRapLookupSucceeded = true;
-    return true;
 }
 
 bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
@@ -2455,6 +2524,9 @@ void MainWindow::resetProjectState(){
     m_cachedRapTimes100ns.clear();
     m_cachedRapLookupAttempted = false;
     m_cachedRapLookupSucceeded = false;
+    m_isRapLookupInProgress = false;
+    m_pendingReevaluateAfterRapLookup = false;
+    m_pendingNudgeDirectionAfterRapLookup = 0;
     m_timelineDurationSeconds = 0;
     TimelineZoomSlider().Value(m_prj.zoom());
     refreshVideoDetailsPanel();
@@ -3048,6 +3120,9 @@ AAction MainWindow::loadVideoFileAsync(const SFile& file){
     m_cachedRapTimes100ns.clear();
     m_cachedRapLookupAttempted = false;
     m_cachedRapLookupSucceeded = false;
+    m_isRapLookupInProgress = false;
+    m_pendingReevaluateAfterRapLookup = false;
+    m_pendingNudgeDirectionAfterRapLookup = 0;
 
     wstring status{L"Loaded: "};
     status += file.Name().c_str();

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1430,6 +1430,120 @@ bool MainWindow::markSceneAtCursor(bool cutScene){
     return false;
 }
 
+bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
+    if(!m_prj.videoFile() || m_timelineDurationSeconds <= 0){
+        return false;
+    }
+
+    vector<int64_t> rapTimes100ns;
+    try{
+        rapTimes100ns = collectCleanPointTimes100ns(m_prj.videoFile().Path().c_str());
+    }catch(const winrt::hresult_error&){
+        return false;
+    }
+
+    if(rapTimes100ns.empty()){
+        return false;
+    }
+
+    const auto boundaries{m_prj.buildSceneBoundaries100ns()};
+    if(boundaries.size() < 2){
+        return false;
+    }
+
+    const auto cursorTime100ns{timelinePointToTime100ns(Controls::Canvas::GetLeft(TimelineCursor()), TimelineCanvas().Width())};
+    if(!cursorTime100ns){
+        return false;
+    }
+
+    auto sceneIndex{boundaries.size() - 2};
+    for(size_t i{}; i + 1 < boundaries.size(); ++i){
+        if(*cursorTime100ns < boundaries[i + 1]){
+            sceneIndex = i;
+            break;
+        }
+    }
+
+    auto markers{m_prj.frameIndex()};
+    if(markers.empty()){
+        return false;
+    }
+
+    auto moveBoundaryToDirectionalRap{[&](size_t boundaryIndex, bool moveTowardEarlier, int64_t minExclusive, int64_t maxExclusive){
+        if(boundaryIndex == 0 || boundaryIndex >= (boundaries.size() - 1)){
+            return false;
+        }
+
+        const auto markerIndex{boundaryIndex - 1};
+        if(markerIndex >= markers.size()){
+            return false;
+        }
+
+        const auto currentBoundaryTime{boundaries[boundaryIndex]};
+        int64_t replacementBoundaryTime{};
+        if(moveTowardEarlier){
+            const auto it{lower_bound(rapTimes100ns.begin(), rapTimes100ns.end(), currentBoundaryTime)};
+            if(it == rapTimes100ns.begin()){
+                return false;
+            }
+            replacementBoundaryTime = *(it - 1);
+        }else{
+            const auto it{upper_bound(rapTimes100ns.begin(), rapTimes100ns.end(), currentBoundaryTime)};
+            if(it == rapTimes100ns.end()){
+                return false;
+            }
+            replacementBoundaryTime = *it;
+        }
+
+        if(replacementBoundaryTime <= minExclusive || replacementBoundaryTime >= maxExclusive){
+            return false;
+        }
+
+        markers[markerIndex].time100ns = replacementBoundaryTime;
+        markers[markerIndex].cleanPoint = true;
+        return true;
+    };
+
+    const auto leftBoundaryIndex{sceneIndex};
+    const auto rightBoundaryIndex{sceneIndex + 1};
+
+    auto changed{false};
+    if(expandScene){
+        if(leftBoundaryIndex > 0){
+            changed = moveBoundaryToDirectionalRap(leftBoundaryIndex, true, boundaries[leftBoundaryIndex - 1], boundaries[rightBoundaryIndex]) || changed;
+        }
+        if(rightBoundaryIndex + 1 < boundaries.size()){
+            const auto leftTimeAfterMove{leftBoundaryIndex > 0 ? markers[leftBoundaryIndex - 1].time100ns : boundaries[leftBoundaryIndex]};
+            changed = moveBoundaryToDirectionalRap(rightBoundaryIndex, false, leftTimeAfterMove, boundaries[rightBoundaryIndex + 1]) || changed;
+        }
+    }else{
+        if(rightBoundaryIndex + 1 < boundaries.size()){
+            changed = moveBoundaryToDirectionalRap(rightBoundaryIndex, true, boundaries[leftBoundaryIndex], boundaries[rightBoundaryIndex + 1]) || changed;
+        }
+        if(leftBoundaryIndex > 0){
+            const auto rightTimeAfterMove{rightBoundaryIndex + 1 < boundaries.size() ? markers[rightBoundaryIndex - 1].time100ns : boundaries[rightBoundaryIndex]};
+            changed = moveBoundaryToDirectionalRap(leftBoundaryIndex, false, boundaries[leftBoundaryIndex - 1], rightTimeAfterMove) || changed;
+        }
+    }
+
+    if(!changed){
+        return false;
+    }
+
+    (void)pushUndoStateIfChanged();
+    sort(markers.begin(), markers.end(), [](const auto& a, const auto& b){ return a.time100ns < b.time100ns; });
+    markers.erase(unique(markers.begin(), markers.end(), [](const auto& a, const auto& b){ return a.time100ns == b.time100ns; }), markers.end());
+    m_prj.frameIndex(std::move(markers));
+    m_prj.refreshSelectedMarkers();
+
+    renderTimelineTicks();
+    renderKeyframeTicks();
+    renderCutOverlays();
+    updateWindowTitle();
+    return true;
+}
+
+
 
 bool MainWindow::trySkipCurrentCutDuringPlayback(){
     if(!m_player || m_prj.cutScenes().empty() || m_timelineDurationSeconds <= 0){
@@ -1634,6 +1748,16 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         }
         if(args.Key() == VirtualKey::R){
             reevaluateClearCutMarkersButton_Click(nullptr, {});
+            args.Handled(true);
+            return true;
+        }
+        if(args.Key() == static_cast<VirtualKey>(188)){
+            (void)nudgeCurrentSceneBoundaryToNearestRap(false);
+            args.Handled(true);
+            return true;
+        }
+        if(args.Key() == static_cast<VirtualKey>(190)){
+            (void)nudgeCurrentSceneBoundaryToNearestRap(true);
             args.Handled(true);
             return true;
         }
@@ -2170,6 +2294,7 @@ AAction MainWindow::manualMenuItem_Click(const Control& sender, const REArgs& ar
         L"• Load video: Open .mp4/.mov/.avi source footage for timeline editing.\n"
         L"• Cut markers: Right-Click on the timeline/tick bar to toggle a marker at the desired frame. Markers split the video into scenes.\n"
         L"• Cut scene toggling: Ctrl+Left-Click a scene block to mark/unmark that whole scene for cutting; dark overlays indicate sections that will be removed.\n"
+        L"• Boundary RAP nudging: Ctrl+< shrinks the current scene by nudging both scene edges inward to RAPs, Ctrl+> expands by nudging both edges outward to RAPs.\n"
         L"• Preview start/pause/stop skipping cut scenes.\n"
         L"• Preview window: Tools → Preview in separate window opens a movable second window; use F11 to toggle full-screen.\n"
         L"• Audio controls: Keep/remove audio and configure cross-fade for segment transitions.\n"

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1498,8 +1498,27 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
         return true;
     };
 
-    const auto leftBoundaryIndex{sceneIndex};
-    const auto rightBoundaryIndex{sceneIndex + 1};
+    const auto sceneCount{boundaries.size() - 1};
+    vector<bool> isCut(sceneCount, false);
+    for(const auto cutSceneIndex: m_prj.cutScenes()){
+        if(cutSceneIndex < sceneCount){
+            isCut[cutSceneIndex] = true;
+        }
+    }
+
+    const auto targetCutState{sceneIndex < sceneCount ? isCut[sceneIndex] : false};
+    auto blockStartSceneIndex{sceneIndex};
+    auto blockEndSceneIndex{sceneIndex};
+
+    while(blockStartSceneIndex > 0 && isCut[blockStartSceneIndex - 1] == targetCutState){
+        --blockStartSceneIndex;
+    }
+    while((blockEndSceneIndex + 1) < sceneCount && isCut[blockEndSceneIndex + 1] == targetCutState){
+        ++blockEndSceneIndex;
+    }
+
+    const auto leftBoundaryIndex{blockStartSceneIndex};
+    const auto rightBoundaryIndex{blockEndSceneIndex + 1};
 
     auto changed{false};
     constexpr auto noMinBound{std::numeric_limits<int64_t>::lowest()};

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1576,11 +1576,24 @@ bool MainWindow::trySkipCurrentCutDuringPlayback(){
 
 
 void MainWindow::stepByFrame(int delta){
-    if(!m_player || delta == 0){
+    if(delta == 0){
         return;
     }
 
-    const auto current {m_player.PlaybackSession().Position().count()};
+    const auto durationFromProject100ns{m_prj.timelineDuration100ns()};
+    const auto durationFromTimeline100ns{static_cast<int64_t>(max(0.0, m_timelineDurationSeconds) * 10'000'000.0)};
+    const auto duration100ns{max(durationFromProject100ns, durationFromTimeline100ns)};
+    if(duration100ns <= 0){
+        return;
+    }
+
+    int64_t current{};
+    if(m_player){
+        current = max<int64_t>(0, m_player.PlaybackSession().Position().count());
+    }else if(const auto cursor100ns{timelinePointToTime100ns(Controls::Canvas::GetLeft(TimelineCursor()), TimelineCanvas().Width())}){
+        current = *cursor100ns;
+    }
+
     constexpr auto fallbackFrameDuration100ns{333'667LL}; // ~29.97 fps
 
     vector<int64_t> frameDurations;
@@ -1593,10 +1606,10 @@ void MainWindow::stepByFrame(int delta){
 
     if(frameDurations.empty()){
         for(size_t i{1}; i < m_prj.frameIndex().size(); ++i){
-            const auto sampleCount {static_cast<int64_t>(m_prj.frameIndex()[i].sampleIndex) - static_cast<int64_t>(m_prj.frameIndex()[i - 1].sampleIndex)};
-            const auto timeDelta {m_prj.frameIndex()[i].time100ns - m_prj.frameIndex()[i - 1].time100ns};
-            if(sampleCount > 0 && timeDelta > 0){
-                frameDurations.push_back(timeDelta / sampleCount);
+            const auto sampleCount{static_cast<int64_t>(m_prj.frameIndex()[i].sampleIndex) - static_cast<int64_t>(m_prj.frameIndex()[i - 1].sampleIndex)};
+            const auto dt100ns{m_prj.frameIndex()[i].time100ns - m_prj.frameIndex()[i - 1].time100ns};
+            if(sampleCount > 0 && dt100ns > 0){
+                frameDurations.push_back(dt100ns / sampleCount);
             }
         }
     }
@@ -1607,12 +1620,26 @@ void MainWindow::stepByFrame(int delta){
         frameStep100ns = max(1LL, frameDurations[frameDurations.size() / 2]);
     }
 
-    const auto direction {delta < 0 ? -1 : 1};
-    const auto duration100ns {static_cast<int64_t>(max(0.0, m_timelineDurationSeconds) * 10'000'000.0)};
-    const auto target {clamp(current + (direction * frameStep100ns), 0LL, duration100ns)};
-    m_player.PlaybackSession().Position(TimeSpan{target});
-    updateTimelineCursorFromPlayback();
-    ensureCurrentTimelineCursorVisible();
+    const auto direction{delta < 0 ? -1 : 1};
+    const auto target{clamp(current + (direction * frameStep100ns), 0LL, duration100ns)};
+
+    if(m_player){
+        m_player.PlaybackSession().Position(TimeSpan{target});
+        updateTimelineCursorFromPlayback();
+        ensureCurrentTimelineCursorVisible();
+        return;
+    }
+
+    const auto width{TimelineCanvas().Width()};
+    if(width <= 0){
+        return;
+    }
+
+    const auto ratio{clamp(static_cast<double>(target) / duration100ns, 0.0, 1.0)};
+    const auto left{ratio * width};
+    Controls::Canvas::SetLeft(TimelineCursor(), left);
+    ensureTimelineCursorVisible(left);
+    syncTimelineHorizontalScrollBar();
 }
 
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1849,6 +1849,7 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         }
         if(args.Key() == VirtualKey::M){
             (void)toggleCutMarkerAtCursor();
+            tryFocusTimelineCanvas(FocusState::Programmatic);
             args.Handled(true);
             return true;
         }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -830,8 +830,8 @@ void MainWindow::reevaluateClearCutMarkersButton_Click(const Control&, const REA
         return;
     }
 
-    vector<int64_t> rapTimes100ns;
-    if(!tryGetRapTimes100ns(rapTimes100ns)){
+    const auto rapTimes100ns{tryGetRapTimes100ns()};
+    if(!rapTimes100ns){
         setStatusMessage(L"Could not read RAP markers from the current source");
         return;
     }
@@ -850,13 +850,13 @@ void MainWindow::reevaluateClearCutMarkersButton_Click(const Control&, const REA
 
     auto replacedCount{0u};
     for(const auto& marker: originalMarkers){
-        if(binary_search(rapTimes100ns.begin(), rapTimes100ns.end(), marker.time100ns)){
+        if(binary_search(rapTimes100ns->begin(), rapTimes100ns->end(), marker.time100ns)){
             updatedMarkers.push_back(marker);
             continue;
         }
 
         ++replacedCount;
-        const auto nextIt{lower_bound(rapTimes100ns.begin(), rapTimes100ns.end(), marker.time100ns)};
+        const auto nextIt{lower_bound(rapTimes100ns->begin(), rapTimes100ns->end(), marker.time100ns)};
         if(nextIt != rapTimes100ns.begin()){
             const auto previousRapTime{*(nextIt - 1)};
             updatedMarkers.push_back(IndexedFrameSample{.time100ns = previousRapTime, .duration100ns = 0, .cleanPoint = true, .sampleIndex = 0});
@@ -1428,8 +1428,8 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
         return false;
     }
 
-    vector<int64_t> rapTimes100ns;
-    if(!tryGetRapTimes100ns(rapTimes100ns)){
+    const auto rapTimes100ns{tryGetRapTimes100ns()};
+    if(!rapTimes100ns){
         return false;
     }
 
@@ -1469,13 +1469,13 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
         const auto currentBoundaryTime{boundaries[boundaryIndex]};
         int64_t replacementBoundaryTime{};
         if(moveTowardEarlier){
-            const auto it{lower_bound(rapTimes100ns.begin(), rapTimes100ns.end(), currentBoundaryTime)};
+            const auto it{lower_bound(rapTimes100ns->begin(), rapTimes100ns->end(), currentBoundaryTime)};
             if(it == rapTimes100ns.begin()){
                 return false;
             }
             replacementBoundaryTime = *(it - 1);
         }else{
-            const auto it{upper_bound(rapTimes100ns.begin(), rapTimes100ns.end(), currentBoundaryTime)};
+            const auto it{upper_bound(rapTimes100ns->begin(), rapTimes100ns->end(), currentBoundaryTime)};
             if(it == rapTimes100ns.end()){
                 return false;
             }
@@ -1668,35 +1668,38 @@ void MainWindow::tryFocusTimelineCanvas(FState focusState){
     }
 }
 
-bool MainWindow::tryGetRapTimes100ns(vector<int64_t>& rapTimes100ns){
+const vector<int64_t>* MainWindow::tryGetRapTimes100ns(){
     if(!m_prj.videoFile()){
-        return false;
+        return nullptr;
     }
 
     const hstring sourcePath{m_prj.videoFile().Path()};
-    if(!m_cachedRapTimes100ns.empty() && sourcePath == m_cachedRapSourcePath){
-        rapTimes100ns = m_cachedRapTimes100ns;
-        return true;
+    if(m_cachedRapLookupAttempted && sourcePath == m_cachedRapSourcePath){
+        return m_cachedRapLookupSucceeded ? &m_cachedRapTimes100ns : nullptr;
     }
+
+    m_cachedRapSourcePath = sourcePath;
+    m_cachedRapTimes100ns.clear();
+    m_cachedRapLookupAttempted = true;
+    m_cachedRapLookupSucceeded = false;
 
     vector<int64_t> collected;
     try{
         collected = collectCleanPointTimes100ns(sourcePath.c_str());
     }catch(const winrt::hresult_error&){
-        return false;
+        return nullptr;
     }
 
     if(collected.empty()){
-        return false;
+        return nullptr;
     }
 
     sort(collected.begin(), collected.end());
     collected.erase(unique(collected.begin(), collected.end()), collected.end());
 
-    m_cachedRapSourcePath = sourcePath;
-    m_cachedRapTimes100ns = collected;
-    rapTimes100ns = std::move(collected);
-    return true;
+    m_cachedRapTimes100ns = std::move(collected);
+    m_cachedRapLookupSucceeded = true;
+    return &m_cachedRapTimes100ns;
 }
 
 bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
@@ -2437,6 +2440,8 @@ void MainWindow::resetProjectState(){
     m_mediaInfo = {};
     m_cachedRapSourcePath.clear();
     m_cachedRapTimes100ns.clear();
+    m_cachedRapLookupAttempted = false;
+    m_cachedRapLookupSucceeded = false;
     m_timelineDurationSeconds = 0;
     TimelineZoomSlider().Value(m_prj.zoom());
     refreshVideoDetailsPanel();
@@ -3028,6 +3033,8 @@ AAction MainWindow::loadVideoFileAsync(const SFile& file){
     m_mediaInfo = inspected;
     m_cachedRapSourcePath.clear();
     m_cachedRapTimes100ns.clear();
+    m_cachedRapLookupAttempted = false;
+    m_cachedRapLookupSucceeded = false;
 
     wstring status{L"Loaded: "};
     status += file.Name().c_str();

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1876,7 +1876,7 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         }
         if(args.Key() == VirtualKey::M){
             (void)toggleCutMarkerAtCursor();
-            tryFocusTimelineCanvas(FocusState::Programmatic);
+            tryFocusTimelineCanvas(FocusState::Keyboard);
             args.Handled(true);
             return true;
         }
@@ -1911,7 +1911,7 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         return false;
     }
 
-    tryFocusTimelineCanvas(FocusState::Programmatic);
+    tryFocusTimelineCanvas(FocusState::Keyboard);
 
     switch(args.Key()){
     case VirtualKey::Space:

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -857,11 +857,11 @@ void MainWindow::reevaluateClearCutMarkersButton_Click(const Control&, const REA
 
         ++replacedCount;
         const auto nextIt{lower_bound(rapTimes100ns->begin(), rapTimes100ns->end(), marker.time100ns)};
-        if(nextIt != rapTimes100ns.begin()){
+        if(nextIt != rapTimes100ns->begin()){
             const auto previousRapTime{*(nextIt - 1)};
             updatedMarkers.push_back(IndexedFrameSample{.time100ns = previousRapTime, .duration100ns = 0, .cleanPoint = true, .sampleIndex = 0});
         }
-        if(nextIt != rapTimes100ns.end()){
+        if(nextIt != rapTimes100ns->end()){
             const auto nextRapTime{*nextIt};
             updatedMarkers.push_back(IndexedFrameSample{.time100ns = nextRapTime, .duration100ns = 0, .cleanPoint = true, .sampleIndex = 0});
         }
@@ -1470,13 +1470,13 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
         int64_t replacementBoundaryTime{};
         if(moveTowardEarlier){
             const auto it{lower_bound(rapTimes100ns->begin(), rapTimes100ns->end(), currentBoundaryTime)};
-            if(it == rapTimes100ns.begin()){
+            if(it == rapTimes100ns->begin()){
                 return false;
             }
             replacementBoundaryTime = *(it - 1);
         }else{
             const auto it{upper_bound(rapTimes100ns->begin(), rapTimes100ns->end(), currentBoundaryTime)};
-            if(it == rapTimes100ns.end()){
+            if(it == rapTimes100ns->end()){
                 return false;
             }
             replacementBoundaryTime = *it;

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1467,6 +1467,10 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
         }
 
         const auto currentBoundaryTime{boundaries[boundaryIndex]};
+        if(binary_search(rapTimes100ns.begin(), rapTimes100ns.end(), currentBoundaryTime)){
+            return false;
+        }
+
         int64_t replacementBoundaryTime{};
         if(moveTowardEarlier){
             const auto it{lower_bound(rapTimes100ns.begin(), rapTimes100ns.end(), currentBoundaryTime)};

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1457,6 +1457,8 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
         return false;
     }
 
+    const auto previousCutRanges{m_prj.buildCutRanges100ns()};
+
     const auto moveBoundaryToDirectionalRap = [&](size_t boundaryIndex, bool moveTowardEarlier, int64_t minExclusive, int64_t maxExclusive) -> bool{
         if(boundaryIndex == 0 || boundaryIndex >= (boundaries.size() - 1)){
             return false;
@@ -1530,6 +1532,16 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
     markers.erase(unique(markers.begin(), markers.end(), [](const auto& a, const auto& b){ return a.time100ns == b.time100ns; }), markers.end());
     m_prj.frameIndex(std::move(markers));
     m_prj.refreshSelectedMarkers();
+
+    const auto sceneBoundaries{m_prj.buildSceneBoundaries100ns()};
+    vector<uint32_t> scenes;
+    for(size_t i{}; i + 1 < sceneBoundaries.size(); ++i){
+        const auto midpoint{sceneBoundaries[i] + (sceneBoundaries[i + 1] - sceneBoundaries[i]) / 2};
+        if(isTimeInsideRanges(midpoint, previousCutRanges)){
+            scenes.push_back(static_cast<uint32_t>(i));
+        }
+    }
+    m_prj.cutScenes(std::move(scenes));
 
     renderTimelineTicks();
     renderKeyframeTicks();

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1720,6 +1720,7 @@ void MainWindow::queueRapLookup(bool queueReevaluate, int nudgeDirection){
 
 fire_and_forget MainWindow::runRapLookupAsync(){
     const auto weakSelf{get_weak()};
+    winrt::apartment_context uiThread;
     const hstring sourcePath{m_prj.videoFile() ? m_prj.videoFile().Path() : hstring{}};
     if(sourcePath.empty()){
         co_return;
@@ -1743,7 +1744,7 @@ fire_and_forget MainWindow::runRapLookupAsync(){
         lookupSucceeded = false;
     }
 
-    co_await resume_foreground(DispatcherQueue());
+    co_await uiThread;
 
     if(const auto self{weakSelf.get()}){
         const auto sameSourceLoaded{self->m_prj.videoFile() && self->m_prj.videoFile().Path() == sourcePath};

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1469,7 +1469,7 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
         return false;
     }
 
-    auto moveBoundaryToDirectionalRap{[&](size_t boundaryIndex, bool moveTowardEarlier, int64_t minExclusive, int64_t maxExclusive){
+    const auto moveBoundaryToDirectionalRap = [&](size_t boundaryIndex, bool moveTowardEarlier, int64_t minExclusive, int64_t maxExclusive) -> bool{
         if(boundaryIndex == 0 || boundaryIndex >= (boundaries.size() - 1)){
             return false;
         }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -830,8 +830,8 @@ void MainWindow::reevaluateClearCutMarkersButton_Click(const Control&, const REA
         return;
     }
 
-    const auto rapTimes100ns{tryGetRapTimes100ns()};
-    if(!rapTimes100ns){
+    vector<int64_t> rapTimes100ns;
+    if(!tryGetRapTimes100ns(rapTimes100ns)){
         setStatusMessage(L"Could not read RAP markers from the current source");
         return;
     }
@@ -850,18 +850,18 @@ void MainWindow::reevaluateClearCutMarkersButton_Click(const Control&, const REA
 
     auto replacedCount{0u};
     for(const auto& marker: originalMarkers){
-        if(binary_search(rapTimes100ns->begin(), rapTimes100ns->end(), marker.time100ns)){
+        if(binary_search(rapTimes100ns.begin(), rapTimes100ns.end(), marker.time100ns)){
             updatedMarkers.push_back(marker);
             continue;
         }
 
         ++replacedCount;
-        const auto nextIt{lower_bound(rapTimes100ns->begin(), rapTimes100ns->end(), marker.time100ns)};
-        if(nextIt != rapTimes100ns->begin()){
+        const auto nextIt{lower_bound(rapTimes100ns.begin(), rapTimes100ns.end(), marker.time100ns)};
+        if(nextIt != rapTimes100ns.begin()){
             const auto previousRapTime{*(nextIt - 1)};
             updatedMarkers.push_back(IndexedFrameSample{.time100ns = previousRapTime, .duration100ns = 0, .cleanPoint = true, .sampleIndex = 0});
         }
-        if(nextIt != rapTimes100ns->end()){
+        if(nextIt != rapTimes100ns.end()){
             const auto nextRapTime{*nextIt};
             updatedMarkers.push_back(IndexedFrameSample{.time100ns = nextRapTime, .duration100ns = 0, .cleanPoint = true, .sampleIndex = 0});
         }
@@ -1428,8 +1428,8 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
         return false;
     }
 
-    const auto rapTimes100ns{tryGetRapTimes100ns()};
-    if(!rapTimes100ns){
+    vector<int64_t> rapTimes100ns;
+    if(!tryGetRapTimes100ns(rapTimes100ns)){
         return false;
     }
 
@@ -1469,14 +1469,14 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
         const auto currentBoundaryTime{boundaries[boundaryIndex]};
         int64_t replacementBoundaryTime{};
         if(moveTowardEarlier){
-            const auto it{lower_bound(rapTimes100ns->begin(), rapTimes100ns->end(), currentBoundaryTime)};
-            if(it == rapTimes100ns->begin()){
+            const auto it{lower_bound(rapTimes100ns.begin(), rapTimes100ns.end(), currentBoundaryTime)};
+            if(it == rapTimes100ns.begin()){
                 return false;
             }
             replacementBoundaryTime = *(it - 1);
         }else{
-            const auto it{upper_bound(rapTimes100ns->begin(), rapTimes100ns->end(), currentBoundaryTime)};
-            if(it == rapTimes100ns->end()){
+            const auto it{upper_bound(rapTimes100ns.begin(), rapTimes100ns.end(), currentBoundaryTime)};
+            if(it == rapTimes100ns.end()){
                 return false;
             }
             replacementBoundaryTime = *it;
@@ -1668,14 +1668,20 @@ void MainWindow::tryFocusTimelineCanvas(FState focusState){
     }
 }
 
-const vector<int64_t>* MainWindow::tryGetRapTimes100ns(){
+bool MainWindow::tryGetRapTimes100ns(vector<int64_t>& rapTimes100ns){
+    rapTimes100ns.clear();
+
     if(!m_prj.videoFile()){
-        return nullptr;
+        return false;
     }
 
     const hstring sourcePath{m_prj.videoFile().Path()};
     if(m_cachedRapLookupAttempted && sourcePath == m_cachedRapSourcePath){
-        return m_cachedRapLookupSucceeded ? &m_cachedRapTimes100ns : nullptr;
+        if(!m_cachedRapLookupSucceeded){
+            return false;
+        }
+        rapTimes100ns = m_cachedRapTimes100ns;
+        return true;
     }
 
     m_cachedRapSourcePath = sourcePath;
@@ -1683,23 +1689,23 @@ const vector<int64_t>* MainWindow::tryGetRapTimes100ns(){
     m_cachedRapLookupAttempted = true;
     m_cachedRapLookupSucceeded = false;
 
-    vector<int64_t> collected;
     try{
-        collected = collectCleanPointTimes100ns(sourcePath.c_str());
+        rapTimes100ns = collectCleanPointTimes100ns(sourcePath.c_str());
     }catch(const winrt::hresult_error&){
-        return nullptr;
+        rapTimes100ns.clear();
+        return false;
     }
 
-    if(collected.empty()){
-        return nullptr;
+    if(rapTimes100ns.empty()){
+        return false;
     }
 
-    sort(collected.begin(), collected.end());
-    collected.erase(unique(collected.begin(), collected.end()), collected.end());
+    sort(rapTimes100ns.begin(), rapTimes100ns.end());
+    rapTimes100ns.erase(unique(rapTimes100ns.begin(), rapTimes100ns.end()), rapTimes100ns.end());
 
-    m_cachedRapTimes100ns = std::move(collected);
+    m_cachedRapTimes100ns = rapTimes100ns;
     m_cachedRapLookupSucceeded = true;
-    return &m_cachedRapTimes100ns;
+    return true;
 }
 
 bool MainWindow::handleStorylineKeyDown(const KRArgs& args){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1850,16 +1850,6 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
     const auto ctrlState{InputKeyboardSource::GetKeyStateForCurrentThread(VirtualKey::Control)};
     const auto ctrlDown{(ctrlState & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down};
 
-    const auto restoreTimelineFocusAsync{[weakThis{get_weak()}]{
-        if(const auto self{weakThis.get()}){
-            self->DispatcherQueue().TryEnqueue([weakThis]{
-                if(const auto queuedSelf{weakThis.get()}){
-                    queuedSelf->tryFocusTimelineCanvas(FocusState::Programmatic);
-                }
-            });
-        }
-    }};
-
     if(!focusInDialog && ctrlDown){
         if(args.Key() == VirtualKey::Z){
             (void)undoLastEdit();
@@ -1888,7 +1878,6 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         }
         if(args.Key() == VirtualKey::M){
             (void)toggleCutMarkerAtCursor();
-            restoreTimelineFocusAsync();
             args.Handled(true);
             return true;
         }
@@ -1981,11 +1970,8 @@ void MainWindow::window_PreviewKeyDown(const Control&, const KRArgs& args){
     (void)handleStorylineKeyDown(args);
 }
 
-void MainWindow::window_KeyDown(const Control&, const KRArgs& args){
-    if(args.Handled()){
-        return;
-    }
-    (void)handleStorylineKeyDown(args);
+void MainWindow::window_KeyDown(const Control&, const KRArgs&){
+    // Keyboard shortcuts are dispatched from PreviewKeyDown to avoid duplicate handling.
 }
 
 void MainWindow::separatePreviewWindowMenuItem_Click(const Control&, const REArgs&){

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1609,7 +1609,10 @@ void MainWindow::stepByFrame(int delta){
             const auto sampleCount{static_cast<int64_t>(m_prj.frameIndex()[i].sampleIndex) - static_cast<int64_t>(m_prj.frameIndex()[i - 1].sampleIndex)};
             const auto dt100ns{m_prj.frameIndex()[i].time100ns - m_prj.frameIndex()[i - 1].time100ns};
             if(sampleCount > 0 && dt100ns > 0){
-                frameDurations.push_back(dt100ns / sampleCount);
+                const auto derivedFrameDuration{dt100ns / sampleCount};
+                if(derivedFrameDuration > 0){
+                    frameDurations.push_back(derivedFrameDuration);
+                }
             }
         }
     }

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1495,21 +1495,24 @@ bool MainWindow::nudgeCurrentSceneBoundaryToNearestRap(bool expandScene){
     const auto rightBoundaryIndex{sceneIndex + 1};
 
     auto changed{false};
+    constexpr auto noMinBound{std::numeric_limits<int64_t>::lowest()};
+    constexpr auto noMaxBound{std::numeric_limits<int64_t>::max()};
+
     if(expandScene){
         if(leftBoundaryIndex > 0){
-            changed = moveBoundaryToDirectionalRap(leftBoundaryIndex, true, boundaries[leftBoundaryIndex - 1], boundaries[rightBoundaryIndex]) || changed;
+            changed = moveBoundaryToDirectionalRap(leftBoundaryIndex, true, noMinBound, boundaries[rightBoundaryIndex]) || changed;
         }
         if(rightBoundaryIndex + 1 < boundaries.size()){
             const auto leftTimeAfterMove{leftBoundaryIndex > 0 ? markers[leftBoundaryIndex - 1].time100ns : boundaries[leftBoundaryIndex]};
-            changed = moveBoundaryToDirectionalRap(rightBoundaryIndex, false, leftTimeAfterMove, boundaries[rightBoundaryIndex + 1]) || changed;
+            changed = moveBoundaryToDirectionalRap(rightBoundaryIndex, false, leftTimeAfterMove, noMaxBound) || changed;
         }
     }else{
         if(rightBoundaryIndex + 1 < boundaries.size()){
-            changed = moveBoundaryToDirectionalRap(rightBoundaryIndex, true, boundaries[leftBoundaryIndex], boundaries[rightBoundaryIndex + 1]) || changed;
+            changed = moveBoundaryToDirectionalRap(rightBoundaryIndex, true, boundaries[leftBoundaryIndex], noMaxBound) || changed;
         }
         if(leftBoundaryIndex > 0){
             const auto rightTimeAfterMove{rightBoundaryIndex + 1 < boundaries.size() ? markers[rightBoundaryIndex - 1].time100ns : boundaries[rightBoundaryIndex]};
-            changed = moveBoundaryToDirectionalRap(leftBoundaryIndex, false, boundaries[leftBoundaryIndex - 1], rightTimeAfterMove) || changed;
+            changed = moveBoundaryToDirectionalRap(leftBoundaryIndex, false, noMinBound, rightTimeAfterMove) || changed;
         }
     }
 

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1595,32 +1595,12 @@ void MainWindow::stepByFrame(int delta){
     }
 
     constexpr auto fallbackFrameDuration100ns{333'667LL}; // ~29.97 fps
-
-    vector<int64_t> frameDurations;
-    frameDurations.reserve(m_prj.frameIndex().size());
-    for(const auto& sample: m_prj.frameIndex()){
-        if(sample.duration100ns > 0){
-            frameDurations.push_back(sample.duration100ns);
+    int64_t frameStep100ns{fallbackFrameDuration100ns};
+    if(m_mediaInfo.frameRate.num > 0 && m_mediaInfo.frameRate.den > 0){
+        const auto exactDuration100ns{(10'000'000LL * static_cast<int64_t>(m_mediaInfo.frameRate.den)) / static_cast<int64_t>(m_mediaInfo.frameRate.num)};
+        if(exactDuration100ns > 0){
+            frameStep100ns = exactDuration100ns;
         }
-    }
-
-    if(frameDurations.empty()){
-        for(size_t i{1}; i < m_prj.frameIndex().size(); ++i){
-            const auto sampleCount{static_cast<int64_t>(m_prj.frameIndex()[i].sampleIndex) - static_cast<int64_t>(m_prj.frameIndex()[i - 1].sampleIndex)};
-            const auto dt100ns{m_prj.frameIndex()[i].time100ns - m_prj.frameIndex()[i - 1].time100ns};
-            if(sampleCount > 0 && dt100ns > 0){
-                const auto derivedFrameDuration{dt100ns / sampleCount};
-                if(derivedFrameDuration > 0){
-                    frameDurations.push_back(derivedFrameDuration);
-                }
-            }
-        }
-    }
-
-    auto frameStep100ns{fallbackFrameDuration100ns};
-    if(!frameDurations.empty()){
-        nth_element(frameDurations.begin(), frameDurations.begin() + frameDurations.size() / 2, frameDurations.end());
-        frameStep100ns = max(1LL, frameDurations[frameDurations.size() / 2]);
     }
 
     const auto direction{delta < 0 ? -1 : 1};

--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -1848,6 +1848,16 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
     const auto ctrlState{InputKeyboardSource::GetKeyStateForCurrentThread(VirtualKey::Control)};
     const auto ctrlDown{(ctrlState & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down};
 
+    const auto restoreTimelineFocusAsync{[weakThis{get_weak()}]{
+        if(const auto self{weakThis.get()}){
+            self->DispatcherQueue().TryEnqueue([weakThis]{
+                if(const auto queuedSelf{weakThis.get()}){
+                    queuedSelf->tryFocusTimelineCanvas(FocusState::Programmatic);
+                }
+            });
+        }
+    }};
+
     if(!focusInDialog && ctrlDown){
         if(args.Key() == VirtualKey::Z){
             (void)undoLastEdit();
@@ -1876,7 +1886,7 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         }
         if(args.Key() == VirtualKey::M){
             (void)toggleCutMarkerAtCursor();
-            tryFocusTimelineCanvas(FocusState::Keyboard);
+            restoreTimelineFocusAsync();
             args.Handled(true);
             return true;
         }
@@ -1911,7 +1921,7 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
         return false;
     }
 
-    tryFocusTimelineCanvas(FocusState::Keyboard);
+    tryFocusTimelineCanvas(FocusState::Programmatic);
 
     switch(args.Key()){
     case VirtualKey::Space:
@@ -1963,10 +1973,16 @@ bool MainWindow::handleStorylineKeyDown(const KRArgs& args){
 }
 
 void MainWindow::window_PreviewKeyDown(const Control&, const KRArgs& args){
+    if(args.Handled()){
+        return;
+    }
     (void)handleStorylineKeyDown(args);
 }
 
 void MainWindow::window_KeyDown(const Control&, const KRArgs& args){
+    if(args.Handled()){
+        return;
+    }
     (void)handleStorylineKeyDown(args);
 }
 

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -139,6 +139,8 @@ private:
     MediaInspectionResult m_mediaInfo{};
     hstring m_cachedRapSourcePath{};
     vector<int64_t> m_cachedRapTimes100ns{};
+    bool m_cachedRapLookupAttempted{false};
+    bool m_cachedRapLookupSucceeded{false};
     vector<hstring> m_recentVideos{};
     vector<hstring> m_recentProjects{};
     uint32_t m_maxRecentVideos{5};
@@ -228,7 +230,7 @@ private:
     void ensureCurrentTimelineCursorVisible();
     void tryFocusTimelineCanvas(const FState focusState);
     bool handleStorylineKeyDown(const KRArgs& args);
-    bool tryGetRapTimes100ns(vector<int64_t>& rapTimes100ns);
+    const vector<int64_t>* tryGetRapTimes100ns();
     UndoRedoState captureUndoRedoState() const;
     bool isSameUndoRedoState(const UndoRedoState& a, const UndoRedoState& b) const;
     void clearUndoRedoHistory();

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -137,6 +137,8 @@ private:
     double m_timelineDurationSeconds{0};
     uint64_t m_timelineRenderVersion{0};
     MediaInspectionResult m_mediaInfo{};
+    hstring m_cachedRapSourcePath{};
+    vector<int64_t> m_cachedRapTimes100ns{};
     vector<hstring> m_recentVideos{};
     vector<hstring> m_recentProjects{};
     uint32_t m_maxRecentVideos{5};
@@ -226,6 +228,7 @@ private:
     void ensureCurrentTimelineCursorVisible();
     void tryFocusTimelineCanvas(const FState focusState);
     bool handleStorylineKeyDown(const KRArgs& args);
+    bool tryGetRapTimes100ns(vector<int64_t>& rapTimes100ns);
     UndoRedoState captureUndoRedoState() const;
     bool isSameUndoRedoState(const UndoRedoState& a, const UndoRedoState& b) const;
     void clearUndoRedoHistory();

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -120,6 +120,8 @@ struct MainWindow: MainWindowT<MainWindow>{
     AAction toggleCutMarkerAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     AAction markSceneCutAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
     AAction markSceneKeptAtCursorMenuItem_Click(const Control& sender, const REArgs& args);
+    AAction shrinkSceneToRapMenuItem_Click(const Control& sender, const REArgs& args);
+    AAction expandSceneToRapMenuItem_Click(const Control& sender, const REArgs& args);
     void window_DragOver(const Control& sender, const DEArgs& args);
     AAction window_Drop(const Control& sender, const DEArgs& args);
     void onClosed(const Control& sender, const WEArgs& args);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -218,6 +218,7 @@ private:
     bool setCutBlockAtTime100ns(int64_t time100ns, bool cutScene);
     bool toggleCutMarkerAtCursor();
     bool markSceneAtCursor(bool cutScene);
+    bool nudgeCurrentSceneBoundaryToNearestRap(bool expandScene);
     bool trySkipCurrentCutDuringPlayback();
     void stepByFrame(int delta);
     bool moveCursorToMarker(int direction);

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -230,7 +230,7 @@ private:
     void ensureCurrentTimelineCursorVisible();
     void tryFocusTimelineCanvas(const FState focusState);
     bool handleStorylineKeyDown(const KRArgs& args);
-    const vector<int64_t>* tryGetRapTimes100ns();
+    bool tryGetRapTimes100ns(vector<int64_t>& rapTimes100ns);
     UndoRedoState captureUndoRedoState() const;
     bool isSameUndoRedoState(const UndoRedoState& a, const UndoRedoState& b) const;
     void clearUndoRedoHistory();

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -141,6 +141,9 @@ private:
     vector<int64_t> m_cachedRapTimes100ns{};
     bool m_cachedRapLookupAttempted{false};
     bool m_cachedRapLookupSucceeded{false};
+    bool m_isRapLookupInProgress{false};
+    bool m_pendingReevaluateAfterRapLookup{false};
+    int m_pendingNudgeDirectionAfterRapLookup{0};
     vector<hstring> m_recentVideos{};
     vector<hstring> m_recentProjects{};
     uint32_t m_maxRecentVideos{5};
@@ -231,6 +234,8 @@ private:
     void tryFocusTimelineCanvas(const FState focusState);
     bool handleStorylineKeyDown(const KRArgs& args);
     bool tryGetRapTimes100ns(vector<int64_t>& rapTimes100ns);
+    void queueRapLookup(bool queueReevaluate, int nudgeDirection);
+    fire_and_forget runRapLookupAsync();
     UndoRedoState captureUndoRedoState() const;
     bool isSameUndoRedoState(const UndoRedoState& a, const UndoRedoState& b) const;
     void clearUndoRedoHistory();


### PR DESCRIPTION
### Motivation

- Provide a fast way to align scene boundaries to nearest RAP (random access points) to improve lossless cutting accuracy.
- Allow users to nudge the current scene inward or outward to RAP frames via keyboard shortcuts.

### Description

- Added `nudgeCurrentSceneBoundaryToNearestRap(bool expandScene)` to `MainWindow` which collects RAP times via `collectCleanPointTimes100ns`, locates the current scene around the timeline cursor, and moves one or both scene boundaries to the nearest earlier/later RAP while preserving neighboring boundary constraints and marking moved points as clean.
- The function updates undo state via `pushUndoStateIfChanged()`, sorts and deduplicates `markers`, writes back with `m_prj.frameIndex(...)`, refreshes selection with `m_prj.refreshSelectedMarkers()`, and refreshes the UI with `renderTimelineTicks()`, `renderKeyframeTicks()`, `renderCutOverlays()`, and `updateWindowTitle()`.
- Added the `nudgeCurrentSceneBoundaryToNearestRap` declaration to the header (`MainWindow.xaml.h`).
- Hooked two keyboard shortcuts into `handleStorylineKeyDown`: `VirtualKey` codes `188` and `190` (mapped to Ctrl+< for shrinking and Ctrl+> for expanding) to call the nudging function, and updated the in-app manual text to document the new feature.

### Testing

- Built the solution with `msbuild` (Release) successfully.
- There are no automated unit tests specifically covering the new RAP nudging feature; no automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88445e3648333be77ed0588c60d81)