### PR TITLE
Use loaded video filename for untitled project title and default save name

### DIFF
--- a/Win/llvc/MainWindow.xaml.cpp
+++ b/Win/llvc/MainWindow.xaml.cpp
@@ -505,7 +505,6 @@ constexpr auto P_RAP_MARKERS{L"rap_markers"};
 constexpr auto P_CUT_SCENES{L"cut_scenes"};
 
 constexpr auto PROJECT_KEY{L"llvc project"};
-constexpr auto UNNAMED_PROJECT{L"Untitled video cut"};
 constexpr auto PROJECT_EXT{L".llvc"};
 
 bool isControlModifierActive(VirtualKeyModifiers modifiers){
@@ -2366,7 +2365,7 @@ AAction MainWindow::saveProjectMenuItem_Click(const Control&, const REArgs&){
         FileSavePicker picker{};
         picker.SuggestedStartLocation(PickerLocationId::DocumentsLibrary);
         picker.FileTypeChoices().Insert(PROJECT_KEY, single_threaded_vector<hstring>({PROJECT_EXT}));
-        picker.SuggestedFileName(UNNAMED_PROJECT);
+        picker.SuggestedFileName(hstring(currentProjectDisplayName()));
 
         auto initWithWindow{picker.as<IInitializeWithWindow>()};
         check_hresult(initWithWindow->Initialize(getWindowHandle()));
@@ -2384,7 +2383,7 @@ AAction MainWindow::saveProjectAsMenuItem_Click(const Control&, const REArgs&){
     FileSavePicker picker{};
     picker.SuggestedStartLocation(PickerLocationId::DocumentsLibrary);
     picker.FileTypeChoices().Insert(PROJECT_KEY, single_threaded_vector<hstring>({PROJECT_EXT}));
-    picker.SuggestedFileName(UNNAMED_PROJECT);
+    picker.SuggestedFileName(hstring(currentProjectDisplayName()));
 
     auto initWithWindow{picker.as<IInitializeWithWindow>()};
     check_hresult(initWithWindow->Initialize(getWindowHandle()));
@@ -2648,16 +2647,30 @@ void MainWindow::resetProjectState(){
     updateWindowTitle();
 }
 
-void MainWindow::updateWindowTitle(){
-    wstring projectName{L"Untitled"};
+std::wstring MainWindow::currentProjectDisplayName() const{
     if(!m_projectPath.empty()){
         const auto projectPath{filesystem::path(m_projectPath.c_str())};
         const auto stem{projectPath.stem().wstring()};
-        projectName = stem.empty() ? projectPath.filename().wstring() : stem;
-        if(projectName.empty()){
-            projectName = L"Untitled";
+        const auto fromProjectPath{stem.empty() ? projectPath.filename().wstring() : stem};
+        if(!fromProjectPath.empty()){
+            return fromProjectPath;
         }
     }
+
+    if(m_prj.videoFile() && !m_prj.videoFile().Name().empty()){
+        const auto videoPath{filesystem::path(m_prj.videoFile().Name().c_str())};
+        const auto stem{videoPath.stem().wstring()};
+        const auto fromVideoPath{stem.empty() ? videoPath.filename().wstring() : stem};
+        if(!fromVideoPath.empty()){
+            return fromVideoPath;
+        }
+    }
+
+    return L"Untitled";
+}
+
+void MainWindow::updateWindowTitle(){
+    auto projectName{currentProjectDisplayName()};
 
     if(m_prj.isDirty()){
         projectName += L"*";

--- a/Win/llvc/MainWindow.xaml.h
+++ b/Win/llvc/MainWindow.xaml.h
@@ -208,6 +208,7 @@ private:
     AAction openProjectFileAsync(const SFile& file);
     AAction saveProjectFileAsync(const SFile& file);
     void resetProjectState();
+    std::wstring currentProjectDisplayName() const;
     void updateWindowTitle();
     IOpBool ensureProjectSavedBeforeContinuingAsync();
     static MediaInspectionResult inspectMediaFile(const wstring& filePath);


### PR DESCRIPTION
### Motivation
- When a video is loaded into a fresh (empty) project the UI should show the loaded video’s filename instead of a generic "Untitled" label so the project is easier to identify.

### Description
- Add `currentProjectDisplayName()` to `MainWindow` to compute the display name from the saved project path, then the loaded video filename stem, falling back to `"Untitled"` if neither is available in `Win/llvc/MainWindow.xaml.cpp` and declare it in `Win/llvc/MainWindow.xaml.h`.
- Change `updateWindowTitle()` to use `currentProjectDisplayName()` so a fresh project adopts the loaded video name and keep the dirty marker behavior (`*`).
- Update `Save` and `Save As` pickers to use `currentProjectDisplayName()` for the suggested filename instead of the previous fixed constant, and remove the now-unused `UNNAMED_PROJECT` constant.

### Testing
- Ran `git diff --check` to verify there are no whitespace/patch issues and it succeeded.
- Used automated searches (`rg`) to confirm occurrences of the old placeholder were replaced and the new `currentProjectDisplayName` symbol is referenced where expected, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69add8bd94b483338b830b399c2339f8)